### PR TITLE
v1.4.2: three follow-up fixes (render perf, .ver stamping, install-webui migrate)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,7 @@ jobs:
           commands: |
             apt-get update
             apt-get install -y python3 python3-pip python3-venv
+            export VERSION="${{ inputs.version }}"
             bash ./build.sh
       - uses: actions/upload-artifact@v7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/
 # Build environment
 .build_venv/
 
+# CI-stamped version file (written by build.sh, embedded in web_ui binary)
+web_static/.ver
+
 # Python
 __pycache__/
 *.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,66 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.2] — Unreleased
+
+Three small follow-ups to v1.4.0/v1.4.1, all surfaced during NJ007
+field deployment. One is a render-perf fix (operator-visible), two
+are quality-of-life cleanups for operator config + build telemetry.
+No new features, no schema changes, no breaking changes.
+
+### Fixed
+
+- **Web UI no longer lags at close zoom.** The Local Web UI's
+  10 concentric distance rings around home are drawn as Leaflet vector
+  overlays. At street-level zoom (>~14), the 10-mile ring is ~27,000
+  pixels across — most of it off-screen, but the default SVG renderer
+  keeps the full path in the DOM and re-projects it on every pan.
+  Measured: 329 ms of browser Presentation delay per pointer event
+  (Chrome DevTools INP) at the affected zoom range. Two changes:
+  - Switch Leaflet to the Canvas renderer (`preferCanvas: true` on
+    the map). Canvas culls off-screen vector geometry far more
+    aggressively than SVG. Also benefits the dashed
+    operator→drone connectors and the flight-path polyline when
+    toggled on. HTML divIcon markers (drone, operator H, home
+    pulse) are unaffected — they're DOM elements, not overlays.
+  - Hide `state.homeLayer` (rings + ring labels + home pulse marker)
+    when zoom > 14. At street-level zoom the rings provide no useful
+    range context anyway. Layer membership is preserved, so panning
+    or zooming back out restores everything instantly.
+
+- **`web_ui` now self-reports the correct firmware version.** The
+  binary's `_read_fw_version()` was looking for a `.ver` file
+  embedded by CI at build time, but `build.sh` never wrote that
+  file — so every release fell through to the hardcoded fallback
+  string in `web_ui.py`. As a result, both v1.4.0 and v1.4.1 self-
+  reported as `v1.4.0` in `/api/status.version` and the UI footer,
+  even though the actual content was correct. `build.sh` now writes
+  `web_static/.ver` from the `VERSION` env var (passed in by
+  `.github/workflows/build.yaml` from `inputs.version`) before the
+  web_ui PyInstaller call. PyInstaller's existing `--add-data`
+  picks it up automatically; no Python changes needed. `.gitignore`
+  updated to skip the build artifact. (Note: this fixes the version
+  string display going forward — installed v1.4.0/v1.4.1 binaries
+  will continue to misreport. `sudo droneaware status` was always
+  correct on those nodes — it reads `/opt/droneaware/version`, not
+  the binary's embedded value.)
+
+- **`sudo droneaware install-webui` now adds every release-level
+  config.env key**, not just the two Web-UI-specific ones. The
+  post-install opt-in path previously wrote only
+  `DRONEAWARE_LOCAL_BUFFER_MAX_BYTES` and `DRONEAWARE_WEB_PORT`
+  directly, skipping `migrate_config_env`. Operators who landed on
+  the Web UI via `install-webui` (rather than via the regular
+  `droneaware update` flow) missed `DRONEAWARE_LOCAL_UDP_TARGETS` and
+  its comment block. Functionally nothing was broken — the feeders
+  default to broadcasting to `255.255.255.255:9999` when the var is
+  unset — but the key wasn't documented in config.env so operators
+  couldn't discover the override. `cmd_install_webui` now calls
+  `migrate_config_env` at the end of its work (idempotent, harmless
+  if migrate already ran via `cmd_update`).
+
+---
+
 ## [1.4.1] — Unreleased
 
 Local Web UI polish — four UX fixes from initial field testing of

--- a/build.sh
+++ b/build.sh
@@ -84,8 +84,20 @@ echo "      Building wifi_feeder..."
     "$SCRIPT_DIR/wifi_feeder.py" \
     > /dev/null 2>&1
 
-# web_ui — bundles web_static/ (index.html, leaflet.js, leaflet.css) into
-# the binary via --add-data so a single PyInstaller --onefile artifact
+# Stamp the version into web_static/.ver so the web_ui binary
+# self-reports the correct firmware version at runtime. web_ui.py's
+# _read_fw_version() reads this file from sys._MEIPASS. Without this,
+# /api/status.version falls through to the hardcoded fallback in
+# web_ui.py and lies about the build. VERSION is set by the CI workflow
+# (inputs.version, prefixed with "v" by convention); falls back to "dev"
+# for local builds without a version export.
+VERSION="${VERSION:-dev}"
+[[ "$VERSION" =~ ^v ]] || VERSION="v$VERSION"
+echo "$VERSION" > "$SCRIPT_DIR/web_static/.ver"
+echo "      Stamped web_static/.ver with: $VERSION"
+
+# web_ui — bundles web_static/ (index.html, leaflet.js, leaflet.css, .ver)
+# into the binary via --add-data so a single PyInstaller --onefile artifact
 # contains every runtime asset. web_ui.py's _static_root() reads
 # sys._MEIPASS to find the bundled dir at runtime.
 echo "      Building web_ui..."

--- a/droneaware
+++ b/droneaware
@@ -855,6 +855,15 @@ cmd_install_webui() {
         echo "DRONEAWARE_WEB_PORT=5000" >> "${INSTALL_DIR}/config.env"
     fi
 
+    # Run the full release migration so operators who land here via the
+    # post-install opt-in path (not cmd_update) still get every config
+    # key the current release introduces — including
+    # DRONEAWARE_LOCAL_UDP_TARGETS, which is feeder-side, not Web-UI-
+    # specific, and so isn't covered by the two direct writes above.
+    # migrate_config_env is idempotent (every block grep-gated), so the
+    # extra call is harmless when migrate already ran via cmd_update.
+    migrate_config_env
+
     # Restart feeders if needed to pick up the buffer bump, then start
     # the Web UI immediately (this is the post-install path — operator
     # has a running node, no reason to force a reboot).

--- a/web_static/index.html
+++ b/web_static/index.html
@@ -860,16 +860,43 @@
       }).addTo(state.map);
     }
 
