### PR TITLE
v1.3.0.1: gate GPS GPIO fallback on NODE_MOBILE=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,36 @@ Full release artifacts and discussion notes live at the
 
 ---
 
-## [1.3.0] — Unreleased
+## [1.3.0.1] — Unreleased
+
+Hotfix for a v1.3.0 regression in GPS auto-discovery. Two operators on
+static nodes (NJ007 + JeGoBE8900, the latter on non-Pi x86_64 Debian)
+hit persistent log noise from the new A.3 GPIO fallback path: `/dev/serial0`
+exists on every Pi by default as the onboard UART symlink, so v1.3.0's
+unconditional GPIO probing surfaced it as a "GPS candidate" on nodes
+without any GPS hardware. The reader thread then either failed baud
+detection (quiet 10s retries) or hit kernel `Input/output error` on
+non-Pi `/dev/serial0` paths (loud 10s WARNING spam) — neither suppressible
+operator-side in v1.3.0.
+
+### Fixed
+- **GPS GPIO fallback now gated on `NODE_MOBILE=true`.** `find_gps_device()`
+  unchanged for the manual-override case (`GPS_DEVICE` env var still wins
+  always) and the USB-present case (still probed on every node — operator
+  plugged something in, we honor it). Only the GPIO/UART path list
+  (`/dev/serial0`, `/dev/ttyAMA0`, `/dev/ttyS0`) is now gated. Static nodes
+  with no GPS hardware go back to the pre-v1.3.0 behavior: silent
+  "GPS: not configured", no probing, no log noise. Mobile nodes (GPIO
+  NEO-6M builds — the Kbrooks use case) still get GPIO auto-discovery
+  as in v1.3.0. Operators with exotic configurations (static + GPS for
+  time sync) can still force a device path via `GPS_DEVICE`.
+
+  Reported as GitHub issue by @JeGoBE8900 on 2026-06-14. Also surfaced
+  on NJ007 (static node, droneaware-node-3) 2026-06-12.
+
+---
+
+## [1.3.0] — 2026-06-11
 
 Reliability + Observability milestone. Scope intentionally narrowed from the
 original "multi-radio" plan (which moved to v1.5.0) to focus on improvements

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -1201,27 +1201,47 @@ def find_gps_device() -> str | None:
     """Locate a GPS serial device, in priority order:
       1. GPS_DEVICE env var if set (always wins, even if path doesn't exist —
          the reader thread surfaces "device_missing" via the state file in
-         that case)
-      2. USB serial dongles: /dev/ttyUSB* (FTDI etc.) and /dev/ttyACM* (CDC)
+         that case). This is the manual-override escape hatch for any
+         configuration the auto-discovery doesn't cover.
+      2. USB serial dongles: /dev/ttyUSB* (FTDI etc.) and /dev/ttyACM* (CDC).
+         Probed for every node regardless of mobile/static — the operator
+         plugged something in, we honor it.
       3. GPIO / on-board UART paths: /dev/serial0 (Pi 3+/4/5 default mini
          UART), /dev/ttyAMA0 (PL011 — Pi 1/2/Zero or swapped-bt configs),
-         /dev/ttyS0 (mini UART direct fallback)
+         /dev/ttyS0 (mini UART direct fallback). ONLY probed when
+         NODE_MOBILE=true — see below.
 
-    USB-first preserves the existing behavior for nodes with a USB GPS dongle
-    present. GPIO fallbacks only get picked up when no USB GPS is found —
-    handles the Kbrooks-style mobile-unit build with NEO-6M wired to the Pi's
-    GPIO header instead of USB.
+    Why GPIO fallback is gated on NODE_MOBILE=true (v1.3.0.1 fix):
+        /dev/serial0 exists on every Pi by default as a symlink to the
+        onboard UART, regardless of whether GPS hardware is wired to the
+        GPIO header. On static nodes (NODE_MOBILE=false), the operator
+        already provided lat/lon at install time and doesn't need GPS —
+        but v1.3.0's unconditional GPIO probing surfaced /dev/serial0 as
+        a "GPS candidate," then failed baud detection (or hit kernel I/O
+        errors on non-Pi /dev/serial0 paths) and spammed warnings every
+        10 seconds. Static nodes with no GPS hardware now skip the GPIO
+        probe entirely. Mobile nodes still get the GPIO auto-discovery
+        path for GPIO-wired NEO-6M builds. Operators with exotic setups
+        (static + GPS for time sync) can still force a device via the
+        GPS_DEVICE env var.
     """
     env_device = os.environ.get("GPS_DEVICE", "").strip()
     if env_device:
         return env_device
