### PR TITLE
v1.4.8: fix BLE async starvation + fleet-wide backlog telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,21 +102,35 @@ tailing `journalctl` see the same story the server does.
   `DualBandHopper`'s own startup log (which reports the real
   timing) speak for itself.
 
+- **WiFi feeder `Forwarder` — same class of fix, different mechanism.**
+  Initial v1.4.8 draft only fixed BLE, on the theory that "WiFi's
+  threading model is less exposed." Re-examination during PR review
+  proved that wrong: WiFi's `Forwarder._flush_locked()` held
+  `self._lock` **across** the 5s `requests.post`. The packet-capture
+  main thread's `add()` would sit blocked on that lock during every
+  slow POST — same functional outcome as the BLE async starvation
+  (packet loss + delayed heartbeat), just via lock contention instead
+  of event-loop starvation. We haven't observed it in the field only
+  because most aftermarket RID modules default to BLE and typical
+  WiFi RID sources are moving drones, not fixed beacons. A stationary
+  WiFi RID source (Skydio DFR ground node, someone's aftermarket
+  module set to WiFi) would trigger it.
+
+  Fix mirrors the BLE side: `Forwarder.add()` no longer triggers
+  sync flush at `batch_size`; new `Forwarder.should_flush()` +
+  `Forwarder.flush()`; `flush()` grabs the batch under lock, releases
+  the lock, does the network POST with no lock held, reacquires
+  briefly to re-queue on failure. Background `_flush_loop` thread
+  handles all flushing.
+
 ### Not fixed here (deferred to v1.4.9)
 
