### PR TITLE
v1.3.0.2: fix false 'state stale' status for not_configured GPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,40 @@ Full release artifacts and discussion notes live at the
 
 ---
 
-## [1.3.0.1] — Unreleased
+## [1.3.0.2] — Unreleased
+
+Follow-up hotfix to v1.3.0.1 — addresses a secondary UX bug that v1.3.0.1's
+fix exposed by making the `not_configured` GPS state much more common on
+static nodes.
+
+### Fixed
+- **`droneaware status` no longer falsely reports "state stale" for
+  not-configured GPS.** v1.3.0.2 reorders the GPS state-file check in
+  `cmd_status` so `not_configured` is handled BEFORE the 120-second
+  staleness check. Pre-v1.3.0.2, after a static node had been running for
+  2+ minutes without GPS hardware, `sudo droneaware status` showed
+  "GPS: state stale (Ns old — wifi_feeder may have stopped)" — misleading
+  because wifi_feeder was running fine; the state file simply isn't
+  refreshed when no reader thread exists.
+
+  The staleness check was originally written (in A.2 / v1.3.0) assuming
+  the state file would always be refreshed by an active reader thread
+  every NMEA cycle. v1.3.0.1's GPIO-gating made `not_configured` a
+  legitimate terminal state where the file is written exactly once at
+  service startup — exposing this assumption gap.
+
+  Active GPS states (`fix`, `reading`, `detecting_baud`, `no_nmea`,
+  `device_missing`) still trip the staleness warning if their reader
+  thread genuinely dies — that signal is preserved. Only `not_configured`
+  is exempt because by definition it has no reader thread.
+
+  Validated on NJ007 (droneaware-node-3) during the v1.3.0.1 post-update
+  check: confirmed staleness warning fires after ~4 minutes pre-v1.3.0.2,
+  not at all post-v1.3.0.2.
+
+---
+
+## [1.3.0.1] — 2026-06-16
 
 Hotfix for a v1.3.0 regression in GPS auto-discovery. Two operators on
 static nodes (NJ007 + JeGoBE8900, the latter on non-Pi x86_64 Debian)

--- a/droneaware
+++ b/droneaware
@@ -294,10 +294,17 @@ lon        = s.get("lon")
 updated_at = s.get("updated_at") or 0
 age        = time.time() - updated_at
 
-if age > 120:
-    print(f"  GPS      : state stale ({int(age)}s old — wifi_feeder may have stopped)")
-elif status == "not_configured":
+if status == "not_configured":
+    # Terminal state — wifi_feeder writes this once at startup (when
+    # find_gps_device returns None) and never refreshes it, because
+    # no reader thread is running to write NMEA cycles. The staleness
+    # check below DOES NOT apply — the file being old is expected and
+    # correct, not a sign that wifi_feeder stopped. (v1.3.0.2 fix:
+    # v1.3.0.1's GPIO-gating made this state common on static nodes,
+    # which then tripped the staleness warning incorrectly after 2 min.)
     print("  GPS      : not configured")
+elif age > 120:
+    print(f"  GPS      : state stale ({int(age)}s old — wifi_feeder may have stopped)")
 elif status == "device_missing":
     print(f"  GPS      : {device} — configured but device not present")
 elif status == "detecting_baud":


### PR DESCRIPTION
## Summary

Follow-up hotfix to v1.3.0.1. The GPIO-gating fix correctly stopped
static nodes from probing `/dev/serial0`, but exposed a latent UX bug
in `sudo droneaware status` that wasn't visible before because
`not_configured` was rarely a sustained terminal state pre-v1.3.0.1.

## The bug

`cmd_status` reads `/run/droneaware/gps_state.json` and applies a
120-second staleness check before rendering status-specific output.
The check was originally written assuming an active `gps_reader_thread`
refreshes the file every NMEA cycle — so a stale file meant the thread
had died.

On static nodes post-v1.3.0.1, `main()` writes the file ONCE at startup
with `status="not_configured"` and never starts a reader thread. After
120 seconds the staleness check fires, and operators see:

```
GPS      : state stale (Ns old — wifi_feeder may have stopped)
```

— which is misleading because `wifi_feeder` is running fine.

## The fix

Three-line reorder in the `cmd_status` python block — handle
`status == "not_configured"` BEFORE the `age > 120` check. The
not-configured state file being old is expected and correct, not a
sign of trouble.

## What stays unchanged

Active GPS states (`fix`, `reading`, `detecting_baud`, `no_nmea`,
`device_missing`) all still trip the staleness warning if their reader
thread genuinely dies. That signal is preserved — it's a real
diagnostic. Only `not_configured` is exempt because by definition it
has no reader thread maintaining the file.

## Validation

Tested via 7 synthetic state-file scenarios (in-memory, not against
the live `/run/droneaware/gps_state.json` to avoid race with the
running wifi_feeder service):

| Scenario | Expected | Actual |
|---|---|---|
| `not_configured` fresh | "GPS: not configured" | ✓ |
| **`not_configured` stale (300s)** | **"GPS: not configured"** (the fix) | ✓ |
| `fix` fresh | "GPS: fix acquired ..." | ✓ |
| `fix` stale (300s) | "GPS: state stale (300s old)" | ✓ |
| `reading` stale (300s) | "GPS: state stale" | ✓ |
| `no_nmea` stale (300s) | "GPS: state stale" | ✓ |
| `device_missing` stale (300s) | "GPS: state stale" | ✓ |

Surfaced live on NJ007 (droneaware-node-3) immediately after
v1.3.0.1 was deployed on 2026-06-16: post-update check showed
"GPS: state stale (255s old)" 4+ minutes after restart, confirming
the bug.