### PR TITLE
v1.4.7: feeder-side CLI auto-heal (unsticks pre-v1.4.6 operators)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,82 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.7] — Unreleased
+
+Closes the last mile of the silent-CLI-update saga from v1.4.5 / v1.4.6.
+v1.4.6 made `cmd_update` non-silent (any future CLI download failure prints
+loudly + gives the fix command) and added feeder-side WARN detection of
+stuck CLIs — but operators **already** stuck on a pre-v1.4.6 CLI couldn't
+get the fix via `sudo droneaware update`, because their old (silent-failure)
+`cmd_update` is what runs during the update. Kbrooks confirmed this on
+2026-07-13: after updating to v1.4.6, his CLI mtime was still 2026-05-10
+(pre-v1.4.0) with zero `install-webui` occurrences — the v1.4.6 update
+had bumped his feeder binaries but silently failed to update the CLI,
+just like every prior update had.
+
+v1.4.7 fixes this by putting the auto-heal in the FEEDER binaries — the
+one part of the update path that reliably succeeds even for stuck
+operators. On next `droneaware update`, stuck operators get:
+
+1. New v1.4.7 feeder binaries download → ✅ (feeder updates always work)
+2. CLI download silently fails → CLI stays stuck (same as always)
+3. Feeders restart with the new v1.4.7 code
+4. **Feeder's `_check_cli_freshness()` runs at startup, detects stale CLI,
+   downloads current CLI from `/releases/latest/download/droneaware`,
+   sanity-checks it, atomic-mv's it into `/usr/local/bin/droneaware`, and
+   logs `Auto-healed stale CLI`.**
+5. Operator's next `sudo droneaware install-webui` works — with no manual
+   command, no Discord archaeology, no awareness that anything was
+   ever broken.
+
+### Added
+
+- **Feeder-side CLI auto-heal.** `ble_feeder` and `wifi_feeder` now
+  actively repair a stale `/usr/local/bin/droneaware` at startup, not
+  just warn about it. Behavior:
+  - Grep the CLI for the v1.4.0+ `install-webui` marker (unchanged
+    from v1.4.6)
+  - If missing: fetch the current CLI from
+    `/releases/latest/download/droneaware` via `urllib` with a 10s
+    timeout
+  - Sanity-check the download: HTTP 200, non-empty, has a shebang,
+    contains `install-webui` itself (refuses to install a download
+    that would leave the operator in the same stuck state)
+  - Atomic-mv into `/usr/local/bin/droneaware` via `.new` intermediate
+  - Log `Auto-healed stale CLI at /usr/local/bin/droneaware` on success
+  - On any failure (offline, GitHub unreachable, download corrupt,
+    permissions): fall back to the v1.4.6 WARN with the manual-fix
+    one-liner
+  - **Non-blocking** — feeder startup is bounded to 10s of extra
+    latency in the worst case; healthy nodes (fresh CLI) skip the
+    heal path entirely and see no delay
+
+### Why the auto-heal was needed even after v1.4.6
+
+The v1.4.6 fix prevented the silent-failure trap from claiming NEW
+victims — any operator whose CLI already had v1.4.6's loud-error
+`cmd_update` would see any future CLI-download failure loudly, plus
+the manual-fix command in-terminal. But it did nothing for the
+operators who had already fallen into the trap in a pre-v1.4.6 update.
+Two field-confirmed cases at time of v1.4.7 (Kbrooks, Warbird/NBG),
+plus an unknown-but-nonzero silent tail across the fleet who haven't
+tried `install-webui` yet.
+
+v1.4.7 closes this by making the fix delivery channel be the FEEDER,
+not the CLI. Feeder-binary updates work reliably even for stuck-CLI
+operators; the auto-heal ships to them there.
+
+### Not changed
+
+- `cmd_update`'s loud-error CLI download from v1.4.6 stays. It's the
+  first line of defense (prevents new stuck cases). The feeder
+  auto-heal is the second line (unsticks anyone who's already stuck).
+- Dual-band dwell defaults from v1.4.6 (3s ch6 / 2s ch149) unchanged.
+- No config.env keys added.
+- No new server-side dependencies. Auto-heal uses stdlib only.
+
+---
+
 ## [1.4.6] — Unreleased
 
 Two independent issues surfaced during the v1.4.4 / v1.4.5 rollout. Both

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -45,26 +45,111 @@ logging.basicConfig(
 log = logging.getLogger("droneaware.ble")
 
 
+CLI_PATH = "/usr/local/bin/droneaware"
+CLI_LATEST_URL = (
+    "https://github.com/fduflyer/DroneAware-Node-Releases/"
+    "releases/latest/download/droneaware"
+)
+
+
 def _check_cli_freshness():
-    """Warn if /usr/local/bin/droneaware appears older than the feeder binaries.
-    See wifi_feeder.py:_check_cli_freshness for the rationale — same check,
-    same message, mirrored here so operators see the warning regardless of
-    which feeder starts first in their journalctl."""
-    cli_path = "/usr/local/bin/droneaware"
+    """Detect + auto-heal a stale /usr/local/bin/droneaware CLI at feeder
+    startup. Mirror of wifi_feeder.py:_check_cli_freshness — see there for
+    the full rationale. Mirrored here so operators see the auto-heal
+    regardless of which feeder starts first in their journalctl. v1.4.7
+    added the auto-heal behavior; v1.4.6 was WARN-only."""
     try:
-        with open(cli_path) as f:
+        with open(CLI_PATH) as f:
             content = f.read()
     except Exception:
         return
-    if "install-webui" not in content:
-        log.warning(
-            f"{cli_path} appears older than the installed feeders "
-            "(missing v1.4.0+ install-webui subcommand). A previous "
-            "`droneaware update` likely failed silently to update the CLI. "
-            "Fix with: sudo curl -fsSL "
-            "https://github.com/fduflyer/DroneAware-Node-Releases/releases/latest/download/droneaware "
-            "-o /usr/local/bin/droneaware && sudo chmod +x /usr/local/bin/droneaware"
+    if "install-webui" in content:
+        return
+
+    log.warning(
+        f"{CLI_PATH} appears stale (missing v1.4.0+ install-webui marker). "
+        f"Attempting auto-heal from {CLI_LATEST_URL} ..."
+    )
+    if _try_heal_cli():
+        log.info(f"Auto-healed stale CLI at {CLI_PATH}")
+        return
+
+    log.warning(
+        f"Auto-heal failed — {CLI_PATH} remains stale. Fix manually: "
+        f"sudo curl -fsSL {CLI_LATEST_URL} -o {CLI_PATH} && "
+        f"sudo chmod +x {CLI_PATH}"
+    )
+
+
+def _try_heal_cli() -> bool:
+    """Download the current CLI from /releases/latest, sanity-check it,
+    atomic-mv into CLI_PATH. Mirror of wifi_feeder.py:_try_heal_cli."""
+    import shutil
+    import urllib.request
+
+    tmp_path = f"/tmp/da_cli_selfheal_{os.getpid()}"
+    try:
+        req = urllib.request.Request(
+            CLI_LATEST_URL,
+            headers={"User-Agent": f"DroneAware-Feeder-SelfHeal/{FW_VERSION}"},
         )
+        with urllib.request.urlopen(req, timeout=10) as response:
+            if response.status != 200:
+                log.warning(f"Auto-heal fetch: HTTP {response.status}")
+                return False
+            with open(tmp_path, "wb") as out:
+                shutil.copyfileobj(response, out)
+    except Exception as e:
+        log.warning(f"Auto-heal fetch failed: {e}")
+        return False
+
+    try:
+        with open(tmp_path, "rb") as f:
+            first_line = f.readline()
+        if not first_line.startswith(b"#!"):
+            log.warning("Auto-heal: downloaded CLI has no shebang — refusing to install")
+            try: os.unlink(tmp_path)
+            except Exception: pass
+            return False
+    except Exception as e:
+        log.warning(f"Auto-heal sanity check failed: {e}")
+        return False
+
+    try:
+        with open(tmp_path) as f:
+            fresh_content = f.read()
+        if "install-webui" not in fresh_content:
+            log.warning(
+                "Auto-heal: downloaded CLI is itself missing install-webui — "
+                "not overwriting on-disk CLI"
+            )
+            try: os.unlink(tmp_path)
+            except Exception: pass
+            return False
+    except Exception as e:
+        log.warning(f"Auto-heal marker check failed: {e}")
+        return False
+
+    try:
+        new_path = CLI_PATH + ".new"
+        shutil.copy(tmp_path, new_path)
+        os.chmod(new_path, 0o755)
+        os.rename(new_path, CLI_PATH)
+        try: os.unlink(tmp_path)
+        except Exception: pass
+        return True
+    except PermissionError:
+        log.warning(
+            f"Auto-heal: insufficient permissions to write {CLI_PATH} "
+            "(feeder should run as root — check the systemd unit)"
+        )
+    except Exception as e:
+        log.warning(f"Auto-heal install failed: {e}")
+
+    for p in (tmp_path, CLI_PATH + ".new"):
+        try: os.unlink(p)
+        except Exception: pass
+    return False
 
 
 def _read_fw_version(fallback: str) -> str:

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -47,33 +47,142 @@ logging.basicConfig(
 log = logging.getLogger("droneaware.wifi")
 
 
+CLI_PATH = "/usr/local/bin/droneaware"
+CLI_LATEST_URL = (
+    "https://github.com/fduflyer/DroneAware-Node-Releases/"
+    "releases/latest/download/droneaware"
+)
+
+
 def _check_cli_freshness():
-    """Warn if /usr/local/bin/droneaware appears older than the feeder binaries.
-    Surfaces the silent CLI-update failure mode where `droneaware update` runs
-    the CLI-download step, hits a transient error, swallows it with `|| true`,
-    and leaves the operator with new feeders + stale CLI. Silent since v1.1.1
-    when CLI self-update shipped; only became painful in v1.4.0 when
-    `install-webui` became the first subcommand that requires a fresh CLI.
-    v1.4.6 makes cmd_update's download failures loud AND surfaces already-stuck
-    CLIs here — this warning appears every service start until the operator
-    runs the manual-fix one-liner. Non-blocking; feeder still runs."""
-    cli_path = "/usr/local/bin/droneaware"
+    """Detect + auto-heal a stale /usr/local/bin/droneaware CLI at feeder
+    startup. Surfaces the silent CLI-update failure mode where `droneaware
+    update` runs the CLI-download step, hits a transient error, swallows it
+    with `|| true`, and leaves the operator with new feeders + stale CLI.
+
+    Silent since v1.1.1 when CLI self-update shipped; only became painful in
+    v1.4.0 when `install-webui` became the first subcommand that requires a
+    fresh CLI. v1.4.6 made cmd_update's download failures loud AND warned on
+    stale CLIs here — but that WARN required the operator to run a manual
+    curl one-liner to fix.
+
+    v1.4.7 turns the warning into an auto-heal: if the CLI is stale, the
+    feeder itself downloads the current CLI from /releases/latest and
+    atomic-mv's it into place. Why this works despite the chicken-and-egg:
+    feeder BINARIES update reliably (only the CLI-update step in cmd_update
+    silently fails). So operators already stuck get auto-fixed on their
+    NEXT `droneaware update` — no user action, no Discord archaeology.
+
+    Non-blocking. If the auto-heal fetch fails (offline, GitHub unreachable),
+    falls back to the v1.4.6 WARN with manual-fix instructions."""
     try:
-        with open(cli_path) as f:
+        with open(CLI_PATH) as f:
             content = f.read()
     except Exception:
-        return  # CLI missing or unreadable — not our concern here
-    # `install-webui` was added in v1.4.0. If the CLI on-disk doesn't have it,
-    # the CLI is stale relative to a v1.4.0+ feeder binary.
-    if "install-webui" not in content:
-        log.warning(
-            f"{cli_path} appears older than the installed feeders "
-            "(missing v1.4.0+ install-webui subcommand). A previous "
-            "`droneaware update` likely failed silently to update the CLI. "
-            "Fix with: sudo curl -fsSL "
-            "https://github.com/fduflyer/DroneAware-Node-Releases/releases/latest/download/droneaware "
-            "-o /usr/local/bin/droneaware && sudo chmod +x /usr/local/bin/droneaware"
+        return  # CLI missing/unreadable — bigger problem, not our fix
+    # `install-webui` was added in v1.4.0. If it's absent, the CLI on-disk
+    # is stale relative to a v1.4.0+ feeder binary.
+    if "install-webui" in content:
+        return  # CLI is fresh, nothing to do
+
+    log.warning(
+        f"{CLI_PATH} appears stale (missing v1.4.0+ install-webui marker). "
+        f"Attempting auto-heal from {CLI_LATEST_URL} ..."
+    )
+    if _try_heal_cli():
+        log.info(f"Auto-healed stale CLI at {CLI_PATH}")
+        return
+
+    # Auto-heal failed — fall back to the v1.4.6 WARN + manual-fix path.
+    log.warning(
+        f"Auto-heal failed — {CLI_PATH} remains stale. Fix manually: "
+        f"sudo curl -fsSL {CLI_LATEST_URL} -o {CLI_PATH} && "
+        f"sudo chmod +x {CLI_PATH}"
+    )
+
+
+def _try_heal_cli() -> bool:
+    """Download the current CLI from /releases/latest, sanity-check it,
+    atomic-mv into CLI_PATH. Returns True on success, False on any failure.
+    Uses only stdlib to avoid adding dependencies for a code path that
+    should almost never fire (needs both the stuck-CLI condition and a
+    feeder restart to trigger)."""
+    import shutil
+    import urllib.request
+
+    tmp_path = f"/tmp/da_cli_selfheal_{os.getpid()}"
+    try:
+        req = urllib.request.Request(
+            CLI_LATEST_URL,
+            headers={"User-Agent": f"DroneAware-Feeder-SelfHeal/{FW_VERSION}"},
         )
+        # 10s timeout keeps feeder startup bounded even on flaky networks.
+        with urllib.request.urlopen(req, timeout=10) as response:
+            if response.status != 200:
+                log.warning(f"Auto-heal fetch: HTTP {response.status}")
+                return False
+            with open(tmp_path, "wb") as out:
+                shutil.copyfileobj(response, out)
+    except Exception as e:
+        log.warning(f"Auto-heal fetch failed: {e}")
+        return False
+
+    # Shebang sanity check — catches captive-portal HTML, corrupt asset, etc.
+    # Same defensive posture v1.4.6's cmd_update uses.
+    try:
+        with open(tmp_path, "rb") as f:
+            first_line = f.readline()
+        if not first_line.startswith(b"#!"):
+            log.warning("Auto-heal: downloaded CLI has no shebang — refusing to install")
+            try: os.unlink(tmp_path)
+            except Exception: pass
+            return False
+    except Exception as e:
+        log.warning(f"Auto-heal sanity check failed: {e}")
+        return False
+
+    # Also require the marker we look for — if the downloaded file itself is
+    # missing install-webui, either GitHub is serving something weird or the
+    # download got interrupted. Refuse to overwrite the on-disk CLI with
+    # something that would leave the operator in the same stuck state.
+    try:
+        with open(tmp_path) as f:
+            fresh_content = f.read()
+        if "install-webui" not in fresh_content:
+            log.warning(
+                "Auto-heal: downloaded CLI is itself missing install-webui — "
+                "not overwriting on-disk CLI"
+            )
+            try: os.unlink(tmp_path)
+            except Exception: pass
+            return False
+    except Exception as e:
+        log.warning(f"Auto-heal marker check failed: {e}")
+        return False
+
+    # Atomic mv via .new intermediate — matches cmd_update's pattern for
+    # safely replacing a bash script that could be concurrently executing.
+    try:
+        new_path = CLI_PATH + ".new"
+        shutil.copy(tmp_path, new_path)
+        os.chmod(new_path, 0o755)
+        os.rename(new_path, CLI_PATH)
+        try: os.unlink(tmp_path)
+        except Exception: pass
+        return True
+    except PermissionError:
+        log.warning(
+            f"Auto-heal: insufficient permissions to write {CLI_PATH} "
+            "(feeder should run as root — check the systemd unit)"
+        )
+    except Exception as e:
+        log.warning(f"Auto-heal install failed: {e}")
+
+    # Cleanup on any failure path
+    for p in (tmp_path, CLI_PATH + ".new"):
+        try: os.unlink(p)
+        except Exception: pass
+    return False
 
 
 def _read_fw_version(fallback: str) -> str:


### PR DESCRIPTION
## Summary

Retires the "run this manual curl one-liner" answer to the stuck-CLI bug. v1.4.6 made `cmd_update` non-silent and added feeder-side WARN detection — but that only helps operators whose CLI is already at v1.4.6+ or later. Operators already stuck on a pre-v1.4.6 CLI (Kbrooks / Warbird / an unknown silent tail across the fleet) couldn't get the fix via `sudo droneaware update`, because their old silent-failure `cmd_update` is what runs during the update.

## The chicken-and-egg, resolved

Feeder-binary updates work reliably even for stuck-CLI operators — the silent failure only affects the CLI-download step within `cmd_update`, not the feeder-binary downloads. So the fix ships in the FEEDER, not the CLI.

On next `sudo droneaware update` for a stuck operator:

1. New v1.4.7 feeder binaries download → ✅ (works, as always)
2. CLI download silently fails → CLI stays stuck (as always)
3. Feeders restart with the new v1.4.7 code
4. **`_check_cli_freshness()` runs at startup → detects stale CLI → downloads current CLI from `/releases/latest/download/droneaware` → sanity-checks → atomic-mv's into place → logs `Auto-healed stale CLI`**
5. `sudo droneaware install-webui` works. No manual step. No Discord archaeology. No operator awareness that anything was broken.

## Confirmed field cases this fixes (without operator action)

- **Kbrooks** — confirmed 2026-07-13 via diagnostic: CLI mtime `2026-05-10`, 0 `install-webui` matches, `firmware=v1.4.6`. Stuck across 4+ updates.
- **Warbird / Nate B Gibson / `homelan`** — confirmed 2026-06-30; fixed manually via curl one-liner.
- **Silent tail** — unknown count of operators who never tried `install-webui` and don't yet know they're stuck.

## Implementation

- `wifi_feeder.py` + `ble_feeder.py` both get enhanced `_check_cli_freshness()` + new `_try_heal_cli()`
- **stdlib only** (`urllib.request` + `shutil`) — no new dependencies
- **10-second timeout** on the CLI fetch — bounded startup latency worst case
- **Defensive sanity checks** on the download: HTTP 200, non-empty, valid shebang, contains `install-webui` marker itself (refuses to install a download that would leave the operator equally stuck)
- **Atomic-mv via `.new` intermediate** — safe for self-modifying bash scripts, matches `cmd_update`'s pattern
- **Non-blocking** — healthy nodes (fresh CLI) skip the heal path entirely, zero startup delay; stuck nodes get a 10s worst-case delay before proceeding

## What v1.4.6 does vs what v1.4.7 does

| Release | Prevents new stuck cases | Unsticks already-stuck operators |
|---|---|---|
| v1.4.6 | ✅ (loud `cmd_update` errors + WARN in `journalctl`) | ❌ (WARN tells them to run manual fix) |
| v1.4.7 | ✅ (v1.4.6's fix still active) | ✅ (feeder auto-heals on next update) |

Together, they permanently retire the "manual curl fix" as the answer.

## Not changed

- v1.4.6's loud-error `cmd_update` behavior (still first line of defense)
- Dual-band dwell defaults from v1.4.6 (3s ch6 / 2s ch149)
- No config.env keys added
- No server-side dependencies added

## Files touched

| File | +/- | Why |
|---|---|---|
| `wifi_feeder.py` | +151/-15 | Auto-heal in `_check_cli_freshness()` + new `_try_heal_cli()` |
| `ble_feeder.py` | +111/-15 | Mirror of the wifi_feeder auto-heal |
| `CHANGELOG.md` | +76 | v1.4.7 entry |