-- **WiFi feeder async model.** WiFi is threading-based, not asyncio,
-  so it's architecturally less exposed to the starvation pattern —
-  its packet handler runs in a different thread than the heartbeat.
-  The `Forwarder._flush()` sync-request-blocking pattern still
-  exists there but only stalls the heartbeat-tick thread, not the
-  packet capture. Left as-is; can revisit if we see similar signals
-  from WiFi-heavy nodes.
-
-- **Forwarder decoupling — sync `add()` still touches the buffer.**
-  Under extreme rates a lock on `self.buffer` between the scanner
-  thread and flush thread could add tail latency. Not observed
-  today; would need `asyncio.Queue` or an equivalent to fully
-  decouple. Waiting for evidence before restructuring.
+- **Full Forwarder decoupling — sync `add()` still touches the buffer.**
+  Even with the new pattern, the packet-capture threads hold
+  `self._lock` briefly to append to the buffer. Under extreme rates
+  this could add microsecond-level tail latency. Not observed today;
+  would need `asyncio.Queue` or an equivalent to fully decouple.
+  Waiting for evidence before restructuring.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,116 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.8] — Unreleased
+
+Node-side response to the **phillyrox saturation incident** (2026-07-16).
+A node parked next to a single continuous BLE Remote ID beacon (Potensic
+RID-916, ~9 broadcasts/sec sustained) went from 12% CPU / 0.15 load to
+70% CPU / load 4.4 in ~90 seconds, and stayed there for **14+ hours**.
+BLE detection dropped to ~17% of pre-onset rate. The BLE feeder's
+heartbeat went silent — but the process was still alive, its uptime
+counter still advancing, still processing (some) advertisements. The
+server had zero signal that anything was wrong.
+
+Full incident forensics in `phillyrox-forensics/` and
+`node-saturation-continuous-broadcaster.md` (server session, 2026-07-16).
+
+### Root cause
+
+The BLE feeder's async architecture puts the scanner-callback dispatch,
+the periodic forwarder flush (`Forwarder._flush()`), and the periodic
+heartbeat all on the **same asyncio event loop**, in the same coroutine
+task. Under sustained high-rate BLE traffic:
+
+- `on_advertisement` is invoked frequently by `bleak`
+- Each call runs through decode + 5 sub-message publishes for a
+  Message Pack (Potensic sends all 5 ASTM types packed)
+- `Forwarder._flush()` uses a **synchronous** `requests.post` with a
+  5s timeout, called from `add()` when the buffer reaches batch size —
+  blocking the entire event loop for the duration of every POST
+- If any flush hits its timeout / server slowness, the batch is
+  re-queued at the front of the buffer, growing the payload, extending
+  the next POST duration, etc. — a positive feedback loop
+- Once entered, the heartbeat coroutine (which shares the same task
+  as the scanner loop) can't get a slot on the event loop to fire its
+  POST. The process is alive but the server sees silence.
+
+### Fixed
+
+- **BLE feeder heartbeat now runs in its own asyncio task**
+  (`_heartbeat_loop`), scheduled via `asyncio.create_task()` in
+  `BLEFeeder.run()`. Even if the scanner loop is saturated, the
+  heartbeat coroutine gets its own turn on the loop.
+
+- **BLE feeder flush no longer blocks the event loop.**
+  `Forwarder.add()` no longer triggers a synchronous flush when the
+  buffer hits batch size. Instead the main scanner loop calls
+  `Forwarder.should_flush()` each tick, and when true awaits
+  `asyncio.to_thread(Forwarder._flush)` — the sync `requests.post`
+  runs on a worker thread and can't block advertisement dispatch or
+  heartbeat scheduling.
+
+- **BLE feeder heartbeat POST also runs via `asyncio.to_thread`.**
+  Removes the last remaining sync-request-in-event-loop pattern.
+
+### Added — telemetry the server didn't have on 2026-07-16
+
+Both feeders now include these fields in every heartbeat POST payload:
+
+- `buffered` — current forwarder buffer length (events)
+- `buffered_bytes` — current forwarder buffer size
+- `dropped_total` — cumulative events dropped from the byte-bounded
+  buffer (was in the `[Heartbeat]` log line but never in the POST
+  payload; Filer #24 requested this exact field)
+- `sent_total` — cumulative events successfully forwarded
+- `restarts_since_boot` — feeder restart counter, persisted at
+  `/run/droneaware/{ble,wifi}_feeder_restarts_since_boot` (tmpfs;
+  naturally resets on Pi boot). Surfaces crash-loop patterns the
+  server can't distinguish from healthy uptime today. phillyrox
+  bounced twice per feeder in its first 45 minutes of deployment
+  — invisible in the server heartbeat stream until we noticed the
+  cumulative uptime_s ratio didn't match wall clock.
+
+BLE feeder additionally sends:
+
+- `event_loop_max_lag_ms` — max delay between scheduled and actual
+  scanner-loop ticks since the last heartbeat. Under healthy load
+  this is 0–20ms; under saturation (phillyrox-style) it climbs into
+  the thousands. **Direct saturation signal**: server can now
+  alert on `event_loop_max_lag_ms > 500` fleet-wide instead of
+  reasoning about symptoms.
+
+`[Heartbeat]` log lines also gain the new counters so operators
+tailing `journalctl` see the same story the server does.
+
+### Also fixed
+
+- **WiFi feeder's leftover "30s cycle" hardcoded log line.**
+  v1.4.6 made the dwell times configurable but a stale log message
+  at `WifiFeeder.__init__` still printed "30s cycle" regardless of
+  actual `WIFI_DWELL_2G_SEC` / `WIFI_DWELL_5G_SEC`. Now says just
+  `Hopper mode: dual-band (ch6 + ch149)` and lets the
+  `DualBandHopper`'s own startup log (which reports the real
+  timing) speak for itself.
+
+### Not fixed here (deferred to v1.4.9)
+
+- **WiFi feeder async model.** WiFi is threading-based, not asyncio,
+  so it's architecturally less exposed to the starvation pattern —
+  its packet handler runs in a different thread than the heartbeat.
+  The `Forwarder._flush()` sync-request-blocking pattern still
+  exists there but only stalls the heartbeat-tick thread, not the
+  packet capture. Left as-is; can revisit if we see similar signals
+  from WiFi-heavy nodes.
+
+- **Forwarder decoupling — sync `add()` still touches the buffer.**
+  Under extreme rates a lock on `self.buffer` between the scanner
+  thread and flush thread could add tail latency. Not observed
+  today; would need `asyncio.Queue` or an equivalent to fully
+  decouple. Waiting for evidence before restructuring.
+
+---
+
 ## [1.4.7] — Unreleased
 
 Closes the last mile of the silent-CLI-update saga from v1.4.5 / v1.4.6.

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -51,6 +51,36 @@ CLI_LATEST_URL = (
     "releases/latest/download/droneaware"
 )
 
