### PR TITLE
v1.4.6: loud CLI-update errors + configurable dual-band dwell times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,78 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.6] — Unreleased
+
+Two independent issues surfaced during the v1.4.4 / v1.4.5 rollout. Both
+fixed here so the fleet gets both improvements in one `sudo droneaware
+update` hop.
+
+### Fixed
+
+- **`droneaware update` no longer silently fails to update the CLI
+  itself.** Previously, `cmd_update` fetched the new `droneaware` CLI
+  script via `curl -fsSL ... || true` and gated the install on
+  `[[ -s /tmp/da_cli ]]`. If the download hit any transient network or
+  HTTP error, both guards silently swallowed the failure — operators
+  ended up with new feeder binaries but a stale CLI, with no message.
+  Only became painful in v1.4.0 when `install-webui` was added as the
+  first subcommand that requires a fresh CLI (previously every
+  subcommand existed in every CLI version, so a stale CLI worked fine).
+
+  `cmd_update` now:
+  - Prints an explicit `Downloading CLI...` line at the step
+  - Checks the download succeeded AND the file is non-empty AND has a
+    shebang (catches captive-portal HTML / corrupt asset responses)
+  - Warns loudly on any failure and prints the manual-fix one-liner so
+    the next operator to hit this sees the fix in their own update output
+  - Prints `CLI updated to vX.Y.Z.` on success so operators can verify
+
+  Companion feeder-side warning: `ble_feeder` and `wifi_feeder` now
+  grep `/usr/local/bin/droneaware` at service startup for a v1.4.0+
+  marker (`install-webui`) and log a WARN to `journalctl` if missing —
+  surfaces any operator who's already stuck on a stale CLI without
+  needing them to try `install-webui` to find out.
+
+- **Dual-band WiFi hopper now cycles ~10× faster + is fully tunable.**
+  Previous defaults were 20s on ch6 (2.4 GHz) → 10s on ch149 (5 GHz),
+  a 30-second cycle. Community feedback (Qerolt 2026-07-01 re: Skydio
+  DFR coverage) made clear these dwells are way too long in the drone
+  context: at typical cruise speed (~20 m/s), a drone flies 400 meters
+  in 20 seconds — exceeding the typical 100–300m urban RID detection
+  range. Drones could transit through a node's entire range on the
+  "wrong" band without ever being seen. Channel-switch overhead is
+  milliseconds; the old defaults optimized for the wrong side of that
+  trade.
+
+  New defaults: **3s ch6 + 2s ch149 (5s cycle)**. Both tunable via new
+  config.env keys:
+  - `WIFI_DWELL_2G_SEC=3` — 2.4 GHz dwell per cycle (default 3)
+  - `WIFI_DWELL_5G_SEC=2` — 5 GHz dwell per cycle (default 2)
+
+  Operators can weight toward one band without going all-in. Examples
+  in the config.env comment block:
+  - Skydio-DFR area (weight to 5 GHz): `WIFI_DWELL_2G_SEC=1
+    WIFI_DWELL_5G_SEC=4`
+  - DJI-heavy area: `WIFI_DWELL_2G_SEC=4  WIFI_DWELL_5G_SEC=1`
+  - `FIXED_CHANNEL=149` still available for 100% lock to one band
+
+  Single-band adapters unaffected (they use the SingleBandHopper class
+  with its own separate DWELL_CH6_MS knob for sub-second sweep dwell).
+
+### Behavior change to expect
+
+- **Existing dual-band nodes will see substantially faster hopping**
+  after `sudo droneaware update`. Expect slightly higher CPU usage
+  (more channel switches per second) and correspondingly better catch
+  rate for fast-moving drones. If the new default doesn't suit your
+  deployment, revert or tune via the new env vars — see the config.env
+  comment block for examples.
+- Nodes that had previously customized the hardcoded class constants
+  by editing `wifi_feeder.py` will lose those customizations on
+  update. Move to the env-var config instead.
+
+---
+
 ## [1.4.5] — Unreleased
 
 Delivers the offline operability the v1.4.0 Local Web UI release

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -44,6 +44,29 @@ logging.basicConfig(
 )
 log = logging.getLogger("droneaware.ble")
 