-    candidates = (
-        glob.glob('/dev/ttyUSB*') +
-        glob.glob('/dev/ttyACM*') +
-        ['/dev/serial0', '/dev/ttyAMA0', '/dev/ttyS0']
-    )
-    candidates = [c for c in candidates if os.path.exists(c)]
-    return candidates[0] if candidates else None
+
+    # USB paths — probed for every node.
+    usb_candidates = glob.glob('/dev/ttyUSB*') + glob.glob('/dev/ttyACM*')
+    usb_candidates = [c for c in usb_candidates if os.path.exists(c)]
+    if usb_candidates:
+        return usb_candidates[0]
+
+    # GPIO/UART paths — only for mobile nodes (see docstring).
+    mobile = os.environ.get("NODE_MOBILE", "false").strip().lower() == "true"
+    if not mobile:
+        return None
+    gpio_candidates = ['/dev/serial0', '/dev/ttyAMA0', '/dev/ttyS0']
+    gpio_candidates = [c for c in gpio_candidates if os.path.exists(c)]
+    return gpio_candidates[0] if gpio_candidates else None
 
 
 def _nmea_checksum_valid(sentence: str) -> bool:


### PR DESCRIPTION
## Summary

Hotfix for a v1.3.0 regression in GPS auto-discovery (A.3).

v1.3.0 added GPIO/UART path fallbacks to `find_gps_device()` to support
GPIO-wired NEO-6M modules on mobile nodes. The problem: `/dev/serial0`
is a default symlink on every Raspberry Pi pointing to the onboard
UART. Its existence isn't a positive signal that GPS hardware is
attached. Operators on static nodes without GPS now get the reader
thread starting, baud detection failing, and persistent log noise
every 10 seconds.

Worse on non-Pi systems where `/dev/serial0` exists as a symlink to
something that's not a usable serial device: `serial.Serial()` returns
a kernel `Input/output error`, producing loud WARNING-level log spam.

## Two confirmed reports

- **NJ007** (static node, dev Pi `droneaware-node-3`) 2026-06-12 —
  silent "device exists but no valid NMEA detected" status line every
  10 seconds.
- **@JeGoBE8900** (static, non-Pi Debian x86_64, GitHub issue
  2026-06-14) — WARNING spam `Could not configure port: Input/output
  error — retrying in 10s` every 10 seconds.

No operator-side workaround exists in v1.3.0 — there is no
"disable GPS" knob, `GPS_DEVICE=` empty falls back to A.3 auto-discovery,
`GPS_DEVICE=/dev/null` fails to open as a tty, `GPS_DEVICE=/dev/nonexistent`
surfaces "device_missing" warnings on its own retry loop. The reader
thread has no way to NOT start. Hence the hotfix.

## Fix

`find_gps_device()` priority order is unchanged except for the GPIO step:

1. `GPS_DEVICE` env var if set (always wins — manual escape hatch)
2. USB paths (`/dev/ttyUSB*`, `/dev/ttyACM*`) — probed for every node
3. GPIO/UART paths — **ONLY probed when `NODE_MOBILE=true`** (the fix)

Static nodes with no GPS hardware go back to the pre-v1.3.0 behavior:
silent "GPS: not configured", no probing, no log noise. Mobile nodes
still get full GPIO auto-discovery as in v1.3.0 (the Kbrooks NEO-6M
use case). Anyone with an exotic configuration (e.g., static node
wanting GPS for time sync) can still force a device path via
`GPS_DEVICE`.

## What stays unchanged

- The A.3 USB-first auto-discovery for mobile nodes
- The Kbrooks-style GPIO NEO-6M mobile-unit build path
- The eight GPS state cases in `sudo droneaware status`
- Wire format, heartbeat schema, all other v1.3.0 behavior

## Validation

Tested against four scenarios on the dev Pi:

| Scenario | Result |
|---|---|
| Static + USB GPS present | `/dev/ttyUSB0` (unchanged from v1.3.0) |
| Static + no USB | `None` (**FIXED** — was `/dev/serial0` in v1.3.0) |
| Mobile + no USB | `/dev/serial0` (unchanged from v1.3.0) |
| Any + `GPS_DEVICE` override | env value (unchanged from v1.3.0) |

`NODE_MOBILE` parsing is case-insensitive + whitespace-tolerant
(`TRUE`, `True`, `"  true  "` all parse correctly to True), matching
the existing env-var read style elsewhere in the codebase.