+# v1.4.8: per-feeder restart counter, since last Pi reboot.
+# Written to tmpfs so a Pi reboot naturally resets it. Server aggregates
+# "restarts_since_boot" alongside uptime and can detect crash-loop patterns
+# (feeder restarting every few minutes) that a raw fw_version + uptime don't
+# surface. Surfaced 2026-07-16 during the phillyrox saturation investigation:
+# the WiFi + BLE feeders had bounced twice each in the first 45 min of
+# deployment, which was invisible in the server's heartbeat stream.
+RESTART_COUNTER_PATH = "/run/droneaware/ble_feeder_restarts_since_boot"
+
+
+def _get_restart_count() -> int:
+    """Read + increment /run/droneaware/ble_feeder_restarts_since_boot.
+    Returns the post-increment value (1 for the first-ever start after
+    boot; 2+ for subsequent restarts). Any error → returns 0; telemetry
+    failures never block feeder startup."""
+    try:
+        os.makedirs("/run/droneaware", exist_ok=True)
+        try:
+            with open(RESTART_COUNTER_PATH) as f:
+                current = int(f.read().strip() or "0")
+        except (FileNotFoundError, ValueError):
+            current = 0
+        new_val = current + 1
+        with open(RESTART_COUNTER_PATH, "w") as f:
+            f.write(str(new_val))
+        return new_val
+    except Exception as e:
+        log.warning(f"Failed to update restart counter: {e}")
+        return 0
+
 
 def _check_cli_freshness():
     """Detect + auto-heal a stale /usr/local/bin/droneaware CLI at feeder
@@ -756,11 +786,26 @@ class Forwarder:
         self.buffer.append((event, size))
         self.buffer_bytes += size
         self._evict_to_cap()
+        # v1.4.8: batch-size trigger no longer flushes here. Under the async
+        # BLE architecture, on_advertisement runs on the event loop thread —
+        # a sync requests.post from here would block advertisement dispatch,
+        # heartbeat, and every other coroutine until the POST returns. The
+        # main scanner loop calls should_flush() and awaits an
+        # asyncio.to_thread(_flush) instead. See BLEFeeder.run() and
+        # phillyrox forensics (2026-07-16) for the full story.
+
+    def should_flush(self) -> bool:
+        """Advisory: True if buffer has reached batch_size OR flush_interval
+        elapsed since last flush. Cheap; safe to call every tick."""
+        if not self.buffer:
+            return False
         if len(self.buffer) >= self.batch_size:
-            self._flush()
+            return True
+        return time.monotonic() - self.last_flush >= self.flush_interval
 
     def tick(self):
-        """Time-based flush — call once per second from the main loop."""
+        """Time-based flush — call once per second from a NON-async context
+        (kept for callers that don't have an event loop, e.g., unit tests)."""
         if time.monotonic() - self.last_flush >= self.flush_interval:
             self._flush()
             self.last_flush = time.monotonic()
@@ -784,6 +829,12 @@ class Forwarder:
             self._warned_high = False
 
     def _flush(self):
+        # v1.4.8: always update last_flush at entry so should_flush() paces
+        # correctly even when the buffer is empty (previously would starve
+        # the timer if buffer was momentarily drained). Also runs from
+        # asyncio.to_thread() now, so this executes on a worker thread and
+        # never blocks the async event loop.
+        self.last_flush = time.monotonic()
         if not self.buffer:
             return
 
@@ -836,6 +887,13 @@ class BLEFeeder:
         self.forwarder    = Forwarder(server_url, node_id, batch_size, flush_interval, token)
         self.publisher    = LocalPublisher()
         self.count        = 0
+        # v1.4.8 telemetry: restart count (see phillyrox incident) + event
+        # loop lag tracker (max delay between scheduled and actual scanner
+        # loop ticks, reset every heartbeat). Under healthy load lag is
+        # 0-20ms; a lag of thousands of ms is the direct signature of the
+        # phillyrox saturation state.
+        self.restart_count           = _get_restart_count()
+        self.max_lag_ms_this_interval = 0
 
     def on_advertisement(self, device: BLEDevice, adv: AdvertisementData):
         """Callback for every BLE advertisement containing UUID 0xFFFA service data."""
@@ -937,6 +995,9 @@ class BLEFeeder:
                         "ble_ok":       False,
                         "ble_adapter":  self.adapter,
                         "ble_fault":    reason,
+                        # v1.4.8: restart count meaningful even in FAULT
+                        # (a crash-looping FAULT feeder should be visible).
+                        "restarts_since_boot": self.restart_count,
                     },
                     headers={"X-Node-Token": self.token},
                     timeout=5,
