### PR TITLE
v1.4.5: offline-capable Web UI basemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,87 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.5] — Unreleased
+
+Delivers the offline operability the v1.4.0 Local Web UI release
+promised but only half-delivered. v1.4.0 made the Web UI itself work
+without internet to droneaware.io (feeders, sidebar, API, SSE all
+local), but the Leaflet basemap still required the browser to reach
+CartoDB at runtime — air-gapped operators got drone markers floating
+on a blank background. v1.4.5 closes that gap.
+
+### Added
+
+- **Bundled world-overview basemap inside the web_ui binary.** A
+  ~15 MB MBTiles file (`web_static/world-tiles.mbtiles`) covering
+  zoom 0-6 worldwide in CartoDB Dark Matter style ships inside the
+  web_ui PyInstaller binary via the existing `--add-data
+  web_static:web_static`. At those zoom levels the operator sees
+  country boundaries, state outlines, coastlines, and major cities —
+  enough recognizable context to know where drone markers are even
+  with zero internet connectivity from the browser.
+
+- **`/tiles/<z>/<x>/<y>.png` route in web_ui.** Serves the bundled
+  MBTiles content. Queries the SQLite file by tile coordinate (with
+  XYZ→TMS row conversion), returns the PNG bytes with aggressive
+  browser caching (`Cache-Control: max-age=86400, immutable` —
+  tile content is fixed for the life of the release). Returns 404
+  for zoom levels beyond the bundle range or for missing tiles, so
+  Leaflet's tile error handler degrades gracefully.
+
+- **`tiles_local` + `tiles_local_max_zoom` fields in `/api/status`.**
+  Lets the frontend (and any API consumer) know whether the bundled
+  basemap is available on this node and up to what zoom level.
+
+- **Dual-layer Leaflet config with online/offline auto-fallback.**
+  The Web UI's tile source is no longer hardcoded to CartoDB:
+  - Initial source picked by `navigator.onLine` at page load
+  - First `tileerror` event on the CartoDB layer triggers an
+    immediate swap to the bundled local layer — covers the
+    "navigator says online but firewall blocks CartoDB" case
+  - `window.online` / `offline` events keep the source in sync
+    with the browser's network state
+  - Online operators get the full street-level CartoDB experience
+    unchanged; offline operators get the world overview seamlessly
+    without any setup or page refresh
+  - Local layer uses `maxNativeZoom: 6` — Leaflet stretches the
+    zoom-6 tiles for higher zooms so the operator can still zoom
+    into a drone's position; the basemap gets blurry but stays
+    correctly positioned
+
+### Architecture notes
+
+- **No new dependencies.** `sqlite3` is in the Python standard
+  library; MBTiles is just a SQLite file with a specific schema.
+- **No operator action required.** Operators upgrade via
+  `sudo droneaware update`; the bundled MBTiles ships with the new
+  web_ui binary automatically. Existing Web UI installs get the
+  offline basemap on next update.
+- **No CDN dependencies for the offline path.** The bundled basemap
+  serves from the local file system; the only external requests
+  remain CartoDB tile loads while online (unchanged from v1.4.0).
+- **Online behavior unchanged.** Online operators see exactly what
+  they saw in v1.4.0 — CartoDB Dark Matter or Positron tiles, full
+  street-level detail at all zoom levels.
+
+### Known limitations (acceptable trade-offs)
+
+- **Bundled tiles are dark-mode only.** Bundling both Dark Matter
+  and Positron would roughly double the binary size (~30 MB
+  instead of ~15 MB). Day-mode toggle while offline leaves the
+  basemap on Dark Matter; the rest of the UI chrome (sidebar,
+  popups, status bar) still flips to day colors. Online operators
+  in day mode see Positron tiles as before.
+- **Maximum offline zoom is 6.** At higher zoom levels the bundle's
+  zoom-6 tiles stretch (visibly blurry but positionally correct).
+  Operators wanting street-level offline detail can either re-run
+  the maintainer script with `--max-zoom 7` for a ~50 MB bundle
+  (and we ship a bigger binary), or wait for v1.4.6's per-region
+  download command which provides street-level detail for the
+  operator's area without inflating the universal world bundle.
+
+---
+
 ## [1.4.4] — Unreleased
 
 Closes the install.sh side of the same config-key drift bug that v1.4.2