+
+def _check_cli_freshness():
+    """Warn if /usr/local/bin/droneaware appears older than the feeder binaries.
+    See wifi_feeder.py:_check_cli_freshness for the rationale — same check,
+    same message, mirrored here so operators see the warning regardless of
+    which feeder starts first in their journalctl."""
+    cli_path = "/usr/local/bin/droneaware"
+    try:
+        with open(cli_path) as f:
+            content = f.read()
+    except Exception:
+        return
+    if "install-webui" not in content:
+        log.warning(
+            f"{cli_path} appears older than the installed feeders "
+            "(missing v1.4.0+ install-webui subcommand). A previous "
+            "`droneaware update` likely failed silently to update the CLI. "
+            "Fix with: sudo curl -fsSL "
+            "https://github.com/fduflyer/DroneAware-Node-Releases/releases/latest/download/droneaware "
+            "-o /usr/local/bin/droneaware && sudo chmod +x /usr/local/bin/droneaware"
+        )
+
+
 def _read_fw_version(fallback: str) -> str:
     try:
         with open("/opt/droneaware/version") as f:
@@ -840,6 +863,7 @@ class BLEFeeder:
 
     async def run(self):
         log.info(f"DroneAware BLE Feeder - Node: {self.node_id}  Adapter: {self.adapter}")
+        _check_cli_freshness()
 
         # Adapter not healthy at startup — try the standard recovery sequence
         # before declaring FAULT. Auto-heals the Pi onboard BT UART sync issue

--- a/droneaware
+++ b/droneaware
@@ -172,6 +172,41 @@ EOF
         info "Added v1.4.0 LocalPublisher UDP targets option to config.env"
     fi
 
+    # v1.4.6 — configurable dual-band dwell times
+    # NOTE: this migration is documentation-only; wifi_feeder uses env-var
+    # defaults when the keys are absent. Writing the keys here surfaces
+    # the knobs in config.env so operators can discover + tune them.
+    if ! grep -q '^WIFI_DWELL_2G_SEC=' "$cfg"; then
+        [[ "$backed_up" == "0" ]] && cp "$cfg" "${cfg}.bak.$(date +%s)" && backed_up=1
+        cat >> "$cfg" <<'EOF'
+
+# ─── Dual-band dwell times (added by droneaware update for v1.4.6+) ───
+# Applies only when a dual-band adapter is in use (WIFI_5G_ENABLED=auto
+# and adapter supports 5 GHz, OR WIFI_5G_ENABLED=true). Ignored on
+# single-band setups. The feeder cycles: WIFI_DWELL_2G_SEC on ch6 →
+# WIFI_DWELL_5G_SEC on ch149 → repeat. Total cycle = sum of the two.
+#
+# v1.4.6 slashed defaults from 20s / 10s (30s cycle) to 3s / 2s
+# (5s cycle) after operator feedback: a drone at 20 m/s cruise covers
+# 400m in 20s, exceeding typical 100-300m urban RID detection range.
+# The old defaults let drones fly through detection range on the
+# "wrong" band and never be seen. Channel-switch overhead is
+# milliseconds; more-frequent switching is the better trade.
+#
+# Tune the split to weight toward one band. Examples:
+#   Skydio-DFR-heavy area (weight toward 5 GHz):
+#     WIFI_DWELL_2G_SEC=1  WIFI_DWELL_5G_SEC=4
+#   DJI-heavy area (weight toward 2.4 GHz, still fast cycle):
+#     WIFI_DWELL_2G_SEC=4  WIFI_DWELL_5G_SEC=1
+#   Fastest reasonable cycle (~2 broadcasts per band per cycle):
+#     WIFI_DWELL_2G_SEC=2  WIFI_DWELL_5G_SEC=2
+# For 100% lock to one band, use FIXED_CHANNEL=6 or FIXED_CHANNEL=149.
+WIFI_DWELL_2G_SEC=3
+WIFI_DWELL_5G_SEC=2
+EOF
+        info "Added v1.4.6 dual-band dwell time options to config.env"
+    fi
+
     # Future release migration blocks go here.
     # Pattern:
     #   if ! grep -q '^NEW_FIELD=' "$cfg"; then
