### PR TITLE
v1.4.3: path fix for web_ui version self-reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.3] — Unreleased
+
+One-line follow-up to v1.4.2's `.ver` stamping work. The v1.4.2 build
+correctly wrote `web_static/.ver` and PyInstaller correctly bundled it
+into the binary at `_MEIPASS/web_static/.ver` — but `_read_fw_version()`
+in `web_ui.py` was looking for the file at `_MEIPASS/.ver` (bundle
+root), not under `web_static/`. So the v1.4.2 binary embedded the
+right version string but couldn't find it at runtime, fell through to
+the hardcoded fallback in `web_ui.py:84`, and continued to misreport
+as `1.4.0`. Verified via `find /tmp -name .ver` on a v1.4.2 install —
+the file was present with the correct value.
+
+### Fixed
+
+- **`web_ui` now actually self-reports the correct version.** Path
+  fix in `_read_fw_version()` — append `web_static/` so the lookup
+  matches the location PyInstaller bundles the file. Single-line
+  Python change. `build.sh`, `.gitignore`, and the workflow's
+  `VERSION` export are unchanged from v1.4.2; they were correct, the
+  Python lookup was the missing piece.
+
+---
+
 ## [1.4.2] — Unreleased
 
 Three small follow-ups to v1.4.0/v1.4.1, all surfaced during NJ007

--- a/web_ui.py
+++ b/web_ui.py
@@ -69,11 +69,16 @@ from flask import Flask, Response, jsonify, request
 # ---- Version stamping (CI overwrites .ver file at build time) ---------------
 
 def _read_fw_version(fallback: str) -> str:
-    """Read embedded version file (written by CI build). Falls back to dev
-    value when running from source."""
+    """Read embedded version file (written by build.sh into web_static/
+    before the PyInstaller --add-data call). Falls back to dev value
+    when running from source without a stamped .ver. The file lives
+    inside web_static/ because that's the directory PyInstaller bundles
+    via --add-data web_static:web_static — at runtime it resolves to
+    _MEIPASS/web_static/.ver."""
     try:
         ver_path = os.path.join(
-            getattr(sys, "_MEIPASS", os.path.dirname(__file__)), ".ver",
+            getattr(sys, "_MEIPASS", os.path.dirname(__file__)),
+            "web_static", ".ver",
         )
         with open(ver_path) as f:
             return f.read().strip()


### PR DESCRIPTION
## Summary

One-line follow-up to v1.4.2's `.ver` stamping. The v1.4.2 build correctly wrote `web_static/.ver` and PyInstaller correctly bundled it at `_MEIPASS/web_static/.ver` — but `_read_fw_version()` in `web_ui.py` was looking at `_MEIPASS/.ver` (bundle root). Lookup failed, fell through to the hardcoded fallback string, and the v1.4.2 binary continued to misreport as `1.4.0`.

**Verified on NJ007 v1.4.2 install:**
```
/tmp/_MEIiLi9HE/web_static/.ver  →  contents: v1.4.2
```

The file is present in the binary with the correct content — only the Python path lookup was wrong.

## Fix

Single-line change in `_read_fw_version()` — append `"web_static"` to `os.path.join(...)` so the lookup matches where PyInstaller actually bundles the file.

`build.sh`, `.gitignore`, and `.github/workflows/build.yaml`'s `VERSION` export are unchanged from v1.4.2 — they were already correct.