--- a/README.md
+++ b/README.md
@@ -233,12 +233,25 @@ cleared on reboot). You can tail it directly:
 tail -f /run/droneaware/detections.jsonl
 ```
 
+**Local Web UI (v1.4.0+) — works offline (v1.4.5+):**
+If you installed the optional Web UI (`sudo droneaware install-webui`),
+point any LAN device at `http://<pi-ip>:5000/` for a live detection map.
+The Web UI runs entirely on the Pi — no internet connectivity to
+droneaware.io required.
+
+From v1.4.5+, the Web UI also bundles a world-overview basemap inside
+the binary, so the map renders cleanly even when the browser can't
+reach CartoDB. Online operators get full street-level detail from
+CartoDB; offline operators get a recognizable country / state context
+with drone markers correctly positioned. The fallback is automatic —
+Leaflet detects failed tile loads and switches sources without a
+refresh.
+
 **HTTP API (v1.4.0+):**
-If you installed the optional Web UI, the same service exposes a small
-read-only JSON / SSE API on port 5000 — often easier to consume than
-UDP for Home Assistant, Node-RED, Homebridge, or any HTTP-aware
-automation tool. Unlike UDP, you also get a full snapshot of recent
-state on connect.
+The Web UI service exposes a small read-only JSON / SSE API on the same
+port (5000) — often easier to consume than UDP for Home Assistant,
+Node-RED, Homebridge, or any HTTP-aware automation tool. Unlike UDP,
+you also get a full snapshot of recent state on connect.
 
 **Endpoints** (all `GET`, no auth, LAN-accessible):
 

