### PR TITLE
v1.2.1: self-modifying script fix, SAST scanning, decoder fix, config.env migration

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,29 @@
+name: ShellCheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Scans every *.sh file and any file with a shell shebang. Surfaces findings in
+# the workflow run logs. Set to "warning" severity to focus on real bugs and
+# skip pure-style nits (SC2086 double-quote suggestions etc.) — can tighten to
+# "style" later once the codebase is fully clean.
+#
+# To suppress a specific finding inline:
+#     # shellcheck disable=SC2086
+#     command "$with" $intentional_splitting
+#
+# Project-wide suppressions go in a .shellcheckrc file at the repo root.
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          severity: warning
+          scandir: '.'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege GITHUB_TOKEN — this workflow only reads the repo to scan it.
+permissions:
+  contents: read
+
 # Scans every *.sh file and any file with a shell shebang. Surfaces findings in
 # the workflow run logs. Set to "warning" severity to focus on real bugs and
 # skip pure-style nits (SC2086 double-quote suggestions etc.) — can tighten to

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -197,45 +197,67 @@ def parse_basic_id(data: bytes) -> dict:
 
 
 def parse_location(data: bytes) -> dict:
+    """
+    Decode ASTM F3411-22a Location/Vector message (25 bytes).
+    See wifi_feeder.py for full byte layout — kept in sync with that file.
+    """
     if len(data) < 25:
         return {}
-    speed_mult  = data[1] & 0x01
-    height_type = (data[1] >> 2) & 0x01
-    lat = struct.unpack_from('<i', data, 2)[0] * 1e-7
-    lon = struct.unpack_from('<i', data, 6)[0] * 1e-7
+
+    status      = data[1]
+    speed_mult  = (status >> 0) & 0x01
+    ew_bit      = (status >> 1) & 0x01
+    height_type = (status >> 2) & 0x01
+
+    direction   = data[2] + (180 if ew_bit else 0)
+    speed       = data[3] * 0.75 + 63.75 if speed_mult else data[3] * 0.25
+    vspeed      = data[4] * 0.5 - 62.0
+
+    lat = struct.unpack_from('<i', data, 5)[0] * 1e-7
+    lon = struct.unpack_from('<i', data, 9)[0] * 1e-7
     if abs(lat) > 90.0 or abs(lon) > 180.0:
         return {}
-    alt_geodetic = struct.unpack_from('<H', data, 12)[0] * 0.5 - 1000.0
-    height       = struct.unpack_from('<H', data, 14)[0] * 0.5 - 1000.0
-    speed        = data[16] * (0.75 if speed_mult else 0.25)
-    vspeed       = data[17] * 0.5 - 62.0
-    heading      = struct.unpack_from('<H', data, 18)[0] * 0.01
+
+    geo_alt = struct.unpack_from('<H', data, 15)[0] * 0.5 - 1000.0
+    height  = struct.unpack_from('<H', data, 17)[0] * 0.5 - 1000.0
+
     return {
         "latitude":       round(lat, 7),
         "longitude":      round(lon, 7),
-        "altitude_geo":   round(alt_geodetic, 1),
+        "altitude_geo":   round(geo_alt, 1),
         "height_agl":     round(height, 1),
         "ground_speed":   round(speed, 2),
         "vertical_speed": round(vspeed, 2),
-        "heading":        round(heading, 1),
+        "heading":        round(direction, 1),
         "height_type":    "AGL" if height_type == 0 else "Above Takeoff",
     }
 
 
 def parse_system_msg(data: bytes) -> dict:
+    """
+    Decode ASTM F3411-22a System Message (16+ bytes).
+    See wifi_feeder.py for full byte layout — kept in sync with that file.
+    """
     if len(data) < 16:
         return {}
