### PR TITLE
ci: create workflows to build the application

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,8 @@ jobs:
             droneaware
       - name: Create Release
         run: |
-          gh release create "v${VERSION}" "${DL_PATH}/ble_feeder" \
+          [[ "$VERSION" =~ ^v ]] || VERSION="v$VERSION"
+          gh release create "${VERSION}" "${DL_PATH}/ble_feeder" \
             "${DL_PATH}/wifi_feeder" \
             install.sh \
             droneaware \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,52 @@
+name: Reusable Build and Release
+on:
+  workflow_call:
+    inputs:
+      version:
+        default: dev
+        type: string
+      publish:
+        default: false
+        type: boolean
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pguyot/arm-runner-action@29ff97a269fc6ef3e98f17583af01253896c5601
+        with:
+          base_image: "raspios_lite_arm64:latest"
+          cpu: cortex-a7
+          copy_artifact_path: dist/
+          commands: |
+            bash ./build.sh
+      - uses: actions/upload-artifact@v7
+        with:
+          path: dist/
+          overwrite: true
+  release:
+    needs: build
+    if: inputs.publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v7
+        id: download
+      - uses: actions/attest@v4
+        with:
+          subject-path: |
+            ${{ steps.download.outputs.download-path }}/ble_feeder
+            ${{ steps.download.outputs.download-path }}/wifi_feeder
+            install.sh
+            droneaware
+      - name: Create Release
+        run: |
+          gh release create "v${VERSION}" "${DL_PATH}/ble_feeder" \
+            "${DL_PATH}/wifi_feeder" \
+            install.sh \
+            droneaware \
+            --generate-notes
+        env:
+          VERSION: ${{ inputs.version }}
+          DL_PATH: ${{ steps.download.outputs.download-path }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,13 @@
+name: Pull Request
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+    permissions:
+      contents: read
+    with:
+      version: pr-${{ github.event.pull_request.number }}
+      publish: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,23 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+        description: The version number for the release (e.g., 1.0.0)
+      publish:
+        default: true
+        type: boolean
+        description: Whether to publish the release on GitHub (defaults to true)
+jobs:
+  build-and-publish:
+    uses: ./.github/workflows/build.yaml
+    permissions:
+      # Contents write is required to create a release
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      version: ${{ inputs.version }}
+      publish: ${{ inputs.publish }}


### PR DESCRIPTION
resolves #13 

This creates workflows that can be run on pull request and on-demand via a workflow dispatch (manual run) to create a new release and upload it.  I'm unsure how you were creating release notes so I just stuck with GitHub's automatic generation functionality.  High level details:

1. There is a  reusable workflow that implements the compilation, attestation, and release creation.
2. There is a workflow for PR and Manual run for releasing.
3. Under the covers it continues to use a standard GitHub runner, and leverages emulation via `qemu` to build without needing to configure arm runners (which based on https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/ I question the long term support of them).

Here's a release I created in my fork using the workflow:
* Workflow Run - https://github.com/wwsean08/DroneAware-Node-Releases/actions/runs/26014159034 (you can see the attestation there)
* Release - https://github.com/wwsean08/DroneAware-Node-Releases/releases/tag/v0.0.6
* Attestation - https://github.com/wwsean08/DroneAware-Node-Releases/attestations/27794716 (which is linked in the summary and includes the commands necessary for user verification of files).