--- a/docs/world-tiles-generation.md
+++ b/docs/world-tiles-generation.md
@@ -1,0 +1,122 @@
+# Maintainer guide — regenerating `web_static/world-tiles.mbtiles`
+
+> **This is a maintainer task, not an operator task.** Operators never
+> touch tiles. The MBTiles file is committed to the repo, bundled into
+> the `web_ui` binary at CI build time, and shipped to every operator
+> as part of `sudo droneaware update`. Operators see the offline basemap
+> automatically — no script, no setup, no extra step.
+>
+> This doc exists so the next time the world-tile bundle needs refreshing
+> (probably once a year or once per major release), you (or a future
+> maintainer) know exactly how to regenerate the file.
+
+## When to regenerate
+
+Almost never. Zoom 0-6 basemap data — country boundaries, state outlines,
+coastlines, major cities — barely moves over years. Reasonable cadences:
+
+- **Once a year**, defensive refresh
+- **Before a v2.0-class release**, when "everything's been refreshed" framing matters
+- **Never**, also defensible — the world's coastlines aren't going anywhere
+
+## How to regenerate
+
+On your laptop (any Python 3 — Mac is fine, no Pi required), from the
+project root:
+
+```bash
+python3 tools/generate-world-tiles.py
+```
+
+This downloads ~5,461 tiles from CartoDB Dark Matter at 2 tiles/sec
+(default — well under any fair-use threshold) and packages them as
+`web_static/world-tiles.mbtiles`. **Takes about 45 minutes.** Leave it
+in a terminal.
+
+When it finishes, commit and push:
+
+```bash
+git add web_static/world-tiles.mbtiles
+git commit -m "v1.4.x: refresh world-tile bundle"
+git push releases v1.4.x-dev
+```
+
+CI's existing `build.sh --add-data web_static:web_static` step bundles
+the file into the `web_ui` binary automatically. No workflow changes
+needed. After the next release, every operator running `droneaware update`
+gets the refreshed basemap.
+
+## What the operator actually sees (just so you know what shipping this gives them)
+
+| Scenario | Without bundle (v1.4.4 and earlier) | With bundle (v1.4.5+) |
+|---|---|---|
+| Online | CartoDB Dark Matter | CartoDB Dark Matter (unchanged) |
+| Offline / browser can't reach CartoDB | Blank Leaflet background, drone markers float in space | Bundled world-overview tiles — country boundaries, state outlines, major cities; drone markers placed correctly; max zoom 6 (tiles get blurry above that but stay positioned) |
+| Online → offline mid-session | Map empties as cached tiles expire | First failed CartoDB tile triggers auto-swap to bundle; map stays usable |
+| Truly air-gapped install | Same as offline (blank) | Recognizable world map immediately, no setup |
+
+## Script options
+
+```bash
+python3 tools/generate-world-tiles.py [options]
+```
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--max-zoom` | `6` | Higher = more detail but exponentially more tiles. Zoom 7 = ~22K tiles (~50 MB), Zoom 0-5 = ~1.4K tiles (~5 MB) |
+| `--rate` | `2.0` | Tiles per second. Don't exceed ~10/sec — CartoDB will rate-limit and you'll get incomplete tiles |
+| `--out` | `web_static/world-tiles.mbtiles` | Output path |
+| `--force` | off | Overwrite existing file instead of erroring |
+
+## Attribution
+
+The output combines:
+
+- **OpenStreetMap data** — licensed under [ODbL](https://www.openstreetmap.org/copyright), explicitly allows redistribution
+- **CartoDB Dark Matter style** — CartoDB's open style sheets (BSD), applied at render time on their tile servers
+
+The Web UI surfaces both attributions in the bottom-right of the map at
+all times. Online mode displays "© OpenStreetMap © CARTO"; offline mode
+appends "(offline bundle)" to make the source explicit. Satisfies both
+ODbL and CartoDB's attribution requirements.
+
+A one-time low-rate archival download of ~5,461 zoom-0-6 tiles for an
+open-source project's offline fallback is consistent with CartoDB's
+stated tile fair-use; the script identifies itself in the User-Agent and
+defaults to a rate well below their throttling threshold.
+
+## Verifying the output before committing
+
+After generation:
+
+```bash
+# File size — should be 10-20 MB for zoom 0-6
+ls -lh web_static/world-tiles.mbtiles
+
+# Tile count by zoom level — should be 1, 4, 16, 64, 256, 1024, 4096
+sqlite3 web_static/world-tiles.mbtiles \
+    "SELECT zoom_level, COUNT(*) FROM tiles GROUP BY zoom_level"
+
+# Metadata sanity check
+sqlite3 web_static/world-tiles.mbtiles "SELECT * FROM metadata"
+```
+
+If counts look short (e.g., 4090 instead of 4096 at zoom 6), some tiles
+failed during download. Re-run with `--force` to start fresh, or accept
+the gaps if they're sparse — the Web UI's tile route returns 404 for
+missing tiles and the map degrades gracefully (small dark squares where
+the missing tile would be).
+
+## Local end-to-end test before shipping
+
+After the file is committed and you've built `web_ui` locally, test the
+fallback path without actually disconnecting from the internet:
+
+1. `sudo systemctl restart droneaware-web` (so the new binary loads)
+2. Open the Web UI in a browser
+3. Dev Tools → Network tab → check "Offline" (Chrome) or "Throttling: Offline" (Firefox)
+4. Refresh the page
+
+CartoDB requests should fail, the page should auto-swap to local tiles
+within 1-2 seconds, map should render with the bundled basemap. Uncheck
+"Offline" — CartoDB tiles return on the next zoom or pan event.

--- a/tools/generate-world-tiles.py
+++ b/tools/generate-world-tiles.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Generate web_static/world-tiles.mbtiles for the Web UI's offline basemap.
+
+The Web UI bundles this MBTiles file inside the web_ui PyInstaller binary
+via build.sh's --add-data. At runtime, when the browser can't reach CartoDB
+(operator offline, firewall, captive portal), Leaflet falls back to a local
+/tiles/{z}/{x}/{y}.png route served by web_ui that reads from this file.
+Without it, an offline operator sees drone markers floating on a blank
+Leaflet background — the whole point of v1.4.5 is to give them a recognizable
+world overview to plot against.
+
+This script downloads CartoDB Dark Matter raster tiles at zoom 0-6
+(~5,461 tiles, ~15 MB) and packages them into MBTiles SQLite format.
+
+This is a MAINTAINER task — operators never run this script. The output
+file (web_static/world-tiles.mbtiles) is committed to the repo just like
+web_static/leaflet.js. CI's existing --add-data web_static:web_static
+bundles it into the binary; every operator gets the basemap automatically
+on `sudo droneaware update`.
+
+Run once per release cycle (basemaps change slowly — OSM data updates are
+the only real driver, and at zoom 0-6 those changes are imperceptible).
+See docs/world-tiles-generation.md for the maintainer workflow.
+
+Usage (from project root):
+
+    python3 tools/generate-world-tiles.py
+
+Options:
+
+    --max-zoom 6          Maximum zoom level to download (default 6)
+    --rate 2.0            Tiles per second (default 2 — well under any
+                          fair-use threshold; takes ~45 min for zoom 0-6)
+    --out PATH            Output path (default web_static/world-tiles.mbtiles)
+    --force               Overwrite existing output
+
+Attribution:
+    Rendered output combines OpenStreetMap data (ODbL) with CartoDB's
+    Dark Matter style. The Web UI surfaces both attributions in the
+    bottom-right of the map at all times, both online (live CartoDB)
+    and offline (bundled tiles — attribution text appended with
+    "(offline bundle)"). A single low-rate archival download for a
+    node's offline fallback is well within CartoDB's stated tile
+    fair-use; we identify ourselves clearly in the User-Agent.
+"""
+import argparse
+import os
+import random
+import sqlite3
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+CARTODB_URL = "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
+SUBDOMAINS = ["a", "b", "c", "d"]
+USER_AGENT = (
+    "DroneAware-Node/world-tiles-generator "
+    "(+https://github.com/fduflyer/DroneAware-Node-Releases)"
+)
+
+
+def init_mbtiles(path, max_zoom):
+    """Create the MBTiles schema and write the standard metadata rows."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS metadata (name TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE IF NOT EXISTS tiles (
+            zoom_level  INTEGER,
+            tile_column INTEGER,
+            tile_row    INTEGER,
+            tile_data   BLOB,
+            PRIMARY KEY (zoom_level, tile_column, tile_row)
+        );
+        """
+    )
+    metadata = [
+        ("name",        "DroneAware World Overview"),
+        ("type",        "baselayer"),
+        ("format",      "png"),
+        ("minzoom",     "0"),
+        ("maxzoom",     str(max_zoom)),
+        ("bounds",      "-180.0,-85.0511,180.0,85.0511"),
+        ("attribution", "&copy; OpenStreetMap &copy; CARTO"),
+        ("description", "Dark Matter style world overview for DroneAware Local Web UI offline fallback"),
+    ]
+    conn.executemany(
+        "INSERT OR REPLACE INTO metadata (name, value) VALUES (?, ?)",
+        metadata,
+    )
+    conn.commit()
+    return conn
+
+
+def download_tile(z, x, y, timeout=30):
+    """Fetch one tile from CartoDB. Returns the PNG bytes."""
+    sub = random.choice(SUBDOMAINS)
+    url = CARTODB_URL.format(s=sub, z=z, x=x, y=y)
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read()
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Build web_static/world-tiles.mbtiles for the Web UI offline basemap",
+    )
+    p.add_argument("--max-zoom", type=int, default=6,
+                   help="Maximum zoom level to download (default 6)")
+    p.add_argument("--rate", type=float, default=2.0,
+                   help="Tiles per second (default 2.0)")
+    p.add_argument("--out", default="web_static/world-tiles.mbtiles",
+                   help="Output MBTiles path (default web_static/world-tiles.mbtiles)")
+    p.add_argument("--force", action="store_true",
+                   help="Overwrite existing output file")
+    args = p.parse_args()
+
+    if os.path.exists(args.out):
+        if not args.force:
+            print(f"ERROR: {args.out} already exists. Pass --force to overwrite.",
+                  file=sys.stderr)
+            sys.exit(1)
+        os.remove(args.out)
+
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+
+    total = sum(4 ** z for z in range(args.max_zoom + 1))
+    sleep_time = 1.0 / args.rate
+    est_minutes = total / args.rate / 60
+
+    print(f"Output:   {args.out}")
+    print(f"Zoom:     0-{args.max_zoom}")
+    print(f"Tiles:    {total} total")
+    print(f"Rate:     {args.rate} tiles/sec")
+    print(f"ETA:      {est_minutes:.0f} minutes")
+    print(f"Source:   {CARTODB_URL}")
+    print()
+
+    conn = init_mbtiles(args.out, args.max_zoom)
+    done = 0
+    failed = 0
+    started = time.time()
+
+    for z in range(args.max_zoom + 1):
+        max_xy = 2 ** z
+        for x in range(max_xy):
+            for y in range(max_xy):
+                try:
+                    data = download_tile(z, x, y)
+                    # MBTiles uses TMS row indexing (y-axis flipped);
+                    # CartoDB serves XYZ. Convert before storing so the
+                    # web_ui /tiles route can do a direct lookup.
+                    tms_y = (1 << z) - 1 - y
+                    conn.execute(
+                        "INSERT INTO tiles VALUES (?, ?, ?, ?)",
+                        (z, x, tms_y, data),
+                    )
+                except urllib.error.HTTPError as e:
+                    failed += 1
+                    print(f"  warn: z{z}/x{x}/y{y} → HTTP {e.code}", file=sys.stderr)
+                except Exception as e:
+                    failed += 1
+                    print(f"  warn: z{z}/x{x}/y{y} → {e}", file=sys.stderr)
+
+                done += 1
+                if done % 50 == 0:
+                    conn.commit()
+                    elapsed = time.time() - started
+                    pct = done / total * 100
+                    eta = (total - done) * sleep_time / 60
+                    print(f"  {done}/{total} ({pct:5.1f}%)  "
+                          f"elapsed {elapsed/60:.1f}m  eta {eta:.1f}m  "
+                          f"failed {failed}")
+
+                time.sleep(sleep_time)
+
+    conn.commit()
+    conn.execute("VACUUM")
+    conn.close()
+
+    size_mb = os.path.getsize(args.out) / 1e6
+    elapsed_min = (time.time() - started) / 60
+
+    print()
+    print(f"Done. {args.out} = {size_mb:.1f} MB")
+    print(f"Downloaded {done - failed} tiles in {elapsed_min:.1f} minutes "
+          f"({failed} failed)")
+    print()
+    print("Next steps (maintainer):")
+    print(f"  git add {args.out}")
+    print(f"  git commit -m 'v1.4.x: refresh world-tile bundle'")
+    print(f"  # CI bundles it into web_ui via build.sh --add-data on next release")
+
+
+if __name__ == "__main__":
+    main()

--- a/web_static/index.html
+++ b/web_static/index.html
@@ -815,6 +815,14 @@
       selectedMac: null,
       sse: null,
       map: null,
+      // Tile source state — "cartocdn" (online, default) or "local"
+      // (offline bundle served by web_ui from MBTiles). Resolved by
+      // navigator.onLine at startup, then maintained by online/offline
+      // window events + Leaflet tileerror auto-swap. tilesLocalAvailable
+      // is set from /api/status at startup so we don't try to swap to a
+      // bundle that doesn't exist on this node.
+      tileSource: (typeof navigator !== "undefined" && navigator.onLine === false) ? "local" : "cartocdn",
+      tilesLocalAvailable: false,
     };
 
     /* ----- Helpers ----- */
@@ -842,22 +850,78 @@
     }
 
     /* ----- Map init ----- */
-    // Tile layer URLs per theme. CartoDB Dark Matter is the dark-mode
-    // (brand-default) basemap; CartoDB Positron is its day-mode sibling.
+    // Two tile sources × two themes. CartoDB (live, "cartocdn") is the
+    // primary — full street-level detail any zoom, requires browser to
+    // reach basemaps.cartocdn.com. Local bundle ("local") is the offline
+    // fallback served by web_ui from a bundled MBTiles file (zoom 0-6
+    // worldwide, Dark Matter style only — day variant uses the dark
+    // tiles too since we don't bundle Positron). Active source is
+    // chosen by navigator.onLine + tileerror auto-swap; see below.
     const TILE_URLS = {
-      dark: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
-      day:  "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+      cartocdn: {
+        dark: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+        day:  "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
+      },
+      local: {
+        // Bundle is dark-only by design — keeps the binary lean
+        // (~15 MB vs ~30 MB for both). Day-mode toggle while offline
+        // leaves the basemap on Dark Matter; everything else (chrome,
+        // popups, sidebar) still flips to day colors.
+        dark: "/tiles/{z}/{x}/{y}.png",
+        day:  "/tiles/{z}/{x}/{y}.png",
+      },
     };
+    const LOCAL_TILES_MAX_ZOOM = 6;
 
     function applyMapTheme() {
-      const t = document.documentElement.dataset.theme || "dark";
-      const url = TILE_URLS[t] || TILE_URLS.dark;
+      const theme = document.documentElement.dataset.theme || "dark";
+      const source = state.tileSource || "cartocdn";
+      const url = TILE_URLS[source][theme];
+
       if (state.tileLayer) state.map.removeLayer(state.tileLayer);
-      state.tileLayer = L.tileLayer(url, {
-        attribution: '&copy; OpenStreetMap &copy; CARTO',
-        subdomains: "abcd",
+
+      const opts = {
+        attribution: source === "cartocdn"
+          ? '&copy; OpenStreetMap &copy; CARTO'
+          : '&copy; OpenStreetMap &copy; CARTO (offline bundle)',
         maxZoom: 19,
-      }).addTo(state.map);
+      };
+      if (source === "cartocdn") {
+        opts.subdomains = "abcd";
+      } else {
+        // Bundle only covers zoom 0-6. Leaflet's maxNativeZoom tells it
+        // to keep using zoom-6 tiles for higher zoom levels, scaling
+        // them up (blurry but positioned correctly). Drone markers and
+        // distance rings still place accurately — basemap just degrades.
+        opts.maxNativeZoom = LOCAL_TILES_MAX_ZOOM;
+      }
+
+      state.tileLayer = L.tileLayer(url, opts).addTo(state.map);
+
+      // Listen for tile load failures on the CartoDB layer — first
+      // failure swaps us to the local bundle. Covers the case where
+      // navigator.onLine reports true but the browser can't actually
+      // reach CartoDB (corporate firewall, captive portal, etc.).
+      // Local layer can't fail meaningfully — it's served by the same
+      // Pi the operator is already connected to — so no handler there.
+      if (source === "cartocdn") {
+        state.tileLayer.on("tileerror", switchToLocalTiles);
+      }
+    }
+
+    function switchToLocalTiles() {
+      if (state.tileSource === "local") return;
+      if (!state.tilesLocalAvailable) return;  // no bundle on this node
+      console.info("[map] Switching to bundled offline tiles");
+      state.tileSource = "local";
+      applyMapTheme();
+    }
+
+    function switchToCartoDBTiles() {
+      if (state.tileSource === "cartocdn") return;
+      console.info("[map] Network back — switching to CartoDB tiles");
+      state.tileSource = "cartocdn";
+      applyMapTheme();
     }
 
     // Above this zoom level, the distance rings + labels are hidden from
@@ -1335,6 +1399,20 @@
         document.getElementById("stat-version").textContent = s.version;
         if (s.node_id) state.nodeId = s.node_id;
 
+        // Bundle availability — once known, swap to local immediately if
+        // we started in offline mode (we couldn't swap at init because
+        // tilesLocalAvailable was unknown). After the first /api/status,
+        // tileerror-driven fallback also becomes possible.
+        if (s.tiles_local && !state.tilesLocalAvailable) {
+          state.tilesLocalAvailable = true;
+          if (state.tileSource === "local") {
+            // Re-apply the layer now that we know the bundle exists —
+            // initial applyMapTheme() may have rendered an empty layer
+            // if we started offline before this status fetch.
+            applyMapTheme();
+          }
+        }
+
         // Home location may change on mobile nodes as the GPS fix moves.
         // Only redraw if the location actually changed (avoids tearing down
         // the rings every 2 seconds for static nodes).
@@ -1608,6 +1686,14 @@
       initMap();
       initFilters();
       document.getElementById("btn-theme").addEventListener("click", toggleTheme);
+
+      // Network transitions → swap the basemap source. CartoDB if we're
+      // online (full street-level detail), bundled local tiles when
+      // offline (world overview). These are coarse signals — tileerror
+      // on the active CartoDB layer is the ground-truth fallback (see
+      // applyMapTheme).
+      window.addEventListener("online",  switchToCartoDBTiles);
+      window.addEventListener("offline", switchToLocalTiles);
 
       // Initial snapshot
       try {

--- a/web_ui.py
+++ b/web_ui.py
@@ -58,6 +58,7 @@ import json
 import logging
 import os
 import socket
+import sqlite3
 import sys
 import threading
 import time
@@ -125,6 +126,18 @@ PRUNE_INTERVAL_SEC = 1.0
 # SSE per-client queue depth — slow clients drop events rather than
 # blocking the publisher. 100 events buffered per client is comfortable.
 SSE_CLIENT_QUEUE_MAX = 100
+
+# Bundled world-overview tiles for offline operation. Generated once with
+# tilemaker against an OSM extract using the CartoDB Dark Matter style
+# (see docs/world-tiles-generation.md), shipped inside the web_ui binary
+# via web_static/. Covers zoom 0-6 (~5,461 tiles, ~15 MB) — recognizable
+# country / state / metro context worldwide. The Leaflet client uses
+# CartoDB's live tile server when online and falls back to this bundle
+# when the browser can't reach CartoDB. If the bundle is missing (e.g.,
+# dev runs without the file), the tile route returns 404 and the client
+# stays on CartoDB — graceful degradation either way.
+WORLD_TILES_FILENAME = "world-tiles.mbtiles"
+WORLD_TILES_MAX_ZOOM = 6
 
 START_TIME = time.time()
 
@@ -516,6 +529,46 @@ def get_home_location() -> dict | None:
         return None
 
 
+# ---- World-tile bundle (offline basemap) ------------------------------------
+
+# MBTiles is the de facto offline raster-tile container — a SQLite file
+# with a `tiles` table keyed by (zoom_level, tile_column, tile_row,
+# tile_data). The schema uses TMS row indexing (y-axis inverted from
+# Leaflet's XYZ scheme); the route below handles the conversion.
+# Connection is opened lazily once and shared across threads — SQLite
+# handles concurrent reads fine with check_same_thread=False; the lock
+# is belt-and-suspenders for sqlite3 module-version variance.
+
+_mbtiles_path = None
+_mbtiles_conn = None
+_mbtiles_lock = threading.Lock()
+
+
+def _mbtiles_init():
+    """Resolve the MBTiles path from the bundled web_static dir and open
+    a shared read-only connection. Called once at app startup."""
+    global _mbtiles_path, _mbtiles_conn
+    candidate = os.path.join(_static_root(), WORLD_TILES_FILENAME)
+    if os.path.isfile(candidate):
+        try:
+            _mbtiles_conn = sqlite3.connect(
+                f"file:{candidate}?mode=ro", uri=True, check_same_thread=False,
+            )
+            _mbtiles_path = candidate
+            log.info(
+                f"World-tile bundle loaded: {candidate} "
+                f"(offline basemap available up to zoom {WORLD_TILES_MAX_ZOOM})"
+            )
+        except Exception as e:
+            log.warning(f"Failed to open world-tile bundle at {candidate}: {e}")
+    else:
+        log.info(
+            f"No world-tile bundle at {candidate} — offline basemap unavailable. "
+            f"Browser will stay on CartoDB; if CartoDB is unreachable the map "
+            f"will render without a basemap (drone markers still position correctly)."
+        )
+
+
 # ---- Flask app --------------------------------------------------------------
 
 app = Flask(
@@ -636,8 +689,55 @@ def api_status():
         "sse_clients": broker.subscriber_count(),
         "home":        get_home_location(),  # {lat, lon, source} or null
         "node_id":     _read_config_env("NODE_ID") or "this-node",
+        # Whether the bundled world-tile MBTiles is available for offline
+        # basemap rendering. Frontend uses this to know whether the
+        # /tiles/{z}/{x}/{y}.png fallback layer will return real tiles
+        # or 404s if CartoDB is unreachable.
+        "tiles_local": _mbtiles_conn is not None,
+        "tiles_local_max_zoom": WORLD_TILES_MAX_ZOOM if _mbtiles_conn else None,
     })
     return jsonify(s)
+
+
+@app.route("/tiles/<int:z>/<int:x>/<int:y>.png")
+def tile(z, x, y):
+    """Serve a single PNG tile from the bundled world-tile MBTiles file.
+    Used by the Leaflet client as the offline basemap fallback when the
+    browser can't reach CartoDB. Out-of-range zooms (z > WORLD_TILES_MAX_ZOOM)
+    and unknown tile coords both return 404 — Leaflet's tileerror handler
+    treats those as missing-tile placeholders, which is the correct UX
+    (operator zoomed past where the bundle has data)."""
+    if _mbtiles_conn is None:
+        # No bundle loaded — return 404 so the Leaflet client falls back
+        # gracefully (the dual-layer config keeps CartoDB as the primary
+        # source; this route is only hit when CartoDB has failed).
+        return Response(status=404)
+    if z > WORLD_TILES_MAX_ZOOM:
+        # Bundle doesn't include high zoom; client should be using
+        # maxNativeZoom on the layer to upscale lower zooms rather than
+        # request these — but if the request lands here anyway, 404 is
+        # the honest answer.
+        return Response(status=404)
+    # MBTiles stores tile_row in TMS scheme (origin = bottom-left);
+    # Leaflet/XYZ uses origin = top-left. Convert: tms_y = 2^z - 1 - y.
+    tms_y = (1 << z) - 1 - y
+    with _mbtiles_lock:
+        cur = _mbtiles_conn.execute(
+            "SELECT tile_data FROM tiles "
+            "WHERE zoom_level = ? AND tile_column = ? AND tile_row = ?",
+            (z, x, tms_y),
+        )
+        row = cur.fetchone()
+    if row is None or not row[0]:
+        return Response(status=404)
+    # Cache aggressively in the browser — tile content for a given (z,x,y)
+    # never changes within a release (the MBTiles file is immutable;
+    # operators get fresh tiles by upgrading the web_ui binary).
+    return Response(
+        row[0],
+        mimetype="image/png",
+        headers={"Cache-Control": "public, max-age=86400, immutable"},
+    )
 
 
 @app.route("/events")
@@ -684,6 +784,8 @@ def main():
     log.info(f"Buffer cap: {store._max_bytes // 1_000_000} MB  "
              f"Stale threshold: {STALE_AGE_SEC}s")
     log.info(f"Data source: tail {LOCAL_RING_PATH} every {TAIL_POLL_SEC}s")
+
+    _mbtiles_init()
 
     threading.Thread(target=consumer_thread, daemon=True).start()
     threading.Thread(target=prune_thread, daemon=True).start()


### PR DESCRIPTION
## Summary

Closes the v1.4.0 promise gap. v1.4.0 made the Local Web UI work without internet to droneaware.io (feeders, sidebar, API, SSE all local), but the Leaflet basemap still required the browser to reach CartoDB at runtime — air-gapped operators saw drone markers floating on a blank background. v1.4.5 bundles a world-overview basemap inside the web_ui binary and auto-falls-back from CartoDB when the browser can't reach it.

## What operators get

| Scenario | Today (v1.4.4) | After v1.4.5 |
|---|---|---|
| Online | CartoDB Dark Matter / Positron, full detail | Unchanged |
| Offline / firewalled / captive portal | Blank Leaflet background, drone markers float | Bundled world-overview tiles, recognizable country/state context, markers correctly positioned, max zoom 6 (stretches above) |
| Online → goes offline mid-session | Map empties as cached tiles expire | First failed CartoDB tile → auto-swap to local bundle within 1-2s |
| Truly air-gapped install | Same as offline | Recognizable world map immediately, no setup |

No operator action required. The MBTiles ships with the web_ui binary via the existing `--add-data web_static:web_static`. Operators get the offline basemap automatically on `sudo droneaware update`.

## What changed

- `web_ui.py` — new `/tiles/<z>/<x>/<y>.png` route serving PNG tiles from a bundled MBTiles SQLite file; new `tiles_local` + `tiles_local_max_zoom` fields in `/api/status`
- `web_static/index.html` — dual-layer Leaflet config (CartoDB online, bundled tiles offline) with `tileerror` auto-swap and `window.online`/`offline` event handling
- `README.md` — note on offline behavior in the Local/Offline Use section
- `CHANGELOG.md` — v1.4.5 entry with architecture notes + known limitations

## Status

**Draft because `web_static/world-tiles.mbtiles` (~15 MB) still needs to be added to the branch.** The wiring works without it (route returns 404, browser stays on CartoDB) but the offline mode is the point of this release. Once the bundle file is committed, the PR will be marked ready-for-review.