-    op_lat      = struct.unpack_from('<i', data, 4)[0] * 1e-7
-    op_lon      = struct.unpack_from('<i', data, 8)[0] * 1e-7
-    area_count  = data[12]
-    area_radius = data[13] * 10
-    alt_takeoff = struct.unpack_from('<H', data, 14)[0] * 0.5 - 1000.0
+    op_location_type = data[1] & 0x0F
+    op_lat = struct.unpack_from('<i', data, 2)[0] * 1e-7
+    op_lon = struct.unpack_from('<i', data, 6)[0] * 1e-7
+
+    if abs(op_lat) > 90.0 or abs(op_lon) > 180.0:
+        op_lat = op_lon = None
+
+    area_count    = struct.unpack_from('<H', data, 10)[0]
+    area_radius_m = data[12] * 10
+    alt_takeoff   = struct.unpack_from('<H', data, 13)[0] * 0.5 - 1000.0
+
     return {
-        "operator_lat":    round(op_lat, 7),
-        "operator_lon":    round(op_lon, 7),
-        "area_count":      area_count,
-        "area_radius_m":   area_radius,
-        "alt_takeoff_geo": round(alt_takeoff, 1),
+        "op_location_type": op_location_type,
+        "operator_lat":     round(op_lat, 7) if op_lat is not None else None,
+        "operator_lon":     round(op_lon, 7) if op_lon is not None else None,
+        "area_count":       area_count,
+        "area_radius_m":    area_radius_m,
+        "alt_takeoff_geo":  round(alt_takeoff, 1),
     }
 
 

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -306,6 +306,13 @@ def decode_rid_message(raw_bytes: bytes) -> dict | None:
 
 # -- Local Publisher -----------------------------------------------------------
 