@@ -979,58 +1040,126 @@ class BLEFeeder:
             adapter=self.adapter,
         )
 
-        async with scanner:
-            ticker = 0
-            while True:
-                await asyncio.sleep(1.0)
-                self.forwarder.tick()
-                ticker += 1
+        # v1.4.8: heartbeat runs in its own asyncio task, independent of
+        # the scanner loop. Even if the scanner loop is saturated processing
+        # advertisement callbacks (as phillyrox was 2026-07-16), the
+        # heartbeat coroutine still gets its own turn on the event loop.
+        # Scanner-loop flushes go through asyncio.to_thread so the sync
+        # requests.post inside Forwarder._flush never blocks the loop
+        # dispatch. Both changes together should make it impossible for
+        # a single burst of BLE traffic to make a node go silent from
+        # the server's perspective.
+        heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        try:
+            async with scanner:
+                last_tick_time = time.monotonic()
+                while True:
+                    await asyncio.sleep(1.0)
 
-                if ticker % 60 == 0:
-                    cpu_temp        = get_cpu_temp()
-                    cpu_pct         = get_cpu_percent()
-                    load_1m, load_5m, load_15m = get_cpu_load()
-                    ble_ok, ble_adp = get_ble_health(self.adapter)
-                    temp_str    = f"{cpu_temp}°C" if cpu_temp is not None else "n/a"
-                    cpu_pct_str = f"{cpu_pct:.1f}%" if cpu_pct is not None else "n/a"
-                    load_str    = f"{load_1m:.2f}" if load_1m is not None else "n/a"
+                    # Measure event loop lag: how much MORE than 1.0s the
+                    # scheduled sleep actually took. Under healthy load
+                    # this is 0-20ms. Under saturation (phillyrox-style)
+                    # this climbs into the thousands of ms.
+                    now = time.monotonic()
+                    lag_ms = max(0, int((now - last_tick_time - 1.0) * 1000))
+                    if lag_ms > self.max_lag_ms_this_interval:
+                        self.max_lag_ms_this_interval = lag_ms
+                    last_tick_time = now
 
-                    log.info(
-                        f"[Heartbeat] seen={self.count}  "
-                        f"sent={self.forwarder.sent_total}  "
-                        f"dropped={self.forwarder.dropped_total}  "
-                        f"buffered={len(self.forwarder.buffer)}  "
-                        f"temp={temp_str}  cpu={cpu_pct_str}  load={load_str}  ble={ble_ok}"
-                    )
-                    if self.token:
+                    # Flush via a worker thread — sync requests.post inside
+                    # Forwarder._flush no longer blocks the async loop.
+                    if self.forwarder.should_flush():
                         try:
-                            requests.post(
-                                "https://api.droneaware.io/api/node/heartbeat",
-                                json={
-                                    # Per-feeder heartbeat: ble_* fields only.
-                                    # Do NOT include wifi_ok or wifi_fault — the
-                                    # server uses presence of an ok-field to
-                                    # route the heartbeat to that feeder's
-                                    # status row. WiFi status comes from
-                                    # wifi_feeder's own heartbeat.
-                                    "node_id":      self.node_id,
-                                    "uptime_s":     int(time.monotonic() - self.start_time),
-                                    "fw_version":   FW_VERSION,
-                                    "cpu_count":    os.cpu_count(),
-                                    "cpu_temp_c":   cpu_temp,
-                                    "cpu_percent":  cpu_pct,
-                                    "load_1m":      load_1m,
-                                    "load_5m":      load_5m,
-                                    "load_15m":     load_15m,
-                                    "ble_ok":       ble_ok,
-                                    "ble_adapter":  ble_adp,
-                                },
-                                headers={"X-Node-Token": self.token},
-                                timeout=5,
-                            )
-                            log.debug("Heartbeat sent to droneaware.io")
-                        except requests.RequestException as e:
-                            log.warning(f"Heartbeat failed: {e}")
+                            await asyncio.to_thread(self.forwarder._flush)
+                        except Exception as e:
+                            log.warning(f"Forwarder flush task failed: {e}")
+        finally:
+            heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def _heartbeat_loop(self):
+        """v1.4.8: heartbeat runs here, in a dedicated asyncio task, so it
+        cannot be starved by scanner-callback processing. Sends the same
+        payload as pre-v1.4.8 plus new telemetry fields:
+          - dropped_total, buffered, buffered_bytes: forwarder backlog
+            state (Filer #24)
+          - restart_count: feeder restarts since Pi boot
+          - event_loop_lag_ms: max scanner-loop tick lag since last
+            heartbeat (direct saturation indicator)
+        POST goes via asyncio.to_thread so the 5s timeout can't block
+        the scanner loop even if this task shares the same worker pool."""
+        while True:
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                return
+
+            try:
+                cpu_temp        = get_cpu_temp()
+                cpu_pct         = get_cpu_percent()
+                load_1m, load_5m, load_15m = get_cpu_load()
+                ble_ok, ble_adp = get_ble_health(self.adapter)
+                temp_str    = f"{cpu_temp}°C" if cpu_temp is not None else "n/a"
+                cpu_pct_str = f"{cpu_pct:.1f}%" if cpu_pct is not None else "n/a"
+                load_str    = f"{load_1m:.2f}" if load_1m is not None else "n/a"
+
+                # Snapshot lag for this interval, then reset for next.
+                lag_ms = self.max_lag_ms_this_interval
+                self.max_lag_ms_this_interval = 0
+
+                log.info(
+                    f"[Heartbeat] seen={self.count}  "
+                    f"sent={self.forwarder.sent_total}  "
+                    f"dropped={self.forwarder.dropped_total}  "
+                    f"buffered={len(self.forwarder.buffer)}  "
+                    f"lag_ms={lag_ms}  "
+                    f"restarts={self.restart_count}  "
+                    f"temp={temp_str}  cpu={cpu_pct_str}  load={load_str}  ble={ble_ok}"
+                )
+                if self.token:
+                    try:
+                        await asyncio.to_thread(
+                            requests.post,
+                            "https://api.droneaware.io/api/node/heartbeat",
+                            json={
+                                # Per-feeder heartbeat: ble_* fields only.
+                                # Do NOT include wifi_ok or wifi_fault — the
+                                # server uses presence of an ok-field to
+                                # route the heartbeat to that feeder's
+                                # status row.
+                                "node_id":                    self.node_id,
+                                "uptime_s":                   int(time.monotonic() - self.start_time),
+                                "fw_version":                 FW_VERSION,
+                                "cpu_count":                  os.cpu_count(),
+                                "cpu_temp_c":                 cpu_temp,
+                                "cpu_percent":                cpu_pct,
+                                "load_1m":                    load_1m,
+                                "load_5m":                    load_5m,
+                                "load_15m":                   load_15m,
+                                "ble_ok":                     ble_ok,
+                                "ble_adapter":                ble_adp,
+                                # v1.4.8 telemetry additions:
+                                "buffered":                   len(self.forwarder.buffer),
+                                "buffered_bytes":             self.forwarder.buffer_bytes,
+                                "dropped_total":              self.forwarder.dropped_total,
+                                "sent_total":                 self.forwarder.sent_total,
+                                "restarts_since_boot":        self.restart_count,
+                                "event_loop_max_lag_ms":      lag_ms,
+                            },
+                            headers={"X-Node-Token": self.token},
+                            timeout=5,
+                        )
+                        log.debug("Heartbeat sent to droneaware.io")
+                    except requests.RequestException as e:
+                        log.warning(f"Heartbeat failed: {e}")
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                # Catch-all — never let a heartbeat exception kill the task.
+                log.warning(f"Heartbeat loop error (continuing): {e}")
 
 
 # -- Enrollment ----------------------------------------------------------------

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -1292,14 +1292,68 @@ class Forwarder:
             self.buffer.append((event, size))
             self.buffer_bytes += size
             self._evict_to_cap_locked()
