### PR TITLE
v1.2.2.2: fix Wi-Fi Beacon local decoder — strip Message Counter byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.2.2.2] — 2026-06-02
+
+### Fixed
+- **WiFi Beacon local decoder — Message Counter byte was being misread
+  as the message type.** ASTM F3411-22a §5.4.2 places a Message Counter
+  byte between the Vendor Type and the ODID message in Wi-Fi Beacon and
+  NAN transports. The node's local decoder was reading `raw_bytes[0]`
+  directly as the message-type header, which means for any real-world
+  Wi-Fi Beacon broadcast that included a counter, the counter byte's
+  high nibble was being labeled as the message type (e.g., counter
+  `0xB7` → "Unknown(0xB)"; `0x27` → "Authentication"). All position /
+  ID fields came back null because the field parsers were reading from
+  the wrong byte offsets.
+- The fix mirrors the server's defensive shim in `api.py`: when the
+  payload's byte 0 is non-Fx AND byte 1 is Fx (Message Pack header),
+  strip the counter for local field extraction. `raw_hex` preserves the
+  original wire bytes, so the payload forwarded to the server is
+  unchanged. Server has its own identical shim and was always decoding
+  correctly — this was strictly a local-decoder bug invisible from
+  server-side data.
+- Surfaced by `@iaincaradoc` on 2026-06-02 when his `nc -luk 9999`
+  capture of a Mavic 4 Pro showed only `Authentication` and
+  `Unknown(0x6)` / `Unknown(0xB)` events with null fields, while the
+  server had the same drone's standard ASTM messages fully decoded.
+
+### Notes on scope
+- **BLE local decoder is unaffected.** `extract_rid_payload` in
+  `ble_feeder.py` already strips the BLE counter (App Code + counter
+  byte) at extraction time, so the BLE decoder operates on clean ODID
+  bytes and never had this bug.
+- **WiFi-NAN frames are forwarded to the server without local decoding**
+  (`decoded=None`). That's a pre-existing feature gap, not a regression
+  — NAN never produced local UDP/ring-buffer output. Local NAN
+  decoding is tracked separately for v1.3.0.
+- **No wire-format change.** The `payload_hex` sent to `/api/ingest` is
+  byte-identical to v1.2.2.1. Existing server data and `gh attestation
+  verify` workflows are unaffected.
+
+---
+
 ## [1.2.2.1] — 2026-06-01
 
 ### Fixed

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -242,22 +242,42 @@ def parse_message_pack(data: bytes) -> list:
     return messages
 
 
-def decode_rid_message(raw_bytes: bytes) -> dict | None:
+def decode_rid_message(raw_bytes: bytes, radio: str | None = None) -> dict | None:
     if len(raw_bytes) < 2:
         return None
-    msg_type  = (raw_bytes[0] >> 4) & 0x0F
+
+    # WiFi-specific Message Counter shim — mirrors the server's defensive
+    # decoder in api.py. ASTM F3411-22a §5.4.2 places a Message Counter byte
+    # between the Vendor Type and the ODID message in Wi-Fi Beacon and NAN
+    # transports. When a Message Pack is preceded by a counter, byte 0 is
+    # the counter (high-nibble != 0xF) and byte 1 is the pack header
+    # (high-nibble == 0xF). Strip the counter for local field extraction
+    # only — `raw_hex` preserves the original wire bytes so the payload
+    # forwarded to the server is unchanged (server has its own identical
+    # shim, will strip on its end).
+    #
+    # Limitation (same as server): a single message preceded by a counter
+    # is ambiguous from bytes alone and is not detected.
+    decode_bytes = raw_bytes
+    if (radio in ("wifi_beacon", "wifi_nan") and len(raw_bytes) > 1
+            and (raw_bytes[0] >> 4) & 0xF != 0xF
+            and (raw_bytes[1] >> 4) & 0xF == 0xF):
+        decode_bytes = raw_bytes[1:]
+
+    msg_type  = (decode_bytes[0] >> 4) & 0x0F
     type_name = MSG_TYPE.get(msg_type, f"Unknown(0x{msg_type:X})")
     result    = {"message_type": type_name, "raw_hex": raw_bytes.hex().upper()}
     if msg_type == 0x0:
-        result.update(parse_basic_id(raw_bytes))
+        result.update(parse_basic_id(decode_bytes))
     elif msg_type == 0x1:
-        result.update(parse_location(raw_bytes))
+        result.update(parse_location(decode_bytes))
     elif msg_type == 0x4:
-        result.update(parse_system_msg(raw_bytes))
+        result.update(parse_system_msg(decode_bytes))
     elif msg_type == 0x5:
-        result.update(parse_operator_id(raw_bytes))
+        result.update(parse_operator_id(decode_bytes))
     elif msg_type == 0xF:
-        sub_msgs = parse_message_pack(raw_bytes)
+        sub_msgs = parse_message_pack(decode_bytes)
+        # Sub-messages never carry their own counter — pass no radio.
         result["messages"] = [m for m in (decode_rid_message(s) for s in sub_msgs) if m]
     return result
 
@@ -1239,7 +1259,7 @@ class WiFiFeeder:
             if rid_payload is None:
                 return
 
-            decoded = decode_rid_message(rid_payload)
+            decoded = decode_rid_message(rid_payload, radio="wifi_beacon")
             if decoded is None:
                 return
 


### PR DESCRIPTION
## Summary

Fix the node's local Wi-Fi Beacon decoder to strip the ASTM F3411-22a Message Counter byte before reading the message-type header. Previously the counter byte's high nibble was being read as the msg_type, producing wrong labels (e.g., `Unknown(0xB)`, `Authentication`) and null position/ID fields for every real-world Wi-Fi RID broadcast.

**Server-side data was always correct** — the server has an independent decoder with the same shim. This bug was strictly local: it affected `/run/droneaware/detections.jsonl` and `nc -luk 9999` consumers, never the canonical server data. The wire payload sent to `/api/ingest` is byte-identical to v1.2.2.1.

## Root cause

ASTM F3411-22a §5.4.2 places a Message Counter byte between the Vendor Type and the ODID message in Wi-Fi Beacon and NAN transports. The node decoder was reading `raw_bytes[0]` directly:

```python
msg_type = (raw_bytes[0] >> 4) & 0x0F   # was reading the COUNTER, not the msg_type
```

For real DJI broadcasts:
- Counter `0xB7` → labeled `Unknown(0xB)` (high nibble = 0xB)
- Counter `0x27` → labeled `Authentication` (high nibble = 0x2)
- Counter `0x67` → labeled `Unknown(0x6)` (high nibble = 0x6)
- Field parsers then read from offset 0 instead of offset 1, producing null/garbage fields

## The fix

Mirror the server's existing defensive shim:

```python
# When byte 0 is non-Fx and byte 1 is Fx (Message Pack header),
# strip the counter for local field extraction only.
decode_bytes = raw_bytes
if (radio in ("wifi_beacon", "wifi_nan") and len(raw_bytes) > 1
        and (raw_bytes[0] >> 4) & 0xF != 0xF
        and (raw_bytes[1] >> 4) & 0xF == 0xF):
    decode_bytes = raw_bytes[1:]
```

`raw_hex` continues to preserve the original wire bytes (with counter), so the payload field forwarded to the server is unchanged. The server has its own identical shim that handles its end.

## Verified scenarios

| Payload shape | Shim fires? | Outcome |
|---|---|---|
| Real DJI: counter `0xB7` + `0xF2` pack header + sub-messages | ✅ Yes | Decoded as Message Pack; Basic ID, Location, System all populated correctly |
| `cmd_test` transmission: `0xF0` pack header (no counter) | ❌ No (byte 0 is Fx) | Decoded as Message Pack correctly — `droneaware test` unchanged |
| DJI single message: `0x00` (Basic ID, no counter) | ❌ No (byte 1 not Fx) | Decoded as Basic ID with correct uas_id |
| `raw_hex` field | — | Real beacon `raw_hex` still starts with counter byte — server wire format unchanged |

## Scope — what's NOT in this PR

- **BLE local decoder is unaffected.** `ble_feeder.extract_rid_payload` already strips the BLE counter (App Code + counter byte) at extraction time, so the BLE decoder operates on clean ODID bytes and never had this bug. No change.
- **WiFi-NAN frames** are forwarded undecoded (`decoded=None`) — pre-existing feature gap, not a regression. NAN events have never produced local UDP/ring-buffer output. Local NAN decoding is tracked separately for v1.3.0.
- **No wire-format change.** `payload_hex` sent to `/api/ingest` is byte-identical to v1.2.2.1.

## Surfaced by

`@iaincaradoc` on 2026-06-02. His `nc -luk 9999` capture of a Mavic 4 Pro showed only `Authentication` and `Unknown(0x6)` / `Unknown(0xB)` events with null fields, while the server had the same drone's standard ASTM messages fully decoded. The discrepancy is what made us look at the parallel decoder paths and find the missing counter-byte shim.