+# Decoded keys already exposed via short aliases in the local record, plus
+# raw_hex (noise). Everything else in the decoded dict is added verbatim so
+# LAN/offline consumers get the full ODID picture.
+_LOCAL_ALIASED = {"message_type", "raw_hex", "latitude", "longitude",
+                  "altitude_geo", "ground_speed", "heading", "uas_id"}
+
+
 class LocalPublisher:
     """
     Writes decoded detections to a tmpfs ring buffer and UDP LAN broadcast.
@@ -336,6 +343,7 @@ class LocalPublisher:
             "rssi":    event.get("rssi"),
             "channel": event.get("channel"),
             "type":    decoded.get("message_type"),
+            # Backward-compatible short aliases (original schema)
             "lat":     decoded.get("latitude"),
             "lon":     decoded.get("longitude"),
             "alt":     decoded.get("altitude_geo"),
@@ -343,6 +351,11 @@ class LocalPublisher:
             "hdg":     decoded.get("heading"),
             "id":      decoded.get("uas_id"),
         }
+        # Surface every remaining decoded field so offline/LAN consumers get the
+        # full ODID picture (operator location, area, id_type, height_agl, etc.).
+        for k, v in decoded.items():
+            if k not in _LOCAL_ALIASED:
+                record[k] = v
         line = json.dumps(record, separators=(',', ':'))
 
         try:

--- a/droneaware
+++ b/droneaware
@@ -13,6 +13,55 @@ fatal() { echo -e "\n  ${RED}✗  ERROR: $*${NC}\n"; exit 1; }
 
 require_root() { [[ $EUID -eq 0 ]] || fatal "Run with sudo: sudo droneaware $1"; }
 
+# ---------------------------------------------------------------------------
+# Config.env additive merge — adds new fields introduced by recent releases
+# to an existing config.env, without touching user-customized values.
+#
+# Pattern for adding a new release's fields:
+#   if ! grep -q '^FIELD_NAME=' "$cfg"; then
+#       cat >> "$cfg" <<'EOF'
+#       ... new fields ...
+#       EOF
+#       info "..."
+#   fi
+#
+# Each block is idempotent (running update twice is a no-op the second time)
+# and cumulative (skipping a version still picks up its additions later).
+# A timestamped backup is written before any changes so users can restore.
+# ---------------------------------------------------------------------------
+migrate_config_env() {
+    local cfg="${INSTALL_DIR}/config.env"
+    [[ -f "$cfg" ]] || return  # nothing to migrate
+
+    local backed_up=0
+
+    # v1.2.0 additions — channel hopper config
+    if ! grep -q '^ADAPTIVE_DWELL=' "$cfg"; then
+        [[ "$backed_up" == "0" ]] && cp "$cfg" "${cfg}.bak.$(date +%s)" && backed_up=1
+        cat >> "$cfg" <<'EOF'
+
+# ─── Channel hopper (added by droneaware update for v1.2.0+) ───
+ADAPTIVE_DWELL=true
+# Optional adaptive-hopper tuning (uncomment to override defaults):
+# FIXED_CHANNEL=6           # Lock 100% to this channel — overrides adaptive logic
+# ACTIVE_WINDOW_SEC=3       # Sticky-mode reset threshold in seconds (default 3.0)
+# DWELL_CH6_MS=800          # Primary channel dwell in sweep mode (default 800ms)
+# DWELL_PEEK_MS=50          # Peek dwell on channels 1 and 11 (default 50ms)
+EOF
+        info "Added v1.2.0 channel hopper options to config.env"
+    fi
+
+    # Future release migration blocks go here.
+    # Pattern:
+    #   if ! grep -q '^NEW_FIELD=' "$cfg"; then
+    #       [[ "$backed_up" == "0" ]] && cp "$cfg" "${cfg}.bak.$(date +%s)" && backed_up=1
+    #       cat >> "$cfg" <<'EOF'
+    # ... new fields ...
+    # EOF
+    #       info "Added vX.Y.Z options to config.env"
+    #   fi
+}
+
 cmd_update() {
     require_root "update"
     echo ""
@@ -66,7 +115,17 @@ cmd_update() {
 
     cp /tmp/da_ble_feeder  "${INSTALL_DIR}/ble_feeder"
     cp /tmp/da_wifi_feeder "${INSTALL_DIR}/wifi_feeder"
-    [[ -s /tmp/da_cli ]] && cp /tmp/da_cli /usr/local/bin/droneaware
+    # Update the droneaware CLI itself. Must use atomic rename (mv) instead
+    # of in-place cp, because bash is currently READING from this same
+    # script file. In-place overwrite would shift bash's file pointer to
+    # bytes in the new (different-sized) file → garbage parsing at script
+    # end (the v1.2.0 "line 426: syntax error" bug). Atomic rename keeps
+    # the open file descriptor pointed at the old inode until bash exits.
+    if [[ -s /tmp/da_cli ]]; then
+        cp /tmp/da_cli /usr/local/bin/droneaware.new
+        chmod +x /usr/local/bin/droneaware.new
+        mv /usr/local/bin/droneaware.new /usr/local/bin/droneaware
+    fi
     rm -f /tmp/da_ble_feeder /tmp/da_wifi_feeder /tmp/da_cli
     echo "$LATEST" > "$VERSION_FILE"
 
@@ -76,6 +135,10 @@ cmd_update() {
     ln -sf "${INSTALL_DIR}/ble_feeder"  /usr/local/bin/ble_feeder  2>/dev/null || true
     ln -sf "${INSTALL_DIR}/wifi_feeder" /usr/local/bin/wifi_feeder 2>/dev/null || true
     info "Binaries installed."
+
+    # Add any new config.env fields introduced by this release before services
+    # restart (so they see the new EnvironmentFile values on the next read).
+    migrate_config_env
 
     systemctl daemon-reload
     systemctl start droneaware-wifi

--- a/install.sh
+++ b/install.sh
@@ -592,7 +592,8 @@ install_services() {
     heading "Installing Services"
     # As of v1.2.0, service files ship with the same release as the binaries.
     local base_url="https://github.com/${GITHUB_REPO}/releases/download/${BINARY_VERSION}"
-    local local_root="$(dirname "${LOCAL_DIST}")"
+    local local_root
+    local_root="$(dirname "${LOCAL_DIST}")"
 
     # bt-select helper
     if [[ "$LOCAL_INSTALL" == "1" ]]; then

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -884,6 +884,13 @@ def gps_reader_thread(device: str):
 
 # -- Local Publisher -----------------------------------------------------------
 
+# Decoded keys already exposed via short aliases in the local record, plus
+# raw_hex (noise). Everything else in the decoded dict is added verbatim so
+# LAN/offline consumers get the full ODID picture.
+_LOCAL_ALIASED = {"message_type", "raw_hex", "latitude", "longitude",
+                  "altitude_geo", "ground_speed", "heading", "uas_id"}
+
+
 class LocalPublisher:
     """
     Writes decoded detections to a tmpfs ring buffer and UDP LAN broadcast.
