### PR TITLE
v1.2.2.1: fix droneaware test per-channel breakdown parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,22 @@ Full release artifacts and discussion notes live at the
 
 ---
 
-## [1.2.2] — Unreleased
+## [1.2.2.1] — 2026-06-01
+
+### Fixed
+- **`droneaware test` per-channel detection breakdown** — the local check
+  introduced in v1.2.2 read the wrong fields when parsing
+  `/run/droneaware/detections.jsonl`. It expected a nested
+  `decoded.uas_id`, but `LocalPublisher` writes a flat `id` field at the
+  top level of each event. Result: tests were always reported as "No
+  local detection found yet" even when 78+ events were sitting in the
+  ring buffer. Fixed to read `e.get("id")` directly. End-to-end
+  validation on a PAU0B AC600 with v1.2.2.1 shows the breakdown now
+  correctly counts ch 6 and ch 149 captures.
+
+---
+
+## [1.2.2] — 2026-06-01
 
 ### Added
 - **5 GHz Wi-Fi RID scanning for dual-band adapters.** New `DualBandHopper` runs a

--- a/droneaware
+++ b/droneaware
@@ -530,8 +530,9 @@ try:
                 e = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            decoded = e.get("decoded") or {}
-            if decoded.get("uas_id") != test_id:
+            # LocalPublisher flattens the decoded sub-message into top-level
+            # keys: 'id' holds uas_id (only present for Basic ID events).
+            if e.get("id") != test_id:
                 continue
             total += 1
             ch = e.get("channel")


### PR DESCRIPTION
## Summary

One-line hotfix for v1.2.2's local-detection check in `droneaware test`.

The per-channel breakdown introduced in v1.2.2 read the wrong field path when parsing `/run/droneaware/detections.jsonl` - it expected nested `decoded.uas_id`, but `LocalPublisher` writes a **flat** `id` field at the top level. Result: every test run reported "No local detection found yet — the server may still be processing" even when the ring buffer was full of test events.

The old v1.2.1 `grep -q "$test_id"` check happened to work because grep is structure-blind; it just matched the literal `TESTFA…` string anywhere on the line. It never read `LocalPublisher.publish()` when wiring up the new parser, which was the bug.

## The fix

Single semantic change in `cmd_test`:

```diff
-            decoded = e.get("decoded") or {}
-            if decoded.get("uas_id") != test_id:
+            if e.get("id") != test_id:
                 continue
```

## Validation (bonus: closes the v1.2.2 5 GHz reception gap)

Verified against actual ring-buffer data from a test transmission on the PAU0B AC600 dual-band adapter:

```
54 events on "channel":6   (2.4 GHz path)
24 events on "channel":149 (5 GHz path)
```

Ratio (~69% / 31%) matches the locked hopper design almost exactly (expected ~67% / 33% based on 20 s ch 6 + 10 s ch 149 dwell). **This is the missing end-to-end validation we couldn't get during the v1.2.2 release** — the dual-band radio path is now confirmed to actually transmit AND receive on both bands, not just cycle through them.

## What's in this PR

- `droneaware` — 2 lines changed in the cmd_test local-check parser
- `CHANGELOG.md` — v1.2.2 dated (2026-06-01), v1.2.2.1 hotfix entry added