@@ -245,10 +280,33 @@ cmd_update() {
     systemctl stop droneaware-ble droneaware-wifi 2>/dev/null || true
     [[ "$update_webui" == "1" ]] && systemctl stop droneaware-web 2>/dev/null || true
 
-    # Also update the droneaware CLI itself
-    curl -fsSL --retry 3 "${BASE}/droneaware" -o /tmp/da_cli || true
-    if [[ -s /tmp/da_cli ]]; then
+    # Also update the droneaware CLI itself. NON-SILENT — earlier
+    # versions swallowed curl failures with `|| true` and gated the
+    # install on `-s /tmp/da_cli` with no diagnostic. Result: some
+    # operators (surfaced 2026-06-30 via NBG / Kbrooks Discord) ended
+    # up with feeders on v1.4.5 but their CLI silently stuck at
+    # pre-v1.4.0 → `install-webui` returned "unknown command" with no
+    # explanation. v1.4.6 makes every failure mode print a warning
+    # plus the exact manual-fix command so the next operator to hit
+    # this sees the fix in their own update output.
+    cli_download_ok=1
+    echo "  Downloading CLI..."
+    if ! curl -fSL --retry 6 "${BASE}/droneaware" -o /tmp/da_cli; then
+        warn "CLI download from ${BASE}/droneaware failed."
+        cli_download_ok=0
+    elif [[ ! -s /tmp/da_cli ]]; then
+        warn "CLI download produced empty /tmp/da_cli — treating as failed."
+        cli_download_ok=0
+    elif ! head -1 /tmp/da_cli | grep -q '^#!'; then
+        warn "Downloaded CLI has no shebang — likely captive-portal HTML or corrupt asset. Refusing to install."
+        cli_download_ok=0
+    else
         chmod +x /tmp/da_cli
+    fi
+    if [[ "$cli_download_ok" == "0" ]]; then
+        warn "Your CLI at /usr/local/bin/droneaware will remain at the previous version."
+        warn "Fix manually with:"
+        warn "  sudo curl -fsSL ${BASE}/droneaware -o /usr/local/bin/droneaware && sudo chmod +x /usr/local/bin/droneaware"
     fi
 
     cp /tmp/da_ble_feeder  "${INSTALL_DIR}/ble_feeder"
@@ -267,10 +325,17 @@ cmd_update() {
     # bytes in the new (different-sized) file → garbage parsing at script
     # end (the v1.2.0 "line 426: syntax error" bug). Atomic rename keeps
     # the open file descriptor pointed at the old inode until bash exits.
-    if [[ -s /tmp/da_cli ]]; then
-        cp /tmp/da_cli /usr/local/bin/droneaware.new
-        chmod +x /usr/local/bin/droneaware.new
-        mv /usr/local/bin/droneaware.new /usr/local/bin/droneaware
+    if [[ "$cli_download_ok" == "1" ]]; then
+        if cp /tmp/da_cli /usr/local/bin/droneaware.new \
+           && chmod +x /usr/local/bin/droneaware.new \
+           && mv /usr/local/bin/droneaware.new /usr/local/bin/droneaware; then
+            info "CLI updated to ${LATEST}."
+        else
+            warn "CLI install to /usr/local/bin failed (disk full? read-only fs?). Old CLI remains."
+            warn "Fix manually with:"
+            warn "  sudo curl -fsSL ${BASE}/droneaware -o /usr/local/bin/droneaware && sudo chmod +x /usr/local/bin/droneaware"
+            rm -f /usr/local/bin/droneaware.new 2>/dev/null || true
+        fi
     fi
     rm -f /tmp/da_ble_feeder /tmp/da_wifi_feeder /tmp/da_web_ui /tmp/da_cli
     echo "$LATEST" > "$VERSION_FILE"

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -46,6 +46,36 @@ logging.basicConfig(
 )
 log = logging.getLogger("droneaware.wifi")
 
+
+def _check_cli_freshness():
+    """Warn if /usr/local/bin/droneaware appears older than the feeder binaries.
+    Surfaces the silent CLI-update failure mode where `droneaware update` runs
+    the CLI-download step, hits a transient error, swallows it with `|| true`,
+    and leaves the operator with new feeders + stale CLI. Silent since v1.1.1
+    when CLI self-update shipped; only became painful in v1.4.0 when
+    `install-webui` became the first subcommand that requires a fresh CLI.
+    v1.4.6 makes cmd_update's download failures loud AND surfaces already-stuck
+    CLIs here — this warning appears every service start until the operator
+    runs the manual-fix one-liner. Non-blocking; feeder still runs."""
+    cli_path = "/usr/local/bin/droneaware"
+    try:
+        with open(cli_path) as f:
+            content = f.read()
+    except Exception:
+        return  # CLI missing or unreadable — not our concern here
+    # `install-webui` was added in v1.4.0. If the CLI on-disk doesn't have it,
+    # the CLI is stale relative to a v1.4.0+ feeder binary.
+    if "install-webui" not in content:
+        log.warning(
+            f"{cli_path} appears older than the installed feeders "
+            "(missing v1.4.0+ install-webui subcommand). A previous "
+            "`droneaware update` likely failed silently to update the CLI. "
+            "Fix with: sudo curl -fsSL "
+            "https://github.com/fduflyer/DroneAware-Node-Releases/releases/latest/download/droneaware "
+            "-o /usr/local/bin/droneaware && sudo chmod +x /usr/local/bin/droneaware"
+        )
+
+
 def _read_fw_version(fallback: str) -> str:
     try:
         with open("/opt/droneaware/version") as f:
@@ -800,16 +830,26 @@ class AdaptiveChannelHopper(threading.Thread):
 
 class DualBandHopper(threading.Thread):
     """
-    30s cycle hopper for dual-band adapters (2.4 GHz + 5 GHz).
+    Fast-cycle hopper for dual-band adapters (2.4 GHz + 5 GHz).
 
     Sweep mode default (WIFI_OFF_CHANNEL_SWEEP=false):
-        20s ch6 → 10s ch149  (1 band switch per cycle, ASTM-compliant channels only)
+        WIFI_DWELL_2G_SEC ch6 → WIFI_DWELL_5G_SEC ch149
+        Defaults: 3s + 2s = 5s cycle.
 
     Sweep mode with off-channel canary (WIFI_OFF_CHANNEL_SWEEP=true, advanced):
-        18s ch6 → 1s ch1 → 1s ch11 → 10s ch149
+        (WIFI_DWELL_2G_SEC - 2) ch6 → 1s ch1 → 1s ch11 → WIFI_DWELL_5G_SEC ch149
 
     Sticky mode (detection within ACTIVE_WINDOW): hold on the detected channel.
     Periodic peek at the other band's primary every STICKY_PEEK_INTERVAL cycles.
+
+    v1.4.6 slashed default dwell times from 20s / 10s (30s cycle) to 3s / 2s
+    (5s cycle) after operator feedback that the old defaults let drones fly
+    through detection range unseen — a drone at 20 m/s cruise covers 400m in
+    20 seconds, exceeding typical 100-300m urban RID detection range on the
+    "wrong" band. Channel-switch overhead is milliseconds; sitting on one
+    band for 20s to avoid it was clearly the wrong trade. Both defaults are
+    tunable now via env vars for operators who want to weight toward one
+    band (e.g., Skydio-DFR hunting on 5 GHz).
 
     Empirical data (project_detection_data memory): ch1/ch11 carry zero unique
     drones — all off-band captures are ch6 drift. Default is compliant-only;
@@ -822,9 +862,9 @@ class DualBandHopper(threading.Thread):
     PEEK_CHANNELS_2G      = [1, 11]
     ACTIVE_WINDOW         = 3.0
 
-    DWELL_CH6_S           = 18.0
-    DWELL_CH6_FULL_S      = 20.0
-    DWELL_CH149_S         = 10.0
+    # Fallback constants used when env vars unset or invalid.
+    DEFAULT_DWELL_2G_S    = 3.0
+    DEFAULT_DWELL_5G_S    = 2.0
     PEEK_S                = 1.0
 
     STICKY_DWELL_MS       = 950
@@ -849,6 +889,38 @@ class DualBandHopper(threading.Thread):
         except ValueError:
             log.warning(f"FIXED_CHANNEL={raw!r} is not an integer — ignoring")
             self.fixed_channel = None
+
+        # v1.4.6: WIFI_DWELL_2G_SEC / WIFI_DWELL_5G_SEC override the class
+        # defaults so operators can weight toward one band. Skydio-DFR
+        # areas might want WIFI_DWELL_5G_SEC=5 WIFI_DWELL_2G_SEC=1;
+        # DJI-heavy areas might want the reverse.
+        self.dwell_2g_s = self._parse_dwell("WIFI_DWELL_2G_SEC", self.DEFAULT_DWELL_2G_S)
+        self.dwell_5g_s = self._parse_dwell("WIFI_DWELL_5G_SEC", self.DEFAULT_DWELL_5G_S)
+
+        # If off-channel sweep is enabled but 2G budget can't accommodate
+        # the 2×PEEK_S reserved for ch1+ch11, disable sweep rather than
+        # produce a nonsensical schedule.
+        if self.off_channel_sweep and self.dwell_2g_s <= 2 * self.PEEK_S:
+            log.warning(
+                f"WIFI_DWELL_2G_SEC={self.dwell_2g_s}s is too small for "
+                f"off-channel peeks ({2 * self.PEEK_S}s reserved for ch1+ch11). "
+                "Disabling WIFI_OFF_CHANNEL_SWEEP for this run."
+            )
+            self.off_channel_sweep = False
+
+    @staticmethod
+    def _parse_dwell(var: str, default: float) -> float:
+        raw = os.environ.get(var, "").strip()
+        if not raw:
+            return default
+        try:
+            val = float(raw)
+            if val <= 0:
+                raise ValueError("must be positive")
+            return val
+        except ValueError as e:
+            log.warning(f"{var}={raw!r} invalid ({e}) — using default {default}s")
+            return default
 
     def notify_detection(self, channel: int | None):
         self.last_detection_time = time.time()
@@ -879,10 +951,12 @@ class DualBandHopper(threading.Thread):
             return
 
         canary = "enabled" if self.off_channel_sweep else "disabled"
+        cycle_s = self.dwell_2g_s + self.dwell_5g_s
         log.info(
-            f"Dual-band hopper started: 30s cycle "
-            f"(ch{self.PRIMARY_CHANNEL_2G} + ch{self.PRIMARY_CHANNEL_5G}), "
-            f"off-channel canary {canary}"
+            f"Dual-band hopper started: "
+            f"{self.dwell_2g_s}s ch{self.PRIMARY_CHANNEL_2G} + "
+            f"{self.dwell_5g_s}s ch{self.PRIMARY_CHANNEL_5G} "
+            f"({cycle_s}s cycle), off-channel canary {canary}"
         )
         prev_mode = "sweep"
 
@@ -911,8 +985,10 @@ class DualBandHopper(threading.Thread):
                         return
             else:
                 if self.off_channel_sweep:
+                    # 2G budget minus 2×PEEK_S reserved for ch1+ch11
+                    primary_2g_s = self.dwell_2g_s - 2 * self.PEEK_S
                     self._set(self.PRIMARY_CHANNEL_2G)
-                    if self._sleep_s(self.DWELL_CH6_S):
+                    if self._sleep_s(primary_2g_s):
                         break
                     for ch in self.PEEK_CHANNELS_2G:
                         self._set(ch)
@@ -920,11 +996,11 @@ class DualBandHopper(threading.Thread):
                             return
                 else:
                     self._set(self.PRIMARY_CHANNEL_2G)
-                    if self._sleep_s(self.DWELL_CH6_FULL_S):
+                    if self._sleep_s(self.dwell_2g_s):
                         break
 
                 self._set(self.PRIMARY_CHANNEL_5G)
-                if self._sleep_s(self.DWELL_CH149_S):
+                if self._sleep_s(self.dwell_5g_s):
                     break
 
     def stop(self):
@@ -1665,6 +1741,7 @@ class WiFiFeeder:
 
     def run(self):
         log.info(f"DroneAware WiFi Feeder - Node: {self.node_id}")
+        _check_cli_freshness()
         target = self.hopper.target_channels
         log.info(f"Interface: {self.iface or '<not configured>'}  |  Hopper channels: {target}")
 


### PR DESCRIPTION
## Summary

Two independent issues surfaced during the v1.4.4 / v1.4.5 rollout, bundled here so operators pick up both in one `sudo droneaware update` hop.

## Fix 1 — `droneaware update` no longer silently fails to update the CLI

Previously, the CLI-download step in `cmd_update` used `curl -fsSL ... || true` and gated the install on `[[ -s /tmp/da_cli ]]`. If either guard fired (transient network hiccup, 5xx, truncated download), the update proceeded with new feeder binaries but a stale CLI, with zero diagnostic.

Only became painful in v1.4.0 when `install-webui` was added as the first subcommand that requires a fresh CLI — pre-v1.4.0, every subcommand existed in every CLI version, so silent CLI-update failures were harmless.

Surfaced 2026-06-30 via Warbird (NBG) + Kbrooks independently reporting `install-webui` returning "unknown command" after upgrading to v1.4.5.

**Changes:**
- Explicit `Downloading CLI...` log line
- Non-silent curl (drops `|| true`, checks exit code)
- Shebang sanity check catches captive-portal HTML / corrupt asset
- Manual-fix one-liner printed on any failure so operators can self-serve without Discord
- `CLI updated to vX.Y.Z.` on success

**Companion feeder-side warning:**
- `ble_feeder` + `wifi_feeder` grep `/usr/local/bin/droneaware` at startup for the v1.4.0+ `install-webui` marker
- WARN with the fix one-liner if missing
- Surfaces already-stuck operators without them needing to try `install-webui` to discover the problem

## Fix 2 — dual-band hopper defaults 20/10 → 3/2, now configurable

**New defaults:**
- `WIFI_DWELL_2G_SEC=3` (was hardcoded 20)
- `WIFI_DWELL_5G_SEC=2` (was hardcoded 10)
- 5s total cycle (was 30s) — ~6x faster

**Both env-configurable** — operators can weight toward one band without going all-in on `FIXED_CHANNEL`:

| Case | Config |
|---|---|
| Skydio-DFR-heavy area (weight 5 GHz) | `WIFI_DWELL_2G_SEC=1  WIFI_DWELL_5G_SEC=4` |
| DJI-heavy area (weight 2.4 GHz) | `WIFI_DWELL_2G_SEC=4  WIFI_DWELL_5G_SEC=1` |
| Balanced fast cycle | defaults (3s / 2s) |
| Full lock to one band | `FIXED_CHANNEL=6` or `FIXED_CHANNEL=149` |

`migrate_config_env` writes the new keys with a full comment block explaining the tuning knobs and giving worked examples.

Single-band adapters unaffected — they use `SingleBandHopper` with its own separate `DWELL_CH6_MS` knob for sub-second sweep dwell.

## Behavior-change notes for operators

- Existing dual-band nodes see substantially faster hopping after update. Slightly higher CPU (more channel switches) traded for meaningfully better catch rate on fast-moving drones.
- Nodes that had customized the hardcoded class constants by editing `wifi_feeder.py` directly will lose those customizations on update. Move to the env-var config instead.

## Files touched

| File | +/- | Why |
|---|---|---|
| `droneaware` | +79/-6 | Loud CLI update in `cmd_update` + new dwell keys in `migrate_config_env` |
| `wifi_feeder.py` | +101/-11 | `_check_cli_freshness()` + dual-band hopper env vars + reduced defaults + updated startup log |
| `ble_feeder.py` | +24 | `_check_cli_freshness()` mirrored from wifi_feeder |
| `CHANGELOG.md` | +72 | v1.4.6 entry with behavior-change callouts |