### PR TITLE
v1.4.4: install.sh runs droneaware __migrate (fresh-install config-key gap fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.4] — Unreleased
+
+Closes the install.sh side of the same config-key drift bug that v1.4.2
+fixed for the install-webui path. Also the **first non-pre-release in
+the v1.4.x line** — operators on v1.3.0.2 will get all of v1.4.x's
+work (Local Web UI, API, UDP target configurability, UX polish, render
+perf, version display fixes, and now the config-key fix) in a single
+`sudo droneaware update` hop, skipping the broken-version-display
+prereleases v1.4.0 through v1.4.2 entirely.
+
+### Fixed
+
+- **Fresh installs now get every release config key.** install.sh's
+  `write_config` was a parallel list of "current release keys" that
+  drifted from the canonical list in the droneaware CLI's
+  `migrate_config_env`. Concretely, `DRONEAWARE_LOCAL_UDP_TARGETS`
+  (added late in the v1.4.0 cycle) reached `migrate_config_env` but
+  never reached `write_config`, so brand-new installs missed the key
+  in their config.env. Functionally harmless — feeders default to
+  broadcasting on `255.255.255.255:9999` — but operators couldn't
+  discover the override in their config without reading docs.
+
+  Fix: install.sh runs `/usr/local/bin/droneaware __migrate` after
+  `write_config` completes (new `migrate_config` step in the main
+  flow). `migrate_config_env` is now the single source of truth for
+  release keys; install.sh's `write_config` only writes the minimum
+  bootstrap config. Future release keys added to `migrate_config_env`
+  automatically reach fresh installs without install.sh updates.
+  Failure is non-fatal — every release key has a code-side default.
+
+### What v1.4.4 brings forward (cumulative since v1.3.0.2)
+
+Operators updating directly from v1.3.0.2 → v1.4.4 receive everything
+shipped in the v1.4.x prereleases:
+
+- **v1.4.0:** Local Web UI (Pi-local detection viewer) + HTTP API + configurable LocalPublisher UDP targets
+- **v1.4.1:** Web UI polish — day-mode tile swap, sidebar sort, Detection Details panel stability, opt-in flight paths
+- **v1.4.2:** Web UI close-zoom render perf (Canvas + ring hiding), web_ui version stamping (build side), install-webui config migration
+- **v1.4.3:** web_ui version-file path lookup (Python side)
+- **v1.4.4:** install.sh release-config migration (this release)
+
+See individual prerelease entries below for full per-version detail.
+
+---
+
 ## [1.4.3] — Unreleased
 
 One-line follow-up to v1.4.2's `.ver` stamping work. The v1.4.2 build

--- a/install.sh
+++ b/install.sh
@@ -698,6 +698,27 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# 9.5. Single-source-of-truth release config — let the droneaware CLI's
+# migrate_config_env fill in any keys install.sh's write_config didn't
+# include. Previously install.sh's write_config + the CLI's
+# migrate_config_env were two parallel lists of "current release keys"
+# that could drift; e.g., DRONEAWARE_LOCAL_UDP_TARGETS was added to
+# migrate when shipped in v1.4.0 but never reached write_config, leaving
+# the key absent from fresh-install config.env's until v1.4.4. Now
+# migrate is canonical; write_config only needs the minimum bootstrap.
+# Failure here is non-fatal — every release key has a code-side default.
+# ---------------------------------------------------------------------------
+migrate_config() {
+    if [[ -x /usr/local/bin/droneaware ]]; then
+        if ! /usr/local/bin/droneaware __migrate; then
+            warn "Release config migration encountered issues — install continues. Run 'sudo droneaware __migrate' to retry."
+        fi
+    else
+        warn "droneaware CLI not found at /usr/local/bin/droneaware — skipping release config migration."
+    fi
+}
+
+# ---------------------------------------------------------------------------
 # 10. Enroll node — requires a logged-in DroneAware account
 # ---------------------------------------------------------------------------
 enroll_node() {
@@ -966,6 +987,7 @@ install_packages
 download_binaries
 install_services
 write_config
+migrate_config
 enroll_node
 install_webui
 print_summary


### PR DESCRIPTION
## Summary

Closes the install.sh side of the same config-key drift bug v1.4.2 fixed for the install-webui path. **First non-pre-release in the v1.4.x line** — operators on v1.3.0.2 will jump to v1.4.4 in a single `sudo droneaware update` hop and get all of v1.4.x's work, skipping the broken-version-display prereleases entirely.

## Root cause

install.sh's `write_config` and the droneaware CLI's `migrate_config_env` were parallel lists of "current release keys" that could drift. `DRONEAWARE_LOCAL_UDP_TARGETS` (added late in the v1.4.0 cycle) reached `migrate_config_env` but never reached `write_config`. So brand-new installs on v1.4.0–v1.4.3 missed the key in their config.env.

Verified on njtestnode1404 fresh v1.4.3 install (2026-06-29):
```
$ sudo grep "^DRONEAWARE_" /opt/droneaware/config.env
DRONEAWARE_BUFFER_MAX_BYTES=50000000
DRONEAWARE_BUFFER_WARN_PCT=75
DRONEAWARE_LOCAL_BUFFER_MAX_BYTES=50000000
DRONEAWARE_WEB_PORT=5000
# DRONEAWARE_LOCAL_UDP_TARGETS missing
```

Functionally harmless — feeders default to broadcasting on `255.255.255.255:9999` — but operators couldn't discover the override in their config.

## Fix

install.sh runs `/usr/local/bin/droneaware __migrate` after `write_config` completes. New `migrate_config` step in the main flow, between `write_config` and `enroll_node`. `migrate_config_env` becomes the single source of truth for release keys; `write_config` only writes the minimum bootstrap config. Future release keys added to `migrate_config_env` automatically reach fresh installs without install.sh updates.

Failure is non-fatal — every release key has a code-side default.

## Release-time plan

Ship as **Latest** (no `--prerelease` flag this time). Effects when published:
- `/releases/latest/download/install.sh` flips from v1.3.0.2 → v1.4.4
- Fleet operators running `sudo droneaware update` jump directly v1.3.0.2 → v1.4.4
- v1.4.0 / v1.4.1 / v1.4.2 / v1.4.3 stay as pre-releases on GitHub for historical record but are never picked up by `/releases/latest`