+    // Above this zoom level, the distance rings + labels are hidden from
+    // the map. At street-level zoom (z > 14) the closest ring is the size
+    // of the viewport and the 10-mile ring is ~27,000 pixels across —
+    // expensive for the renderer to keep around (measured 329ms of
+    // Presentation delay per pointer event before this fix) and useless
+    // as range context for the operator. Threshold picked empirically;
+    // tune downward if low-end clients still struggle at z=14.
+    const HOME_LAYER_HIDE_ZOOM = 14;
+
     function initMap() {
       const m = L.map("map", {
         center: [40.0, -98.0],     // continental US default; recentered on home if available
         zoom: 5,
         zoomControl: true,
         attributionControl: true,
+        // Canvas renderer culls off-screen vector geometry far more
+        // aggressively than SVG. Critical for the 10 large distance
+        // rings and the dashed operator→drone connectors. HTML divIcon
+        // markers (drone, operator H, home pulse) are unaffected —
+        // they're DOM elements, not vector overlays.
+        preferCanvas: true,
       });
       state.map = m;
       state.homeLayer = L.layerGroup().addTo(m);   // holds home marker + rings
       applyMapTheme();
+
+      // Hide the home layer (rings + labels + home marker) at street-level
+      // zoom. Layer membership is preserved so re-attaching restores
+      // everything instantly when the operator zooms back out.
+      m.on("zoomend", () => {
+        const z = m.getZoom();
+        if (z > HOME_LAYER_HIDE_ZOOM) {
+          if (m.hasLayer(state.homeLayer)) m.removeLayer(state.homeLayer);
+        } else {
+          if (!m.hasLayer(state.homeLayer)) state.homeLayer.addTo(m);
+        }
+      });
     }
 
     /* ----- Home location + distance rings ----- */


### PR DESCRIPTION
## Summary

Three small follow-up fixes from NJ007 field deployment of v1.4.0 / v1.4.1. One operator-visible (render perf), two cleanups (build telemetry, config-key discoverability).

### 1. Web UI render lag at close zoom

The 10 distance rings around home are drawn as Leaflet vector overlays. At street-level zoom (z > ~14), the 10-mile ring is ~27,000 pixels across — most off-screen, but the default SVG renderer keeps the full path in the DOM and re-projects it on every pan event. Chrome DevTools measurement: **329 ms of Presentation delay per pointer event** (vs 2 ms of JS Processing duration — confirming the bottleneck is browser paint, not Leaflet).

Two changes in `web_static/index.html`:
- `preferCanvas: true` on `L.map()` — Canvas culls off-screen vector geometry far better than SVG. Also benefits the dashed operator→drone connectors and the flight-path polyline. HTML divIcon markers (drone, operator H, home pulse) are unaffected.
- Hide `state.homeLayer` when zoom > 14. Layer membership preserved, so panning/zooming back out restores everything instantly.

### 2. `.ver` stamping in build.sh (web_ui self-reports correct version)

`web_ui.py:_read_fw_version()` reads a `.ver` file from `sys._MEIPASS` that CI was supposed to write at build time. `build.sh` never wrote it, so every release fell through to the hardcoded fallback. Both v1.4.0 and v1.4.1 self-reported as `v1.4.0` in `/api/status.version` and the UI footer.

- `build.sh` writes `web_static/.ver` from the `VERSION` env var before the web_ui PyInstaller call. The existing `--add-data web_static:web_static` picks it up automatically — no Python changes needed.
- `.github/workflows/build.yaml` exports `VERSION="${{ inputs.version }}"` into the chroot env.
- `.gitignore` skips the build artifact so local runs don't dirty the working tree.

This fixes display going forward; installed v1.4.0 / v1.4.1 binaries will continue to misreport their version. `sudo droneaware status` was always correct on those nodes — it reads `/opt/droneaware/version`, not the embedded value.

### 3. `install-webui` calls `migrate_config_env`

`cmd_install_webui` previously wrote only `DRONEAWARE_LOCAL_BUFFER_MAX_BYTES` and `DRONEAWARE_WEB_PORT`. Operators arriving via the post-install opt-in path (rather than `cmd_update`) missed `DRONEAWARE_LOCAL_UDP_TARGETS` and its comment block. Functionally harmless (feeders default to broadcasting), but poor discoverability. Now calls `migrate_config_env` at the end of its work — idempotent, harmless when migrate already ran via `cmd_update`.

No new features, no schema changes, no breaking changes.