### PR TITLE
v1.2.0: adaptive channel hopper, channel field, soft-fail adapters, release self-stamping, contributor agreement

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,19 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v7
         id: download
+      - name: Stamp install.sh with release version and repo
+        # Each release's install.sh points at its own binaries in its own repo,
+        # so users (and PR testers) can run install.sh from any release directly.
+        run: |
+          [[ "$VERSION" =~ ^v ]] || VERSION="v$VERSION"
+          sed -i "s|^INSTALLER_VERSION=.*|INSTALLER_VERSION=\"${VERSION}\"|" install.sh
+          sed -i "s|^BINARY_VERSION=.*|BINARY_VERSION=\"${VERSION}\"|"       install.sh
+          sed -i "s|^GITHUB_REPO=.*|GITHUB_REPO=\"${REPO}\"|"                install.sh
+          echo "Stamped install.sh:"
+          grep -E '^(INSTALLER_VERSION|BINARY_VERSION|GITHUB_REPO)=' install.sh
+        env:
+          VERSION: ${{ inputs.version }}
+          REPO:    ${{ github.repository }}
       - uses: actions/attest@v4
         with:
           subject-path: |
@@ -39,6 +52,10 @@ jobs:
             ${{ steps.download.outputs.download-path }}/wifi_feeder
             install.sh
             droneaware
+            droneaware-bt-select
+            droneaware-bt-select.service
+            droneaware-ble.service
+            droneaware-wifi.service
       - name: Create Release
         run: |
           [[ "$VERSION" =~ ^v ]] || VERSION="v$VERSION"
@@ -46,6 +63,10 @@ jobs:
             "${DL_PATH}/wifi_feeder" \
             install.sh \
             droneaware \
+            droneaware-bt-select \
+            droneaware-bt-select.service \
+            droneaware-ble.service \
+            droneaware-wifi.service \
             --generate-notes
         env:
           VERSION: ${{ inputs.version }}

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -308,17 +308,18 @@ class LocalPublisher:
             return
 
         record = {
-            "t":     event.get("timestamp") or event.get("observed_at"),
-            "mac":   event.get("source_mac") or event.get("mac"),
-            "radio": event.get("radio"),
-            "rssi":  event.get("rssi"),
-            "type":  decoded.get("message_type"),
-            "lat":   decoded.get("latitude"),
-            "lon":   decoded.get("longitude"),
-            "alt":   decoded.get("altitude_geo"),
-            "speed": decoded.get("ground_speed"),
-            "hdg":   decoded.get("heading"),
-            "id":    decoded.get("uas_id"),
+            "t":       event.get("timestamp") or event.get("observed_at"),
+            "mac":     event.get("source_mac") or event.get("mac"),
+            "radio":   event.get("radio"),
+            "rssi":    event.get("rssi"),
+            "channel": event.get("channel"),
+            "type":    decoded.get("message_type"),
+            "lat":     decoded.get("latitude"),
+            "lon":     decoded.get("longitude"),
+            "alt":     decoded.get("altitude_geo"),
+            "speed":   decoded.get("ground_speed"),
+            "hdg":     decoded.get("heading"),
+            "id":      decoded.get("uas_id"),
         }
         line = json.dumps(record, separators=(',', ':'))
 
@@ -466,6 +467,7 @@ class BLEFeeder:
             "source_mac":           device.address,
             "source_name":          device.name or None,
             "rssi":                 adv.rssi,
+            "channel":              None,  # BLE adv channel (37/38/39) not exposed by bleak
             "tx_power":             getattr(adv, "tx_power", None),
             "service_uuid":         svc_uuid,
             "service_data_hex":     svc_data.hex(),
@@ -495,8 +497,57 @@ class BLEFeeder:
                 pub_event["decoded"] = msg
                 self.publisher.publish(pub_event)
 
+    async def _fault_loop(self, reason: str):
+        """
+        Degraded loop entered when the BLE adapter is unhealthy or absent.
+        Emits heartbeats with ble_ok=False so the server marks the radio as FAULT.
+        Performs no BLE scanning. WiFi status (if measurable) is still reported.
+        """
+        log.warning(f"[FAULT] ble feeder running in degraded mode: {reason}")
+        while True:
+            try:
+                await asyncio.sleep(60)
+                cpu_temp = get_cpu_temp()
+                log.info(
+                    f"[Heartbeat] FAULT — ble_ok=False  reason={reason}  "
+                    f"temp={cpu_temp}°C"
+                )
+                if not self.token:
+                    continue
+                requests.post(
+                    "https://api.droneaware.io/api/node/heartbeat",
+                    json={
+                        # Per-feeder heartbeat: ble_* fields only (see note above)
+                        "node_id":      self.node_id,
+                        "uptime_s":     int(time.monotonic() - self.start_time),
+                        "fw_version":   FW_VERSION,
+                        "cpu_temp_c":   cpu_temp,
+                        "ble_ok":       False,
+                        "ble_adapter":  self.adapter,
+                        "ble_fault":    reason,
+                    },
+                    headers={"X-Node-Token": self.token},
+                    timeout=5,
+                )
+            except requests.RequestException as e:
+                log.warning(f"FAULT heartbeat failed: {e}")
+            except Exception as e:
+                log.warning(f"FAULT loop error: {e}")
+
     async def run(self):
         log.info(f"DroneAware BLE Feeder - Node: {self.node_id}  Adapter: {self.adapter}")
+
+        # FAULT mode — BLE adapter not healthy at startup
+        ble_ok, _ = get_ble_health(self.adapter)
+        if not ble_ok:
+            log.error(
+                f"BLE adapter '{self.adapter}' not healthy — entering FAULT mode."
+            )
+            log.error("WiFi detection (if available) is unaffected and continues independently.")
+            log.error("To restore BLE: connect a working Bluetooth adapter and restart this service.")
+            await self._fault_loop("adapter not present")
+            return
+
         log.info(f"Scanning for Remote ID broadcasts (UUID 0xFFFA)...")
 
         # No service_uuids filter here — the CSR adapter doesn't reliably