@@ -914,6 +921,7 @@ class LocalPublisher:
             "rssi":    event.get("rssi"),
             "channel": event.get("channel"),
             "type":    decoded.get("message_type"),
+            # Backward-compatible short aliases (original schema)
             "lat":     decoded.get("latitude"),
             "lon":     decoded.get("longitude"),
             "alt":     decoded.get("altitude_geo"),
@@ -921,6 +929,12 @@ class LocalPublisher:
             "hdg":     decoded.get("heading"),
             "id":      decoded.get("uas_id"),
         }
+        # Surface every remaining decoded field so offline/LAN consumers get the
+        # full ODID picture (operator location, area, id_type, height_agl, etc.).
+        # Skip raw_hex (noise) and keys already exposed via the short aliases.
+        for k, v in decoded.items():
+            if k not in _LOCAL_ALIASED:
+                record[k] = v
         line = json.dumps(record, separators=(',', ':'))
 
         try:

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -135,49 +135,87 @@ def parse_basic_id(data: bytes) -> dict:
 
 
 def parse_location(data: bytes) -> dict:
+    """
+    Decode ASTM F3411-22a Location/Vector message (25 bytes).
+    Byte layout (matches server-side canonical decoder):
+      0     header (msg_type/version)
+      1     status flags (speed_mult bit 0, EW bit 1, height_type bit 2)
+      2     track direction (raw 0-179, +180 if EW bit set)
+      3     speed (encoding depends on speed_mult)
+      4     vertical speed (raw * 0.5 - 62.0)
+      5-8   latitude  (int32 LE, * 1e-7)
+      9-12  longitude (int32 LE, * 1e-7)
+     13-14  pressure altitude (uint16 LE, * 0.5 - 1000.0)
+     15-16  geometric altitude (uint16 LE, * 0.5 - 1000.0)
+     17-18  height AGL/above-takeoff (uint16 LE, * 0.5 - 1000.0)
+    """
     if len(data) < 25:
         return {}
-    speed_mult  = data[1] & 0x01
-    height_type = (data[1] >> 2) & 0x01
-    lat = struct.unpack_from('<i', data, 2)[0] * 1e-7
-    lon = struct.unpack_from('<i', data, 6)[0] * 1e-7
+
+    status      = data[1]
+    speed_mult  = (status >> 0) & 0x01
+    ew_bit      = (status >> 1) & 0x01
+    height_type = (status >> 2) & 0x01
+
+    direction   = data[2] + (180 if ew_bit else 0)
+    speed       = data[3] * 0.75 + 63.75 if speed_mult else data[3] * 0.25
+    vspeed      = data[4] * 0.5 - 62.0
+
+    lat = struct.unpack_from('<i', data, 5)[0] * 1e-7
+    lon = struct.unpack_from('<i', data, 9)[0] * 1e-7
 
     # Reject null/placeholder GPS values broadcast before lock (e.g. DJI firmware
     # transmits lat>90 or lon>180 as a sentinel until GPS acquires).
     if abs(lat) > 90.0 or abs(lon) > 180.0:
         return {}
 
-    alt_geodetic = struct.unpack_from('<H', data, 12)[0] * 0.5 - 1000.0
-    height       = struct.unpack_from('<H', data, 14)[0] * 0.5 - 1000.0
-    speed        = data[16] * (0.75 if speed_mult else 0.25)
-    vspeed       = data[17] * 0.5 - 62.0
-    heading      = struct.unpack_from('<H', data, 18)[0] * 0.01
+    geo_alt = struct.unpack_from('<H', data, 15)[0] * 0.5 - 1000.0
+    height  = struct.unpack_from('<H', data, 17)[0] * 0.5 - 1000.0
+
     return {
         "latitude":       round(lat, 7),
         "longitude":      round(lon, 7),
-        "altitude_geo":   round(alt_geodetic, 1),
+        "altitude_geo":   round(geo_alt, 1),
         "height_agl":     round(height, 1),
         "ground_speed":   round(speed, 2),
         "vertical_speed": round(vspeed, 2),
-        "heading":        round(heading, 1),
+        "heading":        round(direction, 1),
         "height_type":    "AGL" if height_type == 0 else "Above Takeoff",
     }
 
 
 def parse_system_msg(data: bytes) -> dict:
+    """
+    Decode ASTM F3411-22a System Message (16+ bytes).
+    Byte layout (matches server-side canonical decoder):
+       1 (low nibble)  op_location_type  (d[1] & 0x0F)
+       2-5             operator latitude   (int32 LE, * 1e-7)
+       6-9             operator longitude  (int32 LE, * 1e-7)
+      10-11            area_count          (uint16 LE)
+      12               area_radius_m       (raw * 10)
+      13-14            alt_takeoff_geo     (uint16 LE, * 0.5 - 1000.0)
+    """
     if len(data) < 16:
         return {}
-    op_lat      = struct.unpack_from('<i', data, 4)[0] * 1e-7
-    op_lon      = struct.unpack_from('<i', data, 8)[0] * 1e-7
-    area_count  = data[12]
-    area_radius = data[13] * 10
-    alt_takeoff = struct.unpack_from('<H', data, 14)[0] * 0.5 - 1000.0
+    op_location_type = data[1] & 0x0F
+    op_lat = struct.unpack_from('<i', data, 2)[0] * 1e-7
+    op_lon = struct.unpack_from('<i', data, 6)[0] * 1e-7
+
+    # Reject placeholder/pre-lock values (same convention as parse_location)
+    if abs(op_lat) > 90.0 or abs(op_lon) > 180.0:
+        op_lat = op_lon = None
+
+    area_count    = struct.unpack_from('<H', data, 10)[0]
+    area_radius_m = data[12] * 10
+    alt_takeoff   = struct.unpack_from('<H', data, 13)[0] * 0.5 - 1000.0
+
     return {
-        "operator_lat":    round(op_lat, 7),
-        "operator_lon":    round(op_lon, 7),
-        "area_count":      area_count,
-        "area_radius_m":   area_radius,
-        "alt_takeoff_geo": round(alt_takeoff, 1),
+        "op_location_type": op_location_type,
+        "operator_lat":     round(op_lat, 7) if op_lat is not None else None,
+        "operator_lon":     round(op_lon, 7) if op_lon is not None else None,
+        "area_count":       area_count,
+        "area_radius_m":    area_radius_m,
+        "alt_takeoff_geo":  round(alt_takeoff, 1),
     }
 
 


### PR DESCRIPTION
## Summary

Four fixes, all reported by community feedback or surfaced during v1.2.0 rollout:

- **Self-modifying update script fix** — `cmd_update` now uses an atomic
  `mv` instead of in-place `cp` to install the new CLI. Eliminates the
  cosmetic "line 426: syntax error" message users saw after running
  `sudo droneaware update`. (Note: the v1.2.0 → v1.2.1 update will still
  surface the error one last time, because the buggy v1.2.0 cp is what
  runs during that transition.)

- **SAST scanning** — adds a Shellcheck workflow (`.github/workflows/
  shellcheck.yml`) covering install.sh, droneaware, droneaware-bt-select,
  and build.sh. Pre-cleaned the one warning-level finding. CodeQL setup
  enabled in repo settings for Python coverage.

- **Node-side decoder fix** — fixes wrong byte offsets in
  `parse_location` and `parse_system_msg` in both `wifi_feeder.py` and
  `ble_feeder.py`. Local UDP/9999 broadcasts and the
  `/run/droneaware/detections.jsonl` ring buffer were producing bogus
  coordinates (server-side decode was always correct). Reported by
  @iaincaradoc.

- **Config.env additive merge on `droneaware update`** — adds new
  fields introduced by recent releases to existing config.env files,
  preserving user customizations. Idempotent and cumulative
  (version-skip safe). Backs up to `config.env.bak.<timestamp>` once
  before any modifications. Reported by @JeGoBE8900.

## Test plan
- [ x] Shellcheck workflow passes
- [ x] CodeQL findings reviewed
- [ x] LOCAL_INSTALL test on Bookworm Pi
- [ x] Confirm decoder fix produces correct coords in UDP/9999 broadcast

Closes #17, #18.