+            # v1.4.8: no more sync _flush_locked here. Previously this held
+            # self._lock across a 5s requests.post — under sustained WiFi
+            # RID traffic the packet-capture main thread would sit blocked
+            # in add() while the kernel socket buffer overflowed and
+            # dropped packets silently. Mirrors the phillyrox failure
+            # mode we observed on the BLE side 2026-07-16. Flushing is
+            # now handled entirely by the background _flush_loop thread
+            # via should_flush() + flush().
+
+    def should_flush(self) -> bool:
+        """Advisory: True if a flush is due. Called from background thread."""
+        with self._lock:
+            if not self.buffer:
+                return False
             if len(self.buffer) >= self.batch_size:
-                self._flush_locked()
+                return True
+            return time.time() - self.last_flush >= self.flush_interval
 
     def tick(self):
+        """v1.4.8: kept for API compatibility, delegates to flush() which
+        takes the lock only for the batch-swap, NOT for the network POST."""
+        if self.should_flush():
+            self.flush()
+
+    def flush(self):
+        """Take a batch under lock, release lock during network POST, then
+        reacquire briefly to re-queue on failure. Critical: never hold
+        self._lock across the requests.post — that's what caused the
+        BLE-side analog of the phillyrox saturation and would do the
+        same here under a fixed WiFi RID source."""
         with self._lock:
-            if time.time() - self.last_flush >= self.flush_interval:
-                self._flush_locked()
-                self.last_flush = time.time()
+            if not self.buffer:
+                return
+            batch = list(self.buffer)
+            self.buffer.clear()
+            self.buffer_bytes = 0
+            self.last_flush = time.time()
+
+        # Network POST OUTSIDE the lock — main thread's add() can keep
+        # accepting new events during the (potentially 5s) request.
+        events = [e for e, _ in batch]
+        payload = {"node_id": self.node_id, "events": events}
+        try:
+            headers = {"X-Node-Token": self.token} if self.token else {}
+            r = requests.post(self.url, json=payload, headers=headers, timeout=5)
+            r.raise_for_status()
+            self.sent_total += len(events)
+            log.debug(f"Forwarded {len(events)} events ({self.sent_total} total)")
+        except requests.RequestException as e:
+            with self._lock:
+                for event, size in reversed(batch):
+                    self.buffer.appendleft((event, size))
+                    self.buffer_bytes += size
+                self.failed_total += len(events)
+                self._evict_to_cap_locked()
+            log.warning(
+                f"Forward failed: {e}  "
+                f"(buffered={len(self.buffer)}, "
+                f"buffer_bytes={self.buffer_bytes}, "
+                f"failed_total={self.failed_total}, "
+                f"dropped_total={self.dropped_total})"
+            )
 
     def _evict_to_cap_locked(self):
         """Drop oldest events until buffer_bytes <= max_buffer_bytes. Logs
@@ -1319,34 +1373,12 @@ class Forwarder:
             log.info(f"Forwarder buffer drained to {pct}% — caught up")
             self._warned_high = False
 
-    def _flush_locked(self):
-        if not self.buffer:
-            return
-        batch = list(self.buffer)
-        self.buffer.clear()
-        self.buffer_bytes = 0
-        events = [e for e, _ in batch]
-        payload = {"node_id": self.node_id, "events": events}
-        try:
-            headers = {"X-Node-Token": self.token} if self.token else {}
-            r = requests.post(self.url, json=payload, headers=headers, timeout=5)
-            r.raise_for_status()
-            self.sent_total += len(events)
-            log.debug(f"Forwarded {len(events)} events ({self.sent_total} total)")
-        except requests.RequestException as e:
-            # Re-queue failed events at the front. Any that no longer fit
-            # under the byte cap get evicted via _evict_to_cap_locked below.
-            for event, size in reversed(batch):
-                self.buffer.appendleft((event, size))
-                self.buffer_bytes += size
-            self.failed_total += len(events)
-            self._evict_to_cap_locked()
-            log.warning(
-                f"Forward failed: {e}  "
-                f"(buffered={len(self.buffer)}, "
-                f"buffer_bytes={self.buffer_bytes}, "
-                f"dropped_total={self.dropped_total})"
-            )
+    # v1.4.8: _flush_locked removed. Its logic was inlined into flush()
+    # above with a critical fix: the network POST now runs OUTSIDE the
+    # buffer lock. The old pattern held self._lock across a 5s request
+    # timeout, blocking the packet-capture main thread's add() calls and
+    # causing kernel socket buffer overflow under sustained WiFi RID
+    # traffic — the same failure mode we observed on BLE at phillyrox.
 
 
 # -- GPS Reader ----------------------------------------------------------------

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -53,6 +53,29 @@ CLI_LATEST_URL = (
     "releases/latest/download/droneaware"
 )
 
+# v1.4.8: per-feeder restart counter, since last Pi reboot.
+# See ble_feeder.py for the full rationale.
+RESTART_COUNTER_PATH = "/run/droneaware/wifi_feeder_restarts_since_boot"
+
+
+def _get_restart_count() -> int:
+    """Read + increment /run/droneaware/wifi_feeder_restarts_since_boot.
+    See ble_feeder.py:_get_restart_count for details."""
+    try:
+        os.makedirs("/run/droneaware", exist_ok=True)
+        try:
+            with open(RESTART_COUNTER_PATH) as f:
+                current = int(f.read().strip() or "0")
+        except (FileNotFoundError, ValueError):
+            current = 0
+        new_val = current + 1
+        with open(RESTART_COUNTER_PATH, "w") as f:
+            f.write(str(new_val))
+        return new_val
+    except Exception as e:
+        log.warning(f"Failed to update restart counter: {e}")
+        return 0
+
 
 def _check_cli_freshness():
     """Detect + auto-heal a stale /usr/local/bin/droneaware CLI at feeder
