### PR TITLE
v1.2.0.1: hotfix — pin CI base image to Bookworm

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,17 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pguyot/arm-runner-action@29ff97a269fc6ef3e98f17583af01253896c5601
         with:
-          base_image: "raspios_lite_arm64:latest"
+          # Pin to Debian Bookworm (glibc 2.36) — must match the OS DroneAware
+          # nodes run. raspios_lite_arm64:latest moved to Trixie (glibc 2.41) in
+          # 2026-04, which produced v1.2.0 binaries that fail on Bookworm with
+          # "GLIBC_2.38 not found." Pin keeps binaries forward-compatible:
+          # build on the oldest supported OS so binaries run everywhere newer.
+          base_image: "raspi_3_bookworm:20231109"
           cpu: cortex-a7
           copy_artifact_path: dist/
           commands: |
+            apt-get update
+            apt-get install -y python3 python3-pip python3-venv
             bash ./build.sh
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
v1.2.0 binaries fail to run on Debian Bookworm with
`GLIBC_2.38 not found`. Root cause: `pguyot/arm-runner-action`
with `base_image: raspios_lite_arm64:latest` is now resolving to
a Trixie image (glibc 2.41) as of 2026-04, so binaries built in
CI reference newer glibc symbols than Bookworm provides.

Fix: pin the base image to `raspi_3_bookworm:20231109` (Debian
Bookworm, glibc 2.36).

## Affected users
Anyone on Debian Bookworm who installed v1.2.0 fresh or updated
to v1.2.0 from v1.1.x.