### PR TITLE
v1.2.2: 5 GHz scanning for dual-band adapters, compliant-only default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
           # "GLIBC_2.38 not found." Pin keeps binaries forward-compatible:
           # build on the oldest supported OS so binaries run everywhere newer.
           base_image: "raspi_3_bookworm:20231109"
-          cpu: cortex-a7
+          cpu: cortex-a72
           copy_artifact_path: dist/
           commands: |
             apt-get update
@@ -75,6 +75,36 @@ jobs:
             droneaware-ble.service \
             droneaware-wifi.service \
             --generate-notes
+        env:
+          VERSION: ${{ inputs.version }}
+          DL_PATH: ${{ steps.download.outputs.download-path }}
+          GH_TOKEN: ${{ github.token }}
+      - name: Append SHA256 checksums to release notes
+        # Lower-barrier verification path than `gh attestation verify` (which
+        # needs the GitHub CLI + auth). Users can copy the block below into a
+        # file and run `sha256sum -c <file>` to verify integrity.
+        run: |
+          [[ "$VERSION" =~ ^v ]] || VERSION="v$VERSION"
+          existing=$(gh release view "$VERSION" --json body -q .body)
+          {
+            echo "$existing"
+            echo ""
+            echo "## SHA256 Checksums"
+            echo ""
+            echo 'Verify downloaded files with `sha256sum -c` against this list:'
+            echo ""
+            echo '```'
+            for f in ble_feeder wifi_feeder install.sh droneaware \
+                     droneaware-bt-select droneaware-bt-select.service \
+                     droneaware-ble.service droneaware-wifi.service; do
+              src="${DL_PATH}/${f}"
+              [[ -f "$src" ]] || src="${f}"
+              sha=$(sha256sum "$src" | awk '{print $1}')
+              printf '%s  %s\n' "$sha" "$f"
+            done
+            echo '```'
+          } > /tmp/notes.md
+          gh release edit "$VERSION" --notes-file /tmp/notes.md
         env:
           VERSION: ${{ inputs.version }}
           DL_PATH: ${{ steps.download.outputs.download-path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,144 @@
+# Changelog
+
+All notable changes to DroneAware Node will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Full release artifacts and discussion notes live at the
+[GitHub Releases page](https://github.com/fduflyer/DroneAware-Node-Releases/releases).
+
+---
+
+## [1.2.2] — Unreleased
+
+### Added
+- **5 GHz Wi-Fi RID scanning for dual-band adapters.** New `DualBandHopper` runs a
+  30-second cycle (20 s on channel 6, 10 s on channel 149 — the ASTM F3411
+  channels for 1 Hz Remote ID broadcasts on 2.4 GHz and 5 GHz respectively).
+  Auto-selects when the configured adapter advertises channel 149 in monitor
+  mode; the existing 2.4-only `AdaptiveChannelHopper` continues to drive
+  single-band setups unchanged.
+- `WIFI_5G_ENABLED` config key (`auto` | `true` | `false`) for explicit
+  override of the auto-detect heuristic.
+- `WIFI_OFF_CHANNEL_SWEEP` config key — advanced opt-in for ch 1 and ch 11
+  canary peeks. Off by default (see *Changed* below).
+- **PHY capability verification at feeder startup.** Logs `Hopper channels: […]`
+  reflecting the actual hopper plan and warns if any target channel isn't in
+  the radio's supported set (catches regulatory restrictions, driver bugs, or
+  hot-plug capability drift before the feeder hops blind).
+- **Per-channel breakdown in `droneaware test` output** — confirms 2.4 GHz and
+  5 GHz reception independently after a test transmission, with a "Both bands
+  receiving" confirmation when both produce detections.
+- **SHA256 checksums in release notes.** Lower-barrier verification path than
+  `gh attestation verify`; verify downloads with `sha256sum -c` from any Unix
+  shell.
+- `GPS_BAUD` migration block in `droneaware update` — pre-v1.1.3 configs now
+  pick up the field automatically on upgrade. Harmless when blank (auto-detect
+  runs), but exposes the override for users wanting to pin the baud rate.
+
+### Changed
+- **Default scanning is compliant-channels-only.** Empirical fleet data shows
+  channels 1 and 11 carry zero unique drones — all observed off-band captures
+  are channel-6 adjacent-channel drift. The hopper now spends 100 % of cycle
+  time on ASTM-compliant channels (ch 6, plus ch 149 on dual-band nodes).
+  Operators wanting to chase non-standard transmitters can re-enable the
+  ch 1 / ch 11 canary peeks via `WIFI_OFF_CHANNEL_SWEEP=true`. Net effect on
+  existing v1.2.0+ deployments: ~10 % more ch 6 dwell per cycle, no unique
+  drone loss.
+- `droneaware status` now requires `sudo` (matches `update` and `test`). Fixes
+  a long-standing silent failure where the Node ID line would display empty
+  when run without root, because `config.env` is chmod 600.
+- Startup log replaces the stale `Channels: [1, 2, …, 11]` line with
+  `Hopper channels: […]` derived from the active hopper — accurate for both
+  2.4-only and dual-band deployments.
+- CI workflow `cpu` label corrected from `cortex-a7` to `cortex-a72` (cosmetic;
+  binaries were already aarch64 via the 64-bit base image).
+
+### Notes for operators upgrading from v1.2.0 / v1.2.1
+- 2.4-only nodes: behavior shifts from `[6 → 1 → 11 → 6]` sweep to constant
+  ch 6 dwell. To preserve previous behavior, set `WIFI_OFF_CHANNEL_SWEEP=true`
+  in `/opt/droneaware/config.env` after updating.
+- Nodes with dual-band USB adapters automatically enable 5 GHz scanning. No
+  manual configuration required.
+
+---
+
+## [1.2.1] — 2026-05-27
+
+### Added
+- SAST scanning: CodeQL (Python + Actions) and Shellcheck on PRs, surfaced in
+  the repository's Security tab.
+
+### Fixed
+- **Self-modifying update script crash.** `cmd_update` now writes the new CLI
+  to a temp path and atomically `mv`s it into place instead of overwriting the
+  running file in-place. Eliminates the `syntax error near unexpected token
+  ';;'` reported on the v1.2.0 update (the_ninja, VirusPilot). Takes effect
+  v1.2.1 → v1.2.2 onward — the v1.2.0 → v1.2.1 transition still shows the
+  legacy error once because the buggy `cp` runs from the old CLI.
+- **ASTM F3411-22a Location/Vector and System Message decoder offsets** (issue
+  #18, iaincaradoc). The local UDP broadcast and ring-buffer events now decode
+  to correct coordinates and operator fields; the server wire payload was
+  already correct.
+- **`config.env` additive merge on `droneaware update`** (issue #17,
+  JeGoBE8900). New release fields are appended in idempotent blocks; existing
+  user values (`NODE_ID`, location, etc.) are preserved untouched.
+- All decoded Open Drone ID fields now surfaced in the local UDP and ring
+  buffer streams (operator_lat/lon, area_count, id_type, ua_type, height_agl,
+  etc.) — full data parity for offline consumers.
+
+---
+
+## [1.2.0.1] — 2026-05-26
+
+### Fixed
+- **GLIBC_2.38 regression on Pi OS Bookworm.** CI base image pinned to
+  `raspi_3_bookworm:20231109` (glibc 2.36). The previous
+  `raspios_lite_arm64:latest` had silently moved to Trixie (glibc 2.41),
+  producing v1.2.0 binaries that failed at runtime on Bookworm nodes with
+  `version GLIBC_2.38 not found`. Reported by chuck.meister.
+
+---
+
+## [1.2.0] — 2026-05-24
+
+First release built end-to-end by the GitHub Actions CI/CD pipeline, with
+Sigstore attestation on every artifact.
+
+### Added
+- **Adaptive channel hopper** biased to channel 6 (ASTM F3411 mandates 1 Hz
+  Wi-Fi RID broadcasts on ch 6 in the 2.4 GHz band). Previous flat 1–11 hop
+  spent ~91 % of time on channels where compliant RID cannot exist.
+- `channel` field on detection payloads.
+- Soft-fail on missing adapter — single-radio installations are supported,
+  and a missing radio reports FAULT in the heartbeat with a structured reason
+  string. Installer no longer aborts when only one of BLE / Wi-Fi is present.
+- Per-feeder heartbeat routing — presence of `wifi_ok` or `ble_ok` in the
+  heartbeat is the routing key; cross-radio fields no longer permitted.
+- Service files (`droneaware-wifi.service`, `droneaware-ble.service`,
+  `droneaware-bt-select.service`) bundled in every release artifact.
+- May 2026 Contributor Agreement displayed at install time and shipped in the
+  installer.
+
+### Changed
+- **Release pipeline:** binaries built and signed by GitHub Actions. Verify
+  any artifact with `gh attestation verify <file> --owner fduflyer`.
+- **One release = one version.** `SERVICE_VERSION` removed — service files,
+  binaries, `install.sh`, and the CLI now all ship together in each release,
+  with `install.sh` `sed`-stamped at build time to point at its own assets.
+
+---
+
+## Older releases (v1.0.0 – v1.1.3)
+
+See the [GitHub Releases page](https://github.com/fduflyer/DroneAware-Node-Releases/releases)
+for per-version notes. Highlights:
+
+- **v1.1.x:** test-flight command (`sudo droneaware test`), WiFi NAN frame
+  filtering by ODID Service ID (eliminates Apple Continuity / AirDrop false
+  positives), runtime monitor-mode guard, GPS NMEA checksum-validated baud
+  detection.
+- **v1.0.x:** initial public release, stdlib AF_PACKET sockets (scapy
+  removed), session-token enrollment, mobile / static location prompts,
+  tmpfs ring buffer + UDP LAN broadcast, droneaware CLI introduction.

--- a/droneaware
+++ b/droneaware
@@ -51,6 +51,48 @@ EOF
         info "Added v1.2.0 channel hopper options to config.env"
     fi
 
+    # v1.1.3 catch-up — GPS_BAUD (missing from configs older than v1.1.3)
+    # Harmless when absent (auto-detect runs at startup), but added for
+    # config consistency so users can see/override the value.
+    if ! grep -q '^GPS_BAUD=' "$cfg"; then
+        [[ "$backed_up" == "0" ]] && cp "$cfg" "${cfg}.bak.$(date +%s)" && backed_up=1
+        cat >> "$cfg" <<'EOF'
+
+# ─── GPS baud rate (added by droneaware update for v1.1.3+) ───
+# Blank = auto-detect at startup (tries 9600 → 38400 → 115200 with NMEA
+# checksum validation). Set explicitly to skip detection: GPS_BAUD=9600
+GPS_BAUD=
+EOF
+        info "Added v1.1.3 GPS_BAUD option to config.env"
+    fi
+
+    # v1.2.2 additions — 5 GHz scanning (dual-band adapter support)
+    if ! grep -q '^WIFI_5G_ENABLED=' "$cfg"; then
+        [[ "$backed_up" == "0" ]] && cp "$cfg" "${cfg}.bak.$(date +%s)" && backed_up=1
+        cat >> "$cfg" <<'EOF'
+
+# ─── 5 GHz scanning (added by droneaware update for v1.2.2+) ───
+# Single dual-band adapter runs a 30s cycle (ASTM-compliant channels only):
+#   20s ch6 (2.4 GHz RID) → 10s ch149 (5 GHz RID).
+# Requires the adapter to expose channel 149 in monitor mode.
+#
+# auto  — detect dual-band capability at startup (recommended)
+# true  — force-enable (warns and falls back if adapter doesn't support 5 GHz)
+# false — force-disable (stay on 2.4 GHz only even if adapter is dual-band)
+WIFI_5G_ENABLED=auto
+
+# Off-channel sweep (advanced opt-in). When enabled, the hopper adds brief
+# peeks at ch1 and ch11 (1 sec each per cycle) to surface any non-standard
+# transmitters that might appear on those channels in the future.
+# Empirical fleet data shows ~0% real ch1/ch11 broadcasts today (all observed
+# off-band captures are ch6 drift), so the default is OFF — the platform spends
+# 100% of cycle time on the channels where compliant RID actually transmits.
+# Enable only if you specifically want to chase non-compliant transmitters.
+WIFI_OFF_CHANNEL_SWEEP=false
+EOF
+        info "Added v1.2.2 5 GHz scanning options to config.env"
+    fi
+
     # Future release migration blocks go here.
     # Pattern:
     #   if ! grep -q '^NEW_FIELD=' "$cfg"; then
@@ -154,6 +196,7 @@ cmd_update() {
 }
 
 cmd_status() {
+    require_root "status"
     echo ""
     echo -e "${BOLD}DroneAware Node Status${NC}"
     echo ""
@@ -468,15 +511,50 @@ sock.close()
 print("\n  Transmission complete.")
 PYEOF
 
-    # Check local detection ring buffer
+    # Check local detection ring buffer (per-channel breakdown so the
+    # operator can see whether 2.4 GHz and 5 GHz radio paths both received).
     echo ""
     echo "  Checking local detection buffer..."
     sleep 3
-    if grep -q "$test_id" /run/droneaware/detections.jsonl 2>/dev/null; then
-        info "Local detection confirmed — your node received the test signal."
-    else
+
+    local stats
+    stats=$(python3 - "$test_id" 2>/dev/null <<'PYJSON'
+import json, sys
+test_id = sys.argv[1]
+counts = {}
+total = 0
+try:
+    with open("/run/droneaware/detections.jsonl") as f:
+        for line in f:
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            decoded = e.get("decoded") or {}
+            if decoded.get("uas_id") != test_id:
+                continue
+            total += 1
+            ch = e.get("channel")
+            counts[ch] = counts.get(ch, 0) + 1
+except FileNotFoundError:
+    pass
+print(total, counts.get(6, 0), counts.get(149, 0))
+PYJSON
+)
+
+    local total ch6 ch149
+    read -r total ch6 ch149 <<< "${stats:-0 0 0}"
+
+    if [[ "$total" -eq 0 ]]; then
         warn "No local detection found yet — the server may still be processing."
         warn "Check your My Nodes page in 30 seconds."
+    else
+        info "Local detection confirmed — ${total} events captured"
+        echo "       2.4 GHz (ch  6) : ${ch6}"
+        echo "       5 GHz  (ch 149) : ${ch149}"
+        if [[ "$ch6" -gt 0 && "$ch149" -gt 0 ]]; then
+            info "Both bands receiving — radio fully functional."
+        fi
     fi
     echo ""
 }

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -528,11 +528,56 @@ def restore_managed_mode(iface: str):
 
 
 def set_channel(iface: str, channel: int):
-    """Set the monitor interface to a specific 2.4 GHz channel."""
+    """Set the monitor interface to a specific channel (2.4 or 5 GHz)."""
     subprocess.run(
         ["iw", "dev", iface, "set", "channel", str(channel)],
         check=False, capture_output=True,
     )
+
+
+def _supported_channels(iface: str) -> set:
+    """Channel numbers the iface's PHY can tune to (not disabled, regulatory-allowed).
+    Parses `iw phy phyN info` and extracts bracketed channel numbers from lines
+    like "* 5745 MHz [149] (10.0 dBm)". Newer iw prints "5745.0 MHz" — the
+    bracketed channel is consistent across versions.
+    """
+    try:
+        info = subprocess.run(
+            ["iw", "dev", iface, "info"],
+            capture_output=True, text=True, timeout=2, check=False,
+        )
+        phy = None
+        for line in info.stdout.splitlines():
+            s = line.strip()
+            if s.startswith("wiphy "):
+                phy = s.split()[-1]
+                break
+        if phy is None:
+            return set()
+
+        phyinfo = subprocess.run(
+            ["iw", "phy", f"phy{phy}", "info"],
+            capture_output=True, text=True, timeout=2, check=False,
+        )
+        chans = set()
+        for line in phyinfo.stdout.splitlines():
+            if "MHz" not in line or "[" not in line or "disabled" in line:
+                continue
+            start = line.find("[")
+            end   = line.find("]", start)
+            if start != -1 and end != -1:
+                try:
+                    chans.add(int(line[start + 1:end]))
+                except ValueError:
+                    pass
+        return chans
+    except Exception:
+        return set()
+
+
+def _adapter_supports_5g(iface: str) -> bool:
+    """True if iface's PHY exposes channel 149 (5 GHz ASTM RID channel)."""
+    return 149 in _supported_channels(iface)
 
 
 # -- Channel Hopper ------------------------------------------------------------
@@ -562,6 +607,10 @@ class ChannelHopper(threading.Thread):
         """No-op — flat hop ignores detection feedback. Present for API parity."""
         pass
 
+    @property
+    def target_channels(self) -> list:
+        return list(self.channels)
+
     def stop(self):
         self._stop.set()
 
@@ -572,12 +621,17 @@ class AdaptiveChannelHopper(threading.Thread):
 
     Spec basis: F3411 + opendroneid-core-c require 1 Hz Wi-Fi Beacon RID
     broadcasts on channel 6 (2.4 GHz) or 149 (5 GHz). Off-channel broadcasts
-    must be at 5 Hz, which no manufacturer accepts. Even-hop scanning across
-    1–11 spends ~91% of time on channels where compliant 1 Hz RID cannot
-    exist.
+    must be at 5 Hz, which no manufacturer accepts.
 
-    Sweep mode (idle, no detection within ACTIVE_WINDOW):
-      ~80% on channel 6, brief peeks at 1 and 11.
+    Sweep mode (default — WIFI_OFF_CHANNEL_SWEEP=false):
+      100% dwell on channel 6. This is a compliant-operator detection platform;
+      fleet data shows ch1/ch11 carry zero unique drones (all off-band captures
+      are ch6 drift), so spending no time there is the empirically correct
+      default.
+
+    Sweep mode with off-channel canary (WIFI_OFF_CHANNEL_SWEEP=true, advanced):
+      ~80% on channel 6, brief peeks at 1 and 11 to surface any non-standard
+      transmitters that emerge in the future.
 
     Sticky mode (active detection within ACTIVE_WINDOW):
       Hold on the channel that produced the detection. Forced peek every
@@ -632,6 +686,9 @@ class AdaptiveChannelHopper(threading.Thread):
         self.sweep_primary_ms = _parse_int("DWELL_CH6_MS",  self.SWEEP_PRIMARY_MS)
         self.sweep_peek_ms    = _parse_int("DWELL_PEEK_MS", self.SWEEP_PEEK_MS)
 
+        sweep_raw = os.environ.get("WIFI_OFF_CHANNEL_SWEEP", "false").strip().lower()
+        self.off_channel_sweep = sweep_raw in ("true", "1", "yes", "on")
+
         # Guard against zero/negative dwells that would spin the loop
         if self.sweep_primary_ms <= 0:
             log.warning(f"DWELL_CH6_MS={self.sweep_primary_ms} invalid — using {self.SWEEP_PRIMARY_MS}")
@@ -645,6 +702,15 @@ class AdaptiveChannelHopper(threading.Thread):
         self.last_detection_time = time.time()
         if channel is not None:
             self.last_detection_channel = channel
+
+    @property
+    def target_channels(self) -> list:
+        if self.fixed_channel is not None:
+            return [self.fixed_channel]
+        chans = [self.PRIMARY_CHANNEL]
+        if self.off_channel_sweep:
+            chans.extend(self.PEEK_CHANNELS)
+        return chans
 
     def _set(self, ch: int):
         set_channel(self.iface, ch)
@@ -664,7 +730,8 @@ class AdaptiveChannelHopper(threading.Thread):
 
         log.info(
             f"Adaptive hopper started: primary=ch{self.PRIMARY_CHANNEL}, "
-            f"peek={self.PEEK_CHANNELS}, ACTIVE_WINDOW={self.active_window}s, "
+            f"peek={self.PEEK_CHANNELS if self.off_channel_sweep else '[]'}, "
+            f"ACTIVE_WINDOW={self.active_window}s, "
             f"DWELL_CH6_MS={self.sweep_primary_ms}, DWELL_PEEK_MS={self.sweep_peek_ms}"
         )
         prev_mode = "sweep"
@@ -691,16 +758,152 @@ class AdaptiveChannelHopper(threading.Thread):
                         if self._sleep_ms(self.STICKY_PEEK_MS):
                             return
             else:
-                # Sweep cycle: primary → peek1 → peek2 → primary_tail
+                # Sweep cycle: primary → (optional peek1 → peek2 → primary_tail).
+                # Default is compliant-only (no peeks) — set WIFI_OFF_CHANNEL_SWEEP=true
+                # to surface non-standard transmitters on ch1/ch11.
                 self._set(self.PRIMARY_CHANNEL)
                 if self._sleep_ms(self.sweep_primary_ms):
                     break
-                for ch in self.PEEK_CHANNELS:
-                    self._set(ch)
-                    if self._sleep_ms(self.sweep_peek_ms):
+                if self.off_channel_sweep:
+                    for ch in self.PEEK_CHANNELS:
+                        self._set(ch)
+                        if self._sleep_ms(self.sweep_peek_ms):
+                            return
+                    self._set(self.PRIMARY_CHANNEL)
+                    if self._sleep_ms(self.SWEEP_PRIMARY_TAIL_MS):
+                        break
+
+    def stop(self):
+        self._stop.set()
+
+
+class DualBandHopper(threading.Thread):
+    """
+    30s cycle hopper for dual-band adapters (2.4 GHz + 5 GHz).
+
+    Sweep mode default (WIFI_OFF_CHANNEL_SWEEP=false):
+        20s ch6 → 10s ch149  (1 band switch per cycle, ASTM-compliant channels only)
+
+    Sweep mode with off-channel canary (WIFI_OFF_CHANNEL_SWEEP=true, advanced):
+        18s ch6 → 1s ch1 → 1s ch11 → 10s ch149
+
+    Sticky mode (detection within ACTIVE_WINDOW): hold on the detected channel.
+    Periodic peek at the other band's primary every STICKY_PEEK_INTERVAL cycles.
+
+    Empirical data (project_detection_data memory): ch1/ch11 carry zero unique
+    drones — all off-band captures are ch6 drift. Default is compliant-only;
+    advanced users can enable peeks via WIFI_OFF_CHANNEL_SWEEP=true to surface
+    any future non-standard transmitters.
+    """
+
+    PRIMARY_CHANNEL_2G    = 6
+    PRIMARY_CHANNEL_5G    = 149
+    PEEK_CHANNELS_2G      = [1, 11]
+    ACTIVE_WINDOW         = 3.0
+
+    DWELL_CH6_S           = 18.0
+    DWELL_CH6_FULL_S      = 20.0
+    DWELL_CH149_S         = 10.0
+    PEEK_S                = 1.0
+
+    STICKY_DWELL_MS       = 950
+    STICKY_PEEK_INTERVAL  = 10
+    STICKY_PEEK_MS        = 25
+
+    def __init__(self, iface: str):
+        super().__init__(daemon=True)
+        self.iface                  = iface
+        self.current_channel        = self.PRIMARY_CHANNEL_2G
+        self.last_detection_time    = 0.0
+        self.last_detection_channel = self.PRIMARY_CHANNEL_2G
+        self.sticky_cycle_count     = 0
+        self._stop                  = threading.Event()
+
+        sweep_raw = os.environ.get("WIFI_OFF_CHANNEL_SWEEP", "false").strip().lower()
+        self.off_channel_sweep = sweep_raw in ("true", "1", "yes", "on")
+
+        raw = os.environ.get("FIXED_CHANNEL", "").strip()
+        try:
+            self.fixed_channel = int(raw) if raw else None
+        except ValueError:
+            log.warning(f"FIXED_CHANNEL={raw!r} is not an integer — ignoring")
+            self.fixed_channel = None
+
+    def notify_detection(self, channel: int | None):
+        self.last_detection_time = time.time()
+        if channel is not None:
+            self.last_detection_channel = channel
+
+    @property
+    def target_channels(self) -> list:
+        if self.fixed_channel is not None:
+            return [self.fixed_channel]
+        chans = [self.PRIMARY_CHANNEL_2G, self.PRIMARY_CHANNEL_5G]
+        if self.off_channel_sweep:
+            chans.extend(self.PEEK_CHANNELS_2G)
+        return chans
+
+    def _set(self, ch: int):
+        set_channel(self.iface, ch)
+        self.current_channel = ch
+
+    def _sleep_s(self, seconds: float) -> bool:
+        return self._stop.wait(timeout=seconds)
+
+    def run(self):
+        if self.fixed_channel is not None:
+            log.info(f"Dual-band hopper: FIXED_CHANNEL={self.fixed_channel} — locking, no hop")
+            self._set(self.fixed_channel)
+            self._stop.wait()
+            return
+
+        canary = "enabled" if self.off_channel_sweep else "disabled"
+        log.info(
+            f"Dual-band hopper started: 30s cycle "
+            f"(ch{self.PRIMARY_CHANNEL_2G} + ch{self.PRIMARY_CHANNEL_5G}), "
+            f"off-channel canary {canary}"
+        )
+        prev_mode = "sweep"
+
+        while not self._stop.is_set():
+            in_active = (time.time() - self.last_detection_time) < self.ACTIVE_WINDOW
+            mode      = "sticky" if in_active else "sweep"
+
+            if mode != prev_mode:
+                log.debug(f"DualBand hopper: {prev_mode}→{mode}")
+                if mode == "sweep":
+                    self.sticky_cycle_count = 0
+                prev_mode = mode
+
+            if mode == "sticky":
+                self._set(self.last_detection_channel)
+                if self._sleep_s(self.STICKY_DWELL_MS / 1000.0):
+                    break
+                self.sticky_cycle_count += 1
+
+                if self.sticky_cycle_count % self.STICKY_PEEK_INTERVAL == 0:
+                    other = (self.PRIMARY_CHANNEL_5G
+                             if self.last_detection_channel in (1, 6, 11)
+                             else self.PRIMARY_CHANNEL_2G)
+                    self._set(other)
+                    if self._sleep_s(self.STICKY_PEEK_MS / 1000.0):
                         return
-                self._set(self.PRIMARY_CHANNEL)
-                if self._sleep_ms(self.SWEEP_PRIMARY_TAIL_MS):
+            else:
+                if self.off_channel_sweep:
+                    self._set(self.PRIMARY_CHANNEL_2G)
+                    if self._sleep_s(self.DWELL_CH6_S):
+                        break
+                    for ch in self.PEEK_CHANNELS_2G:
+                        self._set(ch)
+                        if self._sleep_s(self.PEEK_S):
+                            return
+                else:
+                    self._set(self.PRIMARY_CHANNEL_2G)
+                    if self._sleep_s(self.DWELL_CH6_FULL_S):
+                        break
+
+                self._set(self.PRIMARY_CHANNEL_5G)
+                if self._sleep_s(self.DWELL_CH149_S):
                     break
 
     def stop(self):
@@ -980,12 +1183,34 @@ class WiFiFeeder:
         # ADAPTIVE_DWELL=false reverts to legacy flat 1–11 hop (A/B testing)
         adaptive_dwell = os.environ.get("ADAPTIVE_DWELL", "true").strip().lower() \
                             in ("true", "1", "yes", "on")
-        if adaptive_dwell:
-            log.info("Hopper mode: adaptive (sweep + sticky, channel-6 biased)")
-            self.hopper = AdaptiveChannelHopper(iface)
-        else:
+        if not adaptive_dwell:
             log.info("Hopper mode: flat (legacy even hop across 1–11)")
             self.hopper = ChannelHopper(iface, CHANNELS_24, channel_dwell)
+        else:
+            wifi_5g = os.environ.get("WIFI_5G_ENABLED", "auto").strip().lower()
+            if wifi_5g in ("true", "1", "yes", "on"):
+                supports_5g = _adapter_supports_5g(iface) if iface else False
+                if not supports_5g:
+                    log.warning(
+                        f"WIFI_5G_ENABLED=true but {iface or '<none>'} does not "
+                        "expose channel 149 — falling back to 2.4 GHz only"
+                    )
+                enable_5g = supports_5g
+            elif wifi_5g in ("false", "0", "no", "off"):
+                enable_5g = False
+            else:  # "auto" (default) — detect at startup
+                enable_5g = _adapter_supports_5g(iface) if iface else False
+                if iface and enable_5g:
+                    log.info(f"Dual-band adapter detected on {iface} — enabling 5 GHz scanning")
+                elif iface:
+                    log.info(f"Single-band adapter on {iface} — 2.4 GHz only")
+
+            if enable_5g:
+                log.info("Hopper mode: dual-band (ch6 + ch149, 30s cycle)")
+                self.hopper = DualBandHopper(iface)
+            else:
+                log.info("Hopper mode: adaptive (sweep + sticky, channel-6 biased)")
+                self.hopper = AdaptiveChannelHopper(iface)
         self.count       = 0
         self.nan_count   = 0
         self._scanning   = False
@@ -1081,7 +1306,18 @@ class WiFiFeeder:
 
     def run(self):
         log.info(f"DroneAware WiFi Feeder - Node: {self.node_id}")
-        log.info(f"Interface: {self.iface or '<not configured>'}  |  Channels: {CHANNELS_24}")
+        target = self.hopper.target_channels
+        log.info(f"Interface: {self.iface or '<not configured>'}  |  Hopper channels: {target}")
+
+        if self.iface and os.path.exists(f"/sys/class/net/{self.iface}"):
+            supported = _supported_channels(self.iface)
+            if supported:
+                missing = [c for c in target if c not in supported]
+                if missing:
+                    log.warning(
+                        f"PHY does not advertise channels {missing} — "
+                        "hopper will retune but the radio may not actually be there."
+                    )
 
         # FAULT mode — missing or invalid WiFi adapter
         if not self.iface or not os.path.exists(f"/sys/class/net/{self.iface}"):


### PR DESCRIPTION
## Summary

Adds 5 GHz Wi-Fi Remote ID scanning for dual-band USB adapters, flips the default scanning policy to ASTM-compliant channels only, and bundles several CLI/CI/docs improvements. Pre-flight hardware/OS detection was deliberately deferred to v1.2.3 to keep this release focused on the 5 GHz expansion and ensure it deploys cleanly on recommended hardware first.

## Major changes

### New: 5 GHz scanning for dual-band adapters

- `DualBandHopper` class auto-selects when the configured monitor adapter advertises channel 149 in monitor mode (`_adapter_supports_5g()` queries `iw phy`)
- 30 s cycle: 20 s on ch 6 + 10 s on ch 149 (one band switch per cycle)
- Configurable via two new keys: `WIFI_5G_ENABLED` (`auto`/`true`/`false`) and `WIFI_OFF_CHANNEL_SWEEP`
- 2.4-only nodes continue to use `AdaptiveChannelHopper` — no path change for single-band hardware

### Behavior change: compliant-channels-only by default

- Empirical fleet data shows ch 1 / ch 11 carry **zero unique drones** — 100% of observed off-band captures are ch 6 adjacent-channel drift
- Hopper now spends 100% of cycle time on ASTM-compliant channels (ch 6, plus ch 149 on dual-band nodes)
- Operators wanting the previous sweep can opt in via `WIFI_OFF_CHANNEL_SWEEP=true`
- Net effect on existing v1.2.0+ deployments: ~10% more ch 6 dwell per cycle, no unique drone loss

### CLI improvements

- `migrate_config_env` adds `WIFI_5G_ENABLED`, `WIFI_OFF_CHANNEL_SWEEP`, and catch-up `GPS_BAUD` blocks (idempotent additive merge — existing user values preserved)
- `droneaware status` now requires `sudo` (matches `update` and `test`) — fixes the long-standing silent empty Node ID display caused by `config.env` chmod 600
- `droneaware test` reports per-channel detection counts (ch 6 + ch 149), confirming dual-band reception end-to-end with a "Both bands receiving" line when both produce hits

### Detection robustness

- New `_supported_channels()` helper parses `iw phy` for actually-tunable channels
- Feeder startup logs `Hopper channels: [...]` (reflects reality) and warns if any target channel isn't in the PHY's supported set
- Replaces the stale `Channels: [1..11]` log line — accurate for both 2.4-only and dual-band setups

### CI workflow (`.github/workflows/build.yaml`)

- SHA256 checksums appended to auto-generated release notes via `gh release edit` (lower-barrier verification path than `gh attestation verify`)
- Cosmetic `cortex-a7` → `cortex-a72` cpu label (binaries were already aarch64 via the 64-bit base image)

### Documentation

- `CHANGELOG.md` added at repo root following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. Older versions (v1.0.x – v1.1.3) link to the GitHub Releases page rather than backfilling 28 prior entries.

## Operator notes for v1.2.0 / v1.2.1 → v1.2.2 upgrades

- **2.4-only nodes:** scanning shifts from `[6 → 1 → 11 → 6]` sweep to constant ch 6 dwell. To preserve previous behavior, set `WIFI_OFF_CHANNEL_SWEEP=true` in `/opt/droneaware/config.env` after updating.
- **Nodes with dual-band USB adapters (e.g. Panda PAU0B, Alfa AWUS036ACS):** 5 GHz scanning enables automatically. No manual configuration required.

## Validation

Live-validated on a Pi 4 with a Panda PAU0B AC600 (MT7610U) plugged in:

- ✅ `_adapter_supports_5g()` correctly identifies the PAU0B (39 supported channels including ch 149)
- ✅ `DualBandHopper` default cycle: ch 6 (~20 s) → ch 149 (~10 s), zero ch 1 / ch 11 visits across 13 snapshots
- ✅ `DualBandHopper` with canary enabled (`WIFI_OFF_CHANNEL_SWEEP=true`): ch 6 → ch 1 → ch 11 → ch 149 confirmed
- ✅ `AdaptiveChannelHopper` compliant-only mode: 100% dwell on ch 6, peek list empty in startup log
- ✅ Migration blocks idempotent across synthetic v1.1.x, v1.2.0, and v1.2.1 configs (single backup file per run, no duplicate fields)
- ✅ Per-channel test breakdown logic validated against fake ring buffer (mixed test_id + real drone events filter correctly)