@@ -1750,7 +1773,10 @@ class WiFiFeeder:
                     log.info(f"Single-band adapter on {iface} — 2.4 GHz only")
 
             if enable_5g:
-                log.info("Hopper mode: dual-band (ch6 + ch149, 30s cycle)")
+                # Cycle length is per-instance (dwell env vars, v1.4.6+) so
+                # DON'T hardcode it here — the DualBandHopper's own startup
+                # log reports the actual timing after __init__ parses env.
+                log.info("Hopper mode: dual-band (ch6 + ch149)")
                 self.hopper = DualBandHopper(iface)
             else:
                 log.info("Hopper mode: adaptive (sweep + sticky, channel-6 biased)")
@@ -1758,6 +1784,8 @@ class WiFiFeeder:
         self.count       = 0
         self.nan_count   = 0
         self._scanning   = False
+        # v1.4.8: restart count since Pi boot (see phillyrox incident memo).
+        self.restart_count = _get_restart_count()
 
     def _on_packet(self, data: bytes):
         # Parse RadioTap header to get RSSI, channel, and skip to 802.11 MAC header
@@ -1956,6 +1984,11 @@ class WiFiFeeder:
                         "has_gps":      has_gps,
                         "lat":          lat,
                         "lon":          lon,
+                        # v1.4.8 telemetry — restart count is meaningful
+                        # even in FAULT loop (a crash-looping FAULT feeder
+                        # is worth surfacing). No forwarder in FAULT mode,
+                        # so no buffered/dropped fields.
+                        "restarts_since_boot": self.restart_count,
                     },
                     headers={"X-Node-Token": self.token},
                     timeout=5,
@@ -1981,6 +2014,8 @@ class WiFiFeeder:
                     f"[Heartbeat] Beacon RID={self.count}  NAN={self.nan_count}  "
                     f"sent={self.forwarder.sent_total}  failed={self.forwarder.failed_total}  "
                     f"dropped={self.forwarder.dropped_total}  "