@@ -514,30 +565,33 @@ class BLEFeeder:
                 ticker += 1
 
                 if ticker % 60 == 0:
-                    cpu_temp          = get_cpu_temp()
-                    ble_ok, ble_adp   = get_ble_health(self.adapter)
-                    wifi_ok, wifi_adp = get_wifi_health(self.wifi_adapter)
+                    cpu_temp        = get_cpu_temp()
+                    ble_ok, ble_adp = get_ble_health(self.adapter)
 
                     log.info(
                         f"[Heartbeat] seen={self.count}  "
                         f"sent={self.forwarder.sent_total}  "
                         f"dropped={self.forwarder.dropped_total}  "
                         f"buffered={len(self.forwarder.buffer)}  "
-                        f"temp={cpu_temp}°C  ble={ble_ok}  wifi={wifi_ok}"
+                        f"temp={cpu_temp}°C  ble={ble_ok}"
                     )
                     if self.token:
                         try:
                             requests.post(
                                 "https://api.droneaware.io/api/node/heartbeat",
                                 json={
+                                    # Per-feeder heartbeat: ble_* fields only.
+                                    # Do NOT include wifi_ok or wifi_fault — the
+                                    # server uses presence of an ok-field to
+                                    # route the heartbeat to that feeder's
+                                    # status row. WiFi status comes from
+                                    # wifi_feeder's own heartbeat.
                                     "node_id":      self.node_id,
                                     "uptime_s":     int(time.monotonic() - self.start_time),
                                     "fw_version":   FW_VERSION,
                                     "cpu_temp_c":   cpu_temp,
                                     "ble_ok":       ble_ok,
-                                    "wifi_ok":      wifi_ok,
                                     "ble_adapter":  ble_adp,
-                                    "wifi_adapter": wifi_adp,
                                 },
                                 headers={"X-Node-Token": self.token},
                                 timeout=5,

--- a/droneaware
+++ b/droneaware
@@ -136,6 +136,21 @@ cmd_test() {
     token=$(cat /etc/droneaware/token 2>/dev/null | tr -d '[:space:]')
     [[ -z "$token" ]] && fatal "No node credential found. Re-run the installer to enroll this node."
 
+    # WiFi adapter must exist before we contact the server (avoids wasting a
+    # rate-limit slot) or run the embedded transmitter (avoids ENODEV crash on
+    # missing iface). Fail fast with an actionable message.
+    if [[ -z "$iface" || ! -d "/sys/class/net/${iface}" ]]; then
+        echo ""
+        echo -e "  ${RED}✗  Cannot run test — WiFi adapter '${iface:-<none>}' not present.${NC}"
+        echo ""
+        echo "  This command transmits a Remote ID beacon, which requires a USB"
+        echo "  monitor-mode adapter (e.g. Alfa AWUS036N)."
+        echo ""
+        echo "  Connect an adapter and re-run the installer to enable WiFi testing."
+        echo ""
+        exit 1
+    fi
+
     # Fall back to GPS fix if available and static coords are missing
     if [[ -z "$lat" || "$lat" == "0" || -z "$lon" || "$lon" == "0" ]]; then
         local gps_dev

--- a/droneaware-wifi.service
+++ b/droneaware-wifi.service
@@ -10,7 +10,6 @@ EnvironmentFile=/opt/droneaware/config.env
 ExecStart=/opt/droneaware/wifi_feeder \
     --node-id ${NODE_ID} \
     --server ${SERVER_URL} \
-    --iface ${WIFI_ADAPTER} \
     --batch-size ${BATCH_SIZE} \
     --flush-interval ${FLUSH_INTERVAL}
 Restart=always

--- a/install.sh
+++ b/install.sh
@@ -26,10 +26,8 @@ _rollback_nm() {
 trap '_rollback_nm' ERR
 
 INSTALLER_VERSION="v1.1.3"
-BINARY_VERSION="v1.1.3"  # last release containing updated binaries
-
-SERVICE_VERSION="v1.0.21"  # last release containing service files and bt-select script
-GITHUB_REPO="fduflyer/DroneAware-Node-Releases"
+BINARY_VERSION="v1.1.3"  # CI stamps this with the actual release version
+GITHUB_REPO="fduflyer/DroneAware-Node-Releases"  # CI stamps this with the building repo
 INSTALL_DIR="/opt/droneaware"
 CLI_DIR="/usr/local/bin"
 SERVER_URL="https://api.droneaware.io/api"
@@ -476,20 +474,30 @@ download_binaries() {
 # ---------------------------------------------------------------------------
 install_services() {
     heading "Installing Services"
-    local base_url="https://github.com/${GITHUB_REPO}/releases/download/${SERVICE_VERSION}"
+    # As of v1.2.0, service files ship with the same release as the binaries.
+    local base_url="https://github.com/${GITHUB_REPO}/releases/download/${BINARY_VERSION}"
+    local local_root="$(dirname "${LOCAL_DIST}")"
 
     # bt-select helper
-    curl -fsSL --retry 3 \
-        "${base_url}/droneaware-bt-select" \
-        -o "${CLI_DIR}/droneaware-bt-select"
+    if [[ "$LOCAL_INSTALL" == "1" ]]; then
+        cp "${local_root}/droneaware-bt-select" "${CLI_DIR}/droneaware-bt-select"
+    else
+        curl -fsSL --retry 3 \
+            "${base_url}/droneaware-bt-select" \
+            -o "${CLI_DIR}/droneaware-bt-select"
+    fi
     chmod +x "${CLI_DIR}/droneaware-bt-select"
     info "droneaware-bt-select installed."
 
     # Systemd service files
     for svc in droneaware-bt-select.service droneaware-ble.service droneaware-wifi.service; do
-        curl -fsSL --retry 3 \
-            "${base_url}/${svc}" \
-            -o "/etc/systemd/system/${svc}"
+        if [[ "$LOCAL_INSTALL" == "1" ]]; then
+            cp "${local_root}/${svc}" "/etc/systemd/system/${svc}"
+        else
+            curl -fsSL --retry 3 \
+                "${base_url}/${svc}" \
+                -o "/etc/systemd/system/${svc}"
+        fi
         info "$svc installed."
     done
 

--- a/install.sh
+++ b/install.sh
@@ -52,42 +52,158 @@ show_terms() {
     clear
     echo -e "${BOLD}"
     echo "╔══════════════════════════════════════════════════════════════════════╗"
-    echo "║            DroneAware Feeder Node — Installer v1.1.3               ║"
+    echo "║         DroneAware Feeder Node — Installer ${INSTALLER_VERSION}                 ║"
     echo "╚══════════════════════════════════════════════════════════════════════╝"
     echo -e "${NC}"
 
-    echo -e "${BOLD}ACCEPTANCE UPON NODE REGISTRATION${NC}"
-    echo ""
-    echo "  BINDING ACCEPTANCE"
-    echo "  You are entering into and agreeing to be legally bound by the"
-    echo "  DroneAware Feeder Node Contributor Agreement at the time you claim"
-    echo "  or activate a Node."
-    echo ""
-    echo "  CONDITION OF PARTICIPATION"
-    echo "  Acceptance of this Agreement is a mandatory condition of registering"
-    echo "  or operating any Node on the DroneAware network. You may not transmit"
-    echo "  data to DroneAware systems without accepting this Agreement."
-    echo ""
-    echo "  DATA OWNERSHIP ASSIGNMENT"
-    echo "  As a condition of Node registration and operation, you agree that all"
-    echo "  data transmitted from your Node is subject to the Data Ownership"
-    echo "  Assignment provisions of this Agreement, including the irrevocable"
-    echo "  assignment of all rights, title, and interest to DroneAware, LLC."
-    echo ""
-    echo "  AFFIRMATIVE ACTION REQUIRED"
-    echo "  Acceptance requires an affirmative action during Node registration."
-    echo ""
-    echo "  RECORD OF ACCEPTANCE"
-    echo "  DroneAware may record and retain evidence of your acceptance,"
-    echo "  including: timestamp, IP address, account identity, and agreement"
-    echo "  version. Such records shall constitute proof of your agreement."
-    echo ""
-    echo "  NO OPERATION WITHOUT ACCEPTANCE"
-    echo "  If you do not accept this Agreement, you are not authorized to"
-    echo "  register a Node, connect a Node to the network, or transmit any"
-    echo "  data to DroneAware."
-    echo ""
-    echo "──────────────────────────────────────────────────────────────────────"
+    cat <<'EOF'
+DroneAware Feeder Node Contributor Agreement
+Last Updated: May 2026
+
+This Feeder Node Contributor Agreement ("Agreement") governs participation
+in the DroneAware Network.
+
+By installing or operating a DroneAware feeder node you agree to these
+terms.
+
+1. PARTICIPATION IN THE NETWORK
+   Participants may operate hardware devices ("Feeder Nodes") that
+   collect and transmit radio signals and telemetry data to DroneAware
+   servers. Participation is voluntary. DroneAware may approve or reject
+   nodes at its discretion.
+
+2. HARDWARE RESPONSIBILITY
+   Participants are responsible for: acquiring hardware, maintaining
+   equipment, complying with local laws, and ensuring safe installation.
+   DroneAware is not responsible for hardware damage or operating costs.
+
+3. DATA CONTRIBUTION
+   Feeder nodes transmit captured ASTM F3411 Remote Identification
+   broadcasts to DroneAware servers. This data may include:
+   - Remote ID Basic ID, Location/Vector, System, Operator ID, Self ID,
+     and Authentication messages
+   - Signal strength (RSSI) and capture timestamps
+   - Detecting node identifier and radio band (BLE 4 Legacy, BLE 5 Long
+     Range, Wi-Fi NAN, Wi-Fi Beacon)
+
+3.1 SCOPE OF DATA COLLECTION
+    DroneAware feeder software runs Wi-Fi adapters in monitor mode,
+    which is technically capable of capturing many kinds of radio
+    traffic. By design, the feeder collects and forwards only ASTM
+    F3411 Remote ID broadcasts. Specifically, the feeder will not:
+    - Capture, store, or transmit non-Remote-ID Bluetooth advertisements
+      (including Apple Continuity, AirDrop, AirTag, fitness trackers, or
+      other proximity beacon transmissions)
+    - Capture, store, or transmit non-Remote-ID Wi-Fi traffic (including
+      probe requests, encrypted client frames, hidden-SSID enumeration,
+      or device-fingerprinting metadata)
+    - Correlate observed MAC addresses or hardware identifiers with
+      personal identities outside of what the Remote ID specification
+      itself discloses
+    - Build movement profiles, location histories, or behavioral
+      analytics from non-Remote-ID radio observations
+    These commitments are enforced in the feeder software itself. The
+    node release binaries are published in DroneAware's public GitHub
+    repository so that operators may independently verify the scope of
+    collection.
+
+4. LICENSE TO SUBMITTED DATA
+   By operating a feeder node, the participant grants DroneAware, LLC a
+   worldwide, royalty-free, perpetual, irrevocable, sublicensable
+   license to use, reproduce, modify, distribute, and create derivative
+   works from the data transmitted through the feeder node ("Submitted
+   Data"), for any purpose consistent with this Agreement and the
+   Privacy Policy. The participant retains whatever underlying ownership
+   rights they may have in such data; this license does not transfer
+   ownership.
+
+   The scope of Submitted Data is limited as described in Section 3.1.
+
+5. DATA USAGE
+   DroneAware may use Submitted Data to:
+   - Display real-time and historical drone activity on droneaware.io
+   - Generate aggregate airspace statistics and analytics
+   - Power detection-alert features for node operators and subscribers
+   - Improve detection algorithms and platform reliability
+   - Provide controlled API access to approved third-party users under
+     separate written agreement, subject to this Agreement and the
+     Privacy Policy
+
+   Participants acknowledge that DroneAware may generate revenue from
+   the Service. Participants are not entitled to compensation unless
+   otherwise agreed in writing.
+
+   DroneAware will not sell Node Owner Personal Information for
+   advertising, identity resolution, law-enforcement targeting, or
+   unrelated third-party profiling purposes. DroneAware is a public
+   airspace-awareness and data platform and is not provided as a
+   certified, safety-critical, law-enforcement, counter-UAS, or
+   operational security system; it should not be used as the sole
+   basis for enforcement, interdiction, navigation, or safety-of-life
+   decisions.
+
+6. NODE MONITORING
+   DroneAware may monitor feeder nodes for uptime, data integrity,
+   software version, and network health. DroneAware may collect system
+   metrics from nodes.
+
+7. SOFTWARE UPDATES
+   Feeder software updates are not pushed automatically. Updates are
+   pulled by the operator running 'sudo droneaware update' on the node.
+   DroneAware does not have unattended administrative access to
+   participant hardware.
+
+   A future version of the installer may offer an opt-in daily
+   auto-update mechanism for operators who prefer it. If introduced,
+   auto-update will be off by default and require explicit consent at
+   install time or via Settings.
+
+8. NODE REVOCATION
+   DroneAware may suspend or disable feeder nodes if data appears
+   manipulated, the node violates network policies, the node threatens
+   network integrity, or legal issues arise. DroneAware may revoke
+   participation at any time.
+
+9. NETWORK INTEGRITY
+   Participants agree not to: inject false data, modify detection
+   outputs, reverse engineer proprietary software, or interfere with
+   network operation. Violations may result in permanent removal from
+   the network.
+
+10. NO WARRANTY
+    Participation is provided "as-is." DroneAware does not guarantee
+    network uptime, data access, or availability of dashboards or APIs.
+
+11. LIMITATION OF LIABILITY
+    DroneAware shall not be liable for equipment damage, electricity
+    costs, network usage charges, or indirect damages arising from
+    participation in the feeder network.
+
+12. GOVERNING LAW
+    This Agreement is governed by the laws of the State of New Jersey,
+    without regard to conflict-of-law principles.
+
+13. CHANGES TO THIS AGREEMENT
+    DroneAware is committed to changing this Agreement only through a
+    deliberate, transparent process. Material changes to the scope of
+    data collection (Section 3 and 3.1), the license grant (Section 4),
+    or the data usage (Section 5) will:
+    - Be announced publicly at least 30 days before taking effect,
+      posted on droneaware.io and sent by email to affected participants
+    - Require explicit re-consent from existing participants before
+      applying retroactively
+    - Be tied to a versioned revision with a public changelog
+    - Not apply retroactively to Submitted Data collected under prior
+      versions without re-consent
+
+    Tightening commitments (additional restrictions on collection,
+    additional protections for participants) may be applied immediately
+    without re-consent.
+
+──────────────────────────────────────────────────────────────────────
+Full agreement and revision history: https://droneaware.io/legal.html
+──────────────────────────────────────────────────────────────────────
+EOF
     echo ""
 }
 

--- a/install.sh
+++ b/install.sh
@@ -259,9 +259,19 @@ detect_wifi_adapter() {
     done < <(iw dev 2>/dev/null | awk '$1=="Interface"{print $2}')
 
     if [[ -z "$WIFI_ADAPTER" ]]; then
+        echo ""
         warn "No USB WiFi adapter detected."
-        warn "Connect your Alfa AWUS036N (or compatible adapter) and re-run this installer."
-        fatal "USB WiFi adapter required."
+        warn "Continuing in BLE-only mode — WiFi detection will be disabled."
+        warn "The wifi feeder will start, report FAULT status, and produce no detections."
+        warn "To enable WiFi later: connect a USB monitor-mode adapter (e.g. Alfa AWUS036N)"
+        warn "and re-run this installer."
+        echo ""
+        read -rp "  Continue without a WiFi adapter? [y/N]: " WIFI_SKIP </dev/tty
+        if [[ ! "${WIFI_SKIP,,}" =~ ^y(es)?$ ]]; then
+            fatal "Installation cancelled. Connect a WiFi adapter and re-run."
+        fi
+        WIFI_ADAPTER=""
+        WIFI_ADAPTER_MAC=""
     fi
 }
 
@@ -269,6 +279,10 @@ detect_wifi_adapter() {
 # 4. Persist any netplan-backed WiFi profiles to disk before touching NM
 # ---------------------------------------------------------------------------
 persist_wifi_profiles() {
+    if [[ -z "$WIFI_ADAPTER" ]]; then
+        info "Skipping WiFi profile persistence — no WiFi adapter present."
+        return
+    fi
     heading "Securing WiFi Profiles"
     local count=0
 
@@ -321,6 +335,10 @@ persist_wifi_profiles() {
 # 5. Pin WiFi monitor adapter as unmanaged in NetworkManager
 # ---------------------------------------------------------------------------
 pin_wifi_unmanaged() {
+    if [[ -z "$WIFI_ADAPTER" ]]; then
+        info "Skipping NetworkManager configuration — no WiFi adapter to manage."
+        return
+    fi
     heading "Configuring NetworkManager"
 
     # Safety check: if the USB adapter is currently the active network interface,
@@ -494,16 +512,41 @@ write_config() {
     [[ -z "$BLE_ADAPTER_MAC" ]] && BLE_ADAPTER_MAC="00:00:00:00:00:00"
 
     cat > "${INSTALL_DIR}/config.env" <<EOF
-NODE_ID=${NODE_ID}
-SERVER_URL=${SERVER_URL}
+# ─── Hardware adapters ────────────────────────────────────────────────────
 BLE_ADAPTER=${BLE_ADAPTER}
 BLE_ADAPTER_MAC=${BLE_ADAPTER_MAC}
 WIFI_ADAPTER=${WIFI_ADAPTER}
+
+# ─── Location & GPS ───────────────────────────────────────────────────────
 NODE_MOBILE=${NODE_MOBILE}
 NODE_LAT=${NODE_LAT:-}
 NODE_LON=${NODE_LON:-}
 GPS_DEVICE=${GPS_DEVICE:-}
 GPS_BAUD=
+
+# ─── Channel hopper ───────────────────────────────────────────────────────
+# "true" = adaptive (channel-6 biased, sweep+sticky — recommended).
+# "false" = legacy flat hop across channels 1-11.
+ADAPTIVE_DWELL=true
+# Optional adaptive-hopper tuning (uncomment to override defaults):
+# FIXED_CHANNEL=6           # Lock 100% to this channel — overrides adaptive logic
+#                           # (useful for DFR monitoring of a known-channel drone)
+# ACTIVE_WINDOW_SEC=3       # Sticky-mode reset threshold in seconds (default 3.0)
+# DWELL_CH6_MS=800          # Primary channel dwell in sweep mode (default 800ms)
+# DWELL_PEEK_MS=50          # Peek dwell on channels 1 and 11 (default 50ms)
+
+# ─── Advanced — do not edit unless directed by DroneAware support ─────────
+# NODE_ID and SERVER_URL are set automatically at install and bind this node
+# to your DroneAware account. Changing them will break the server connection —
+# the node will appear offline and detections will stop flowing. Contact
+# support@droneaware.io if you need to migrate or rename a node.
+NODE_ID=${NODE_ID}
+SERVER_URL=${SERVER_URL}
+
+# BATCH_SIZE and FLUSH_INTERVAL control how often detections are forwarded to
+# the server. Increasing them holds events on the node longer, which can delay
+# real-time map updates and email alerts — and a crash before the next flush
+# will lose buffered detections. Leave at defaults unless directed by support.
 BATCH_SIZE=200
 FLUSH_INTERVAL=5.0
 EOF

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -1202,8 +1202,8 @@ def main():
         description="DroneAware WiFi Remote ID Feeder (Raspberry Pi + Alfa AWUS036N)"
     )
     parser.add_argument(
-        "--iface", default="wlan1",
-        help="Monitor-mode interface (default: wlan1)"
+        "--iface", default=os.environ.get("WIFI_ADAPTER", "") or "wlan1",
+        help="Monitor-mode interface (default: $WIFI_ADAPTER from config.env, or wlan1)"
     )
     parser.add_argument(
         "--node-id", default=socket.gethostname(),

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -227,23 +227,35 @@ def decode_rid_message(raw_bytes: bytes) -> dict | None:
 # -- Raw 802.11 Frame Parsers --------------------------------------------------
 # Replaces scapy — uses stdlib socket + struct only.
 
-def _parse_radiotap(data: bytes) -> tuple[int, int | None]:
+def _freq_to_channel(freq_mhz: int) -> int | None:
+    """Convert WiFi center frequency (MHz) to channel number. None if unknown."""
+    if 2412 <= freq_mhz <= 2472:
+        return (freq_mhz - 2412) // 5 + 1
+    if freq_mhz == 2484:
+        return 14
+    if 5180 <= freq_mhz <= 5825:
+        return (freq_mhz - 5000) // 5
+    return None
+
+
+def _parse_radiotap(data: bytes) -> tuple[int, int | None, int | None]:
     """
     Parse RadioTap header (IEEE 802.11-2020 Annex I).
-    Returns (header_length, rssi_dbm_or_None).
+    Returns (header_length, rssi_dbm_or_None, channel_or_None).
 
     Fields are walked in present-bitmap order with natural alignment relative
     to the start of the header. Only fields needed to reach dBm Signal (bit 5)
     are decoded; the rest are skipped by size.
     """
     if len(data) < 8:
-        return len(data), None
+        return len(data), None, None
 
     rt_len  = struct.unpack_from('<H', data, 2)[0]
     present = struct.unpack_from('<I', data, 4)[0]
 
-    rssi   = None
-    offset = 8  # first field starts after the fixed 8-byte header
+    rssi    = None
+    channel = None
+    offset  = 8  # first field starts after the fixed 8-byte header
 
     # Bit 31 (EXT): chipsets like Atheros AR9271 chain additional present words
     # before field data begins. Read each word and check its own bit 31 — do not
@@ -252,7 +264,7 @@ def _parse_radiotap(data: bytes) -> tuple[int, int | None]:
     ext_word = present
     while ext_word & (1 << 31):
         if offset + 4 > len(data):
-            return rt_len, None
+            return rt_len, None, None
         ext_word = struct.unpack_from('<I', data, offset)[0]
         offset += 4
 
@@ -269,6 +281,9 @@ def _parse_radiotap(data: bytes) -> tuple[int, int | None]:
     # Bit 3: Channel — uint16 freq + uint16 flags, align 2
     if present & (1 << 3):
         offset = (offset + 1) & ~1
+        if offset + 2 <= len(data):
+            freq_mhz = struct.unpack_from('<H', data, offset)[0]
+            channel = _freq_to_channel(freq_mhz)
         offset += 4
     # Bit 4: FHSS — uint8 hop_set + uint8 hop_pattern
     if present & (1 << 4):
@@ -279,7 +294,7 @@ def _parse_radiotap(data: bytes) -> tuple[int, int | None]:
             rssi = struct.unpack_from('b', data, offset)[0]
         offset += 1
 
-    return rt_len, rssi
+    return rt_len, rssi, channel
 
 
 def _mac_str(b: bytes) -> str:
@@ -485,23 +500,170 @@ def set_channel(iface: str, channel: int):
 # -- Channel Hopper ------------------------------------------------------------
 
 class ChannelHopper(threading.Thread):
-    """Cycles through 2.4 GHz channels at a fixed dwell time."""
+    """Cycles through 2.4 GHz channels at a fixed dwell time (legacy flat hop)."""
 
     def __init__(self, iface: str, channels: list, dwell: float):
         super().__init__(daemon=True)
-        self.iface    = iface
-        self.channels = channels
-        self.dwell    = dwell
-        self._stop    = threading.Event()
+        self.iface           = iface
+        self.channels        = channels
+        self.dwell           = dwell
+        self.current_channel = channels[0] if channels else None
+        self._stop           = threading.Event()
 
     def run(self):
-        log.info(f"Channel hopper started: {self.channels} @ {self.dwell}s dwell")
+        log.info(f"Flat channel hopper started: {self.channels} @ {self.dwell}s dwell")
         while not self._stop.is_set():
             for ch in self.channels:
                 if self._stop.is_set():
                     break
                 set_channel(self.iface, ch)
+                self.current_channel = ch
                 time.sleep(self.dwell)
+
+    def notify_detection(self, channel: int | None):
+        """No-op — flat hop ignores detection feedback. Present for API parity."""
+        pass
+
+    def stop(self):
+        self._stop.set()
+
+
+class AdaptiveChannelHopper(threading.Thread):
+    """
+    Two-mode channel hopper biased to ASTM F3411-mandated channels.
+
+    Spec basis: F3411 + opendroneid-core-c require 1 Hz Wi-Fi Beacon RID
+    broadcasts on channel 6 (2.4 GHz) or 149 (5 GHz). Off-channel broadcasts
+    must be at 5 Hz, which no manufacturer accepts. Even-hop scanning across
+    1–11 spends ~91% of time on channels where compliant 1 Hz RID cannot
+    exist.
+
+    Sweep mode (idle, no detection within ACTIVE_WINDOW):
+      ~80% on channel 6, brief peeks at 1 and 11.
+
+    Sticky mode (active detection within ACTIVE_WINDOW):
+      Hold on the channel that produced the detection. Forced peek every
+      STICKY_PEEK_INTERVAL cycles to avoid lockout of other airspace.
+    """
+
+    # Defaults — overridable via config.env (v1.2.0+)
+    PRIMARY_CHANNEL       = 6
+    PEEK_CHANNELS         = [1, 11]
+    ACTIVE_WINDOW         = 3.0     # seconds — sticky-mode reset threshold
+
+    SWEEP_PRIMARY_MS      = 800
+    SWEEP_PEEK_MS         = 50
+    SWEEP_PRIMARY_TAIL_MS = 100     # → total sweep cycle ≈ 1000ms
+
+    STICKY_DWELL_MS       = 950
+    STICKY_PEEK_INTERVAL  = 10
+    STICKY_PEEK_MS        = 25
+
+    def __init__(self, iface: str):
+        super().__init__(daemon=True)
+        self.iface                  = iface
+        self.current_channel        = self.PRIMARY_CHANNEL
+        self.last_detection_time    = 0.0
+        self.last_detection_channel = self.PRIMARY_CHANNEL
+        self.sticky_cycle_count     = 0
+        self._stop                  = threading.Event()
+
+        # config.env overrides — log invalid values as warnings and fall back
+        def _parse_int(name: str, default):
+            raw = os.environ.get(name, "").strip()
+            if not raw:
+                return default
+            try:
+                return int(raw)
+            except ValueError:
+                log.warning(f"{name}={raw!r} is not an integer — using default {default}")
+                return default
+
+        def _parse_float(name: str, default):
+            raw = os.environ.get(name, "").strip()
+            if not raw:
+                return default
+            try:
+                return float(raw)
+            except ValueError:
+                log.warning(f"{name}={raw!r} is not a number — using default {default}")
+                return default
+
+        self.fixed_channel    = _parse_int("FIXED_CHANNEL", None)
+        self.active_window    = _parse_float("ACTIVE_WINDOW_SEC", self.ACTIVE_WINDOW)
+        self.sweep_primary_ms = _parse_int("DWELL_CH6_MS",  self.SWEEP_PRIMARY_MS)
+        self.sweep_peek_ms    = _parse_int("DWELL_PEEK_MS", self.SWEEP_PEEK_MS)
+
+        # Guard against zero/negative dwells that would spin the loop
+        if self.sweep_primary_ms <= 0:
+            log.warning(f"DWELL_CH6_MS={self.sweep_primary_ms} invalid — using {self.SWEEP_PRIMARY_MS}")
+            self.sweep_primary_ms = self.SWEEP_PRIMARY_MS
+        if self.sweep_peek_ms < 0:
+            log.warning(f"DWELL_PEEK_MS={self.sweep_peek_ms} invalid — using {self.SWEEP_PEEK_MS}")
+            self.sweep_peek_ms = self.SWEEP_PEEK_MS
+
+    def notify_detection(self, channel: int | None):
+        """Called by the feeder when an RID packet is received."""
+        self.last_detection_time = time.time()
+        if channel is not None:
+            self.last_detection_channel = channel
+
+    def _set(self, ch: int):
+        set_channel(self.iface, ch)
+        self.current_channel = ch
+
+    def _sleep_ms(self, ms: int) -> bool:
+        """Sleep for ms milliseconds, returning True if stop was signaled."""
+        return self._stop.wait(timeout=ms / 1000.0)
+
+    def run(self):
+        # FIXED_CHANNEL: lock to one channel forever (DFR / single-drone monitoring)
+        if self.fixed_channel is not None:
+            log.info(f"Adaptive hopper: FIXED_CHANNEL={self.fixed_channel} — locking, no hop")
+            self._set(self.fixed_channel)
+            self._stop.wait()
+            return
+
+        log.info(
+            f"Adaptive hopper started: primary=ch{self.PRIMARY_CHANNEL}, "
+            f"peek={self.PEEK_CHANNELS}, ACTIVE_WINDOW={self.active_window}s, "
+            f"DWELL_CH6_MS={self.sweep_primary_ms}, DWELL_PEEK_MS={self.sweep_peek_ms}"
+        )
+        prev_mode = "sweep"
+
+        while not self._stop.is_set():
+            in_active = (time.time() - self.last_detection_time) < self.active_window
+            mode      = "sticky" if in_active else "sweep"
+
+            if mode != prev_mode:
+                log.debug(f"Hopper: {prev_mode}→{mode}")
+                if mode == "sweep":
+                    self.sticky_cycle_count = 0
+                prev_mode = mode
+
+            if mode == "sticky":
+                self._set(self.last_detection_channel)
+                if self._sleep_ms(self.STICKY_DWELL_MS):
+                    break
+                self.sticky_cycle_count += 1
+
+                if self.sticky_cycle_count % self.STICKY_PEEK_INTERVAL == 0:
+                    for ch in self.PEEK_CHANNELS:
+                        self._set(ch)
+                        if self._sleep_ms(self.STICKY_PEEK_MS):
+                            return
+            else:
+                # Sweep cycle: primary → peek1 → peek2 → primary_tail
+                self._set(self.PRIMARY_CHANNEL)
+                if self._sleep_ms(self.sweep_primary_ms):
+                    break
+                for ch in self.PEEK_CHANNELS:
+                    self._set(ch)
+                    if self._sleep_ms(self.sweep_peek_ms):
+                        return
+                self._set(self.PRIMARY_CHANNEL)
+                if self._sleep_ms(self.SWEEP_PRIMARY_TAIL_MS):
+                    break
 
     def stop(self):
         self._stop.set()
@@ -708,17 +870,18 @@ class LocalPublisher:
             return
 
         record = {
-            "t":     event.get("timestamp") or event.get("observed_at"),
-            "mac":   event.get("source_mac") or event.get("mac"),
-            "radio": event.get("radio"),
-            "rssi":  event.get("rssi"),
-            "type":  decoded.get("message_type"),
-            "lat":   decoded.get("latitude"),
-            "lon":   decoded.get("longitude"),
-            "alt":   decoded.get("altitude_geo"),
-            "speed": decoded.get("ground_speed"),
-            "hdg":   decoded.get("heading"),
-            "id":    decoded.get("uas_id"),
+            "t":       event.get("timestamp") or event.get("observed_at"),
+            "mac":     event.get("source_mac") or event.get("mac"),
+            "radio":   event.get("radio"),
+            "rssi":    event.get("rssi"),
+            "channel": event.get("channel"),
+            "type":    decoded.get("message_type"),
+            "lat":     decoded.get("latitude"),
+            "lon":     decoded.get("longitude"),
+            "alt":     decoded.get("altitude_geo"),
+            "speed":   decoded.get("ground_speed"),
+            "hdg":     decoded.get("heading"),
+            "id":      decoded.get("uas_id"),
         }
         line = json.dumps(record, separators=(',', ':'))
 
@@ -762,16 +925,28 @@ class WiFiFeeder:
         self.start_time  = time.time()
         self.forwarder   = Forwarder(server_url, node_id, batch_size, flush_interval, token)
         self.publisher   = LocalPublisher()
-        self.hopper      = ChannelHopper(iface, CHANNELS_24, channel_dwell)
+        # ADAPTIVE_DWELL=false reverts to legacy flat 1–11 hop (A/B testing)
+        adaptive_dwell = os.environ.get("ADAPTIVE_DWELL", "true").strip().lower() \
+                            in ("true", "1", "yes", "on")
+        if adaptive_dwell:
+            log.info("Hopper mode: adaptive (sweep + sticky, channel-6 biased)")
+            self.hopper = AdaptiveChannelHopper(iface)
+        else:
+            log.info("Hopper mode: flat (legacy even hop across 1–11)")
+            self.hopper = ChannelHopper(iface, CHANNELS_24, channel_dwell)
         self.count       = 0
         self.nan_count   = 0
         self._scanning   = False
 
     def _on_packet(self, data: bytes):
-        # Parse RadioTap header to get RSSI and skip to 802.11 MAC header
-        rt_len, rssi = _parse_radiotap(data)
+        # Parse RadioTap header to get RSSI, channel, and skip to 802.11 MAC header
+        rt_len, rssi, channel = _parse_radiotap(data)
         if rt_len >= len(data):
             return
+
+        # Radiotap Channel field is optional; fall back to hopper state
+        if channel is None:
+            channel = self.hopper.current_channel
 
         mac_data = data[rt_len:]
         header = _parse_dot11_mgmt(mac_data)
@@ -812,6 +987,7 @@ class WiFiFeeder:
                     "radio":     "wifi_beacon",
                     "mac":       addr2,
                     "rssi":      rssi,
+                    "channel":   channel,
                     "payload":   raw_hex,
                     "decoded":   msg,
                 }
@@ -827,6 +1003,7 @@ class WiFiFeeder:
                     )
                 self.forwarder.add(event)
                 self.publisher.publish(event)
+            self.hopper.notify_detection(channel)
             return
 
         # ---- Wi-Fi NAN Remote ID (subtype 13 — action frame) ----
@@ -843,16 +1020,35 @@ class WiFiFeeder:
                 "radio":     "wifi_nan",
                 "mac":       addr2,
                 "rssi":      rssi,
+                "channel":   channel,
                 "payload":   raw,
                 "decoded":   None,  # NAN full parsing is a future enhancement
             }
             self.forwarder.add(event)
+            self.hopper.notify_detection(channel)
 
     def run(self):
         log.info(f"DroneAware WiFi Feeder - Node: {self.node_id}")
-        log.info(f"Interface: {self.iface}  |  Channels: {CHANNELS_24}")
+        log.info(f"Interface: {self.iface or '<not configured>'}  |  Channels: {CHANNELS_24}")
 
-        set_monitor_mode(self.iface)
+        # FAULT mode — missing or invalid WiFi adapter
+        if not self.iface or not os.path.exists(f"/sys/class/net/{self.iface}"):
+            log.error(
+                f"WiFi adapter '{self.iface or 'none'}' not present — entering FAULT mode."
+            )
+            log.error("BLE detection (if available) is unaffected and continues independently.")
+            log.error("To restore WiFi: connect a USB monitor-mode adapter and re-run the installer.")
+            self._fault_loop("adapter not present")
+            return
+
+        try:
+            set_monitor_mode(self.iface)
+        except Exception as e:
+            log.error(f"Could not put {self.iface} into monitor mode: {e}")
+            log.error("Entering FAULT mode — adapter likely does not support monitor mode.")
+            self._fault_loop("monitor mode unsupported")
+            return
+
         self.hopper.start()
 
         log.info("Scanning for Remote ID beacon frames (ASTM F3411)...")
@@ -883,6 +1079,52 @@ class WiFiFeeder:
                 f"sent={self.forwarder.sent_total}  failed={self.forwarder.failed_total}"
             )
 
+    def _fault_loop(self, reason: str):
+        """
+        Degraded loop entered when no usable WiFi adapter is present.
+        Emits heartbeats with wifi_ok=False so the server marks the radio as FAULT.
+        Performs no monitor-mode setup, no packet capture, no event forwarding.
+        """
+        log.warning(f"[FAULT] wifi feeder running in degraded mode: {reason}")
+        while True:
+            try:
+                time.sleep(60)
+                log.info(
+                    f"[Heartbeat] FAULT — wifi_ok=False  reason={reason}  "
+                    f"uptime={int(time.time() - self.start_time)}s"
+                )
+                if not self.token:
+                    continue
+                with _gps_lock:
+                    lat, lon = _gps_lat, _gps_lon
+                cpu_temp = get_cpu_temp()
+                has_gps  = os.path.exists(os.environ.get("GPS_DEVICE", "/dev/ttyUSB0"))
+                mobile   = os.environ.get("NODE_MOBILE", "false").lower() == "true"
+                requests.post(
+                    "https://api.droneaware.io/api/node/heartbeat",
+                    json={
+                        # Per-feeder heartbeat: wifi_* fields only (see note above)
+                        "node_id":      self.node_id,
+                        "uptime_s":     int(time.time() - self.start_time),
+                        "fw_version":   FW_VERSION,
+                        "cpu_temp_c":   cpu_temp,
+                        "wifi_ok":      False,
+                        "wifi_adapter": self.iface or None,
+                        "wifi_fault":   reason,
+                        "scanning":     False,
+                        "mobile":       mobile,
+                        "has_gps":      has_gps,
+                        "lat":          lat,
+                        "lon":          lon,
+                    },
+                    headers={"X-Node-Token": self.token},
+                    timeout=5,
+                )
+            except requests.RequestException as e:
+                log.warning(f"FAULT heartbeat failed: {e}")
+            except Exception as e:
+                log.warning(f"FAULT loop error: {e}")
+
     def _flush_loop(self):
         """Periodically flush the forwarder buffer (runs in background thread)."""
         last_heartbeat = time.time()
@@ -906,14 +1148,16 @@ class WiFiFeeder:
                         requests.post(
                             "https://api.droneaware.io/api/node/heartbeat",
                             json={
+                                # Per-feeder heartbeat: wifi_* fields only.
+                                # Do NOT include ble_ok or ble_fault — the server
+                                # uses presence of an ok-field to route the
+                                # heartbeat to that feeder's status row.
                                 "node_id":      self.node_id,
                                 "uptime_s":     int(time.time() - self.start_time),
                                 "fw_version":   FW_VERSION,
                                 "cpu_temp_c":   cpu_temp,
                                 "wifi_ok":      wifi_ok,
                                 "wifi_adapter": wifi_adp,
-                                "ble_ok":       None,
-                                "ble_adapter":  None,
                                 "scanning":     self._scanning,
                                 "mobile":       mobile,
                                 "has_gps":      has_gps,


### PR DESCRIPTION
## Summary
- Adds `channel` field to detection payloads (server accepts as nullable int)
- Replaces flat channel hopper with adaptive sweep+sticky biased to channel 6 (ASTM F3411 mandate)
- New config.env variables: ADAPTIVE_DWELL, FIXED_CHANNEL, ACTIVE_WINDOW_SEC, DWELL_CH6_MS, DWELL_PEEK_MS
- Soft-fail on missing WiFi/BLE adapter — installer permissive, feeders report FAULT in heartbeat with per-feeder routing
- Release infrastructure: install.sh now self-stamps at build time, service files bundle into every release
- SERVICE_VERSION variable removed — one release = one version
- Updated installer to display the May 2026 Contributor Agreement (matches droneaware.io/legal.html)

## Test plan
- [ ] CI build succeeds on this PR (publish=false)
- [ ] LOCAL_INSTALL=1 test on a fresh Pi
- [ ] 24h soak test with detections + heartbeats
- [ ] If clean → merge → cut v1.2.0 release via Release workflow