+                    f"buffered={len(self.forwarder.buffer)}  "
+                    f"restarts={self.restart_count}  "
                     f"cpu={cpu_pct_str}  load={load_str}"
                 )
                 if self.token:
@@ -2014,6 +2049,14 @@ class WiFiFeeder:
                                 "has_gps":      has_gps,
                                 "lat":          lat,
                                 "lon":          lon,
+                                # v1.4.8 telemetry additions — mirror BLE.
+                                "buffered":            len(self.forwarder.buffer),
+                                "buffered_bytes":      self.forwarder.buffer_bytes,
+                                "dropped_total":       self.forwarder.dropped_total,
+                                "sent_total":          self.forwarder.sent_total,
+                                "restarts_since_boot": self.restart_count,
+                                # WiFi feeder is threading-based — no
+                                # equivalent event_loop_max_lag_ms metric.
                             },
                             headers={"X-Node-Token": self.token},
                             timeout=5,


### PR DESCRIPTION
## Summary

Node-side response to the **phillyrox saturation incident** (2026-07-16). A node parked next to a single continuous BLE Remote ID beacon (Potensic RID-916, ~9 broadcasts/sec sustained) went from 12% CPU / 0.15 load to **70% CPU / load 4.4 in ~90 seconds**, and stayed there for 14+ hours. BLE detection dropped to ~17% of pre-onset rate. The BLE feeder's heartbeat went silent — but the process was still alive, its uptime counter still advancing. The server had zero signal anything was wrong.

## Root cause

BLE feeder's async architecture puts scanner-callback dispatch, `Forwarder._flush()` (sync `requests.post`), and the heartbeat POST all on the **same asyncio event loop, in the same task**. Under sustained high-rate BLE traffic:

- `on_advertisement` runs frequently — decode + N sub-message publishes for Message Packs (Potensic sends 5 msg types packed)
- `Forwarder.add()` triggers **synchronous** `_flush()` when batch_size hit → blocks event loop for up to 5s (`requests.post` timeout)
- Flush failure re-queues batch → larger next batch → longer next POST → positive feedback
- Heartbeat coroutine sharing the task never gets a slot on the loop

## Fixes

### 1. Heartbeat runs in its own asyncio task

`BLEFeeder.run()` now calls `asyncio.create_task(self._heartbeat_loop())`. Even if the scanner loop is saturated, the heartbeat coroutine gets its own turn on the event loop.

### 2. Flush no longer blocks the event loop

- `Forwarder.add()` no longer triggers sync `_flush()` at `batch_size`
- New `Forwarder.should_flush()` advisory check
- Main scanner loop calls `await asyncio.to_thread(self.forwarder._flush)` when `should_flush()` is true
- Heartbeat POST also runs via `asyncio.to_thread`

Sync `requests.post` never runs on the event loop thread again.

### 3. Fleet-wide backlog telemetry (both feeders)

New fields in every heartbeat POST payload:

| Field | Purpose |
|---|---|
| `buffered` | Current forwarder buffer length (events) |
| `buffered_bytes` | Current forwarder buffer size |
| `dropped_total` | Cumulative dropped events — was in log line, never in POST payload (Filer #24) |
| `sent_total` | Cumulative events successfully forwarded |
| `restarts_since_boot` | Feeder restart counter, tmpfs at `/run/droneaware/` |

BLE additionally sends:

| Field | Purpose |
|---|---|
| `event_loop_max_lag_ms` | Max scheduled-vs-actual scanner-loop tick delay since last heartbeat. **Direct saturation indicator** — 0-20ms healthy, thousands under phillyrox-style starvation. |

Server can now alert on `event_loop_max_lag_ms > 500` fleet-wide instead of reasoning from symptoms after the fact.

### 4. Bonus — leftover "30s cycle" log line fixed

v1.4.6 made dwells configurable but missed a `log.info("Hopper mode: dual-band (ch6 + ch149, 30s cycle)")` in `WifiFeeder.__init__`. Now just says `Hopper mode: dual-band (ch6 + ch149)` — the `DualBandHopper`'s own startup log reports the actual timing.
