### PR TITLE
v1.4.9: Local Web UI polish — trail, altitude, units, trail color, mobile jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,46 +12,109 @@ Full release artifacts and discussion notes live at the
 
 ## [1.4.9] — Unreleased
 
-Local Web UI trail truncation fix. Operators reported flight-path
-polylines that appeared to "only show the last few seconds" of a
-sortie, even when the drone was still overhead. Two independent nodes
-reproduced the same behavior on the same operator's flights.
+Local Web UI polish release: five operator-reported issues addressed
+in one pass. All changes are frontend or in-memory store bounds — no
+feeder, protocol, or server contract changes.
 
-### Root cause
+### 1. Trail truncation — flight path only showed the last minute
 
-`web_ui.py`'s `Store.snapshot()` derived a chronological list of unique
-lat/lon positions from each MAC's event deque, then capped the returned
-list at the last 60 entries (`trail[-60:]`). ASTM RID drones broadcast
-Location messages at ~1 Hz, so 60 unique positions ≈ 60 seconds of
-visible trail. Anything longer scrolled the polyline forward — the
-head of the flight dropped off silently. The 60-cap predated the
-current byte-cap deque (50 MB across all MACs) and the 12h stale-prune
-sweep, both of which already bound memory. The trail cap was doing no
-additional bounding work — just losing data.
+Two independent nodes reproduced the same complaint: flight-path
+polylines "only show the last few seconds" of a sortie, even with the
+drone still overhead.
 
-### Fix
+Root cause: `web_ui.py`'s `Store.snapshot()` derived a chronological
+list of unique lat/lon positions from each MAC's event deque, then
+capped the returned list at the last 60 entries (`trail[-60:]`). ASTM
+RID drones broadcast Location messages at ~1 Hz, so 60 unique
+positions ≈ 60 seconds of visible trail. Anything longer scrolled the
+polyline forward — the head of the flight dropped off silently. The
+60-cap predated the current byte-cap deque (50 MB across all MACs)
+and the 12h stale-prune sweep, both of which already bound memory.
 
-- Bump per-MAC trail cap from **60 → 10,000 unique positions**.
-  At 1 Hz that's ~2.8 hours of visible flight — comfortably beyond
-  any single sortie and inside the 12h stale window that already
-  ages events out of the deque.
-- Snapshot payload per MAC stays under ~150 KB even at the new
-  ceiling; deque byte-cap and stale prune remain the actual memory
-  bounds.
+Fix: per-MAC trail cap **60 → 10,000 unique positions**. At 1 Hz
+that's ~2.8h of visible flight — comfortably beyond any single sortie
+and inside the 12h stale window. Snapshot payload per MAC stays under
+~150 KB at the new ceiling.
+
+### 2. Altitude label lied about what it was showing
+
+The popup and sidebar card labeled altitude "ft AGL" but were reading
+`altitude_geo` (ASTM F3411 geometric altitude = WGS84 ellipsoid MSL).
+Real AGL travels on a separate ODID field (`height_agl`, Location
+bytes 17-18). For a drone flying near sea level the numbers happen to
+match; for anyone flying at meaningful ground elevation the "AGL"
+label was showing MSL. Verified on live tmpfs data with a grounded
+drone: `alt: -14.0` (MSL) vs `height_agl: 0.0` (correct AGL) —
+frontend was rendering "-46 ft AGL" for a drone on the ground.
+
+Fix: prefer `evt.height_agl` when the drone broadcasts it; fall back
+to `evt.alt`/`evt.altitude_geo` for the small minority of drones that
+only send geometric altitude (silent fallback, current behavior for
+those cases).
+
+### 3. Metric / imperial unit toggle
+
+Prior release displayed altitude in feet ("ft AGL") but speed in km/h
+— an imperial/metric mix that confused US operators reading a card
+labeled "ft" alongside a number that "seemed like meters." Rather than
+just flip speed to mph, this release adds a header toggle (**ft** ↔
+**m** button next to the theme toggle) that switches every unit in
+the UI at once. Default is imperial; the preference is remembered
+per-browser via `localStorage`.
+
+Affected displays:
+- Altitude: `ft AGL` ↔ `m AGL`
+- Speed: `mph` ↔ `km/h` (`Hovering` unchanged when < 1 m/s)
+- Home rings: `1 mi..10 mi` ↔ `1 km..10 km` (redrawn on toggle)
+
+### 4. Flight-path trail — bright yellow, wider
+
+Operators reported the trail polyline was easy to miss during a
+flight. Previous trail took the current freshness-tier color (cyan /
+orange / red) at weight 2 opacity 0.75 — fine on a dark basemap, but
+freshness is already communicated by the drone marker. Trail now
+renders in fixed bright yellow (`#FFD400`), weight 4, opacity 1.0 —
+decoupled from freshness so the two visual signals don't overload
+each other.
+
+### 5. Mobile Web UI jitter — map recentered every 2s
+
+On mobile nodes (`NODE_MOBILE=true`), the status poll pulls a fresh
+GPS fix every 2 seconds. Even a stationary GPS drifts ±3-10 m each
+poll, and the frontend's old strict-equality guard (`cur.lat !==
+s.home.lat`) treated every micro-drift as a real move. That triggered
+`drawHomeView()`, which called `state.map.setView(center, 11)` — wiping
+out any manual pan/zoom the operator had done. Result: the map
+recentered and reset to zoom 11 twice per second, which operators
+correctly described as "the zoom level resets every 2 seconds."
+
+Fix: two guards.
+- Ignore GPS movement smaller than ~11 m (`0.0001°`) at the status-
+  poll layer — that's above typical stationary drift but well below
+  any meaningful travel.
+- Only call `setView(center, 11)` on the **first** home draw. Later
+  redraws update the marker and rings at the new position without
+  touching the map view, so the operator's pan/zoom sticks.
 
 ### Files changed
 
-- `web_ui.py`: `snapshot()` trail slice `[-60:]` → `[-10000:]` plus
-  updated docstring.
+- `web_ui.py` — `snapshot()` trail cap `[-60:]` → `[-10000:]` + doc.
+- `web_static/index.html` — altitude/speed helpers refactored around a
+  `state.units` flag with `height_agl` preferred over `altitude_geo`;
+  header units button + toggle handler; home-ring step and label made
+  unit-aware; trail polyline color/weight/opacity fixed;
+  `drawHomeView()` skips `setView` after the first draw and the
+  status-refresh guard adds a ~11 m movement threshold.
 
 ### Not in this release
 
-- Mobile Web UI jitter (map recenters every 2s from GPS noise) —
-  scoped for v1.5.0 alongside the multi-radio work.
 - Server-side CSV export dropping data (operator report, same day)
   — server session territory, tracked separately.
 - Alert cooldown reset-on-inactivity + fleet allowlist — server
   session feature backlog.
+- WiFi adapter identification fragility (Chris's backhaul-swap
+  incident) + dual-adapter dual-band scanning — the full v1.5.0
+  scope.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.9] — Unreleased
+
+Local Web UI trail truncation fix. Operators reported flight-path
+polylines that appeared to "only show the last few seconds" of a
+sortie, even when the drone was still overhead. Two independent nodes
+reproduced the same behavior on the same operator's flights.
+
+### Root cause
+
+`web_ui.py`'s `Store.snapshot()` derived a chronological list of unique
+lat/lon positions from each MAC's event deque, then capped the returned
+list at the last 60 entries (`trail[-60:]`). ASTM RID drones broadcast
+Location messages at ~1 Hz, so 60 unique positions ≈ 60 seconds of
+visible trail. Anything longer scrolled the polyline forward — the
+head of the flight dropped off silently. The 60-cap predated the
+current byte-cap deque (50 MB across all MACs) and the 12h stale-prune
+sweep, both of which already bound memory. The trail cap was doing no
+additional bounding work — just losing data.
+
+### Fix
+
+- Bump per-MAC trail cap from **60 → 10,000 unique positions**.
+  At 1 Hz that's ~2.8 hours of visible flight — comfortably beyond
+  any single sortie and inside the 12h stale window that already
+  ages events out of the deque.
+- Snapshot payload per MAC stays under ~150 KB even at the new
+  ceiling; deque byte-cap and stale prune remain the actual memory
+  bounds.
+
+### Files changed
+
+- `web_ui.py`: `snapshot()` trail slice `[-60:]` → `[-10000:]` plus
+  updated docstring.
+
+### Not in this release
+
+- Mobile Web UI jitter (map recenters every 2s from GPS noise) —
+  scoped for v1.5.0 alongside the multi-radio work.
+- Server-side CSV export dropping data (operator report, same day)
+  — server session territory, tracked separately.
+- Alert cooldown reset-on-inactivity + fleet allowlist — server
+  session feature backlog.
+
+---
+
 ## [1.4.8] — Unreleased
 
 Node-side response to the **phillyrox saturation incident** (2026-07-16).

--- a/web_static/index.html
+++ b/web_static/index.html
@@ -693,6 +693,7 @@
       </span>
     </div>
     <div class="header-right">
+      <button class="icon-btn" id="btn-units" title="Toggle units (imperial / metric)" aria-label="Toggle units" style="font-size: 12px; font-weight: 700; letter-spacing: 0.5px;">ft</button>
       <button class="icon-btn" id="btn-theme" title="Toggle theme" aria-label="Toggle theme">◐</button>
     </div>
   </div>
@@ -823,6 +824,15 @@
       // bundle that doesn't exist on this node.
       tileSource: (typeof navigator !== "undefined" && navigator.onLine === false) ? "local" : "cartocdn",
       tilesLocalAvailable: false,
+      // Display units: "imperial" (ft AGL / mph / mi rings) or "metric"
+      // (m AGL / km/h / km rings). Persisted per-browser in localStorage.
+      // Default imperial — matches US operator majority; international
+      // operators can flip via the header toggle and the choice sticks.
+      units: (typeof localStorage !== "undefined" && localStorage.getItem("da_units") === "metric") ? "metric" : "imperial",
+      // Cached home location so we can re-draw distance rings when the
+      // unit toggle flips between miles and kilometers without waiting
+      // for the next /api/status refresh.
+      home: null,
     };
 
     /* ----- Helpers ----- */
@@ -964,12 +974,14 @@
     }
 
     /* ----- Home location + distance rings ----- */
-    // 10 concentric rings at 1-mile intervals around the node's home
-    // location. No offset applied — offline view is inherently private
-    // (LAN-only, no internet exposure), so showing the actual node
-    // location is fine. Rings give the operator instant range context
-    // for any detection on the map.
+    // 10 concentric rings around the node's home location — 1 mi steps
+    // in imperial mode, 1 km steps in metric mode (chosen at render
+    // time from state.units). No offset applied — offline view is
+    // inherently private (LAN-only, no internet exposure), so showing
+    // the actual node location is fine. Rings give the operator instant
+    // range context for any detection on the map.
     const MILE_METERS = 1609.344;
+    const KM_METERS = 1000;
     const RING_COUNT = 10;
 
     function drawHomeView(home) {
@@ -979,17 +991,25 @@
         // no GPS fix yet.
         return;
       }
+      const isFirstDraw = state.home == null;
+      state.home = home;
       state.homeLayer.clearLayers();
       const center = [home.lat, home.lon];
 
-      // Recenter the map on home. Zoom 11 gives a ~15-mile-wide view,
-      // comfortable for showing all 10 rings on a typical display.
-      state.map.setView(center, 11);
+      // Recenter + zoom the map on the FIRST home draw only. On mobile
+      // nodes the GPS fix updates every ~2s and re-calling setView here
+      // would wipe out any manual pan/zoom the operator has done. The
+      // rings/marker below still redraw at the new position, so the map
+      // stays accurate — the user's chosen view just isn't blown away.
+      if (isFirstDraw) state.map.setView(center, 11);
 
-      // Concentric distance rings: 1mi through 10mi, dashed cyan.
+      const stepMeters = state.units === "metric" ? KM_METERS : MILE_METERS;
+      const unitLabel  = state.units === "metric" ? "km" : "mi";
+
+      // Concentric distance rings, dashed cyan.
       for (let i = 1; i <= RING_COUNT; i++) {
         L.circle(center, {
-          radius: i * MILE_METERS,
+          radius: i * stepMeters,
           color: "#00E5FF",
           weight: 1,
           opacity: 0.22,
@@ -999,11 +1019,11 @@
         }).addTo(state.homeLayer);
 
         // Distance label at the 12 o'clock position of each ring.
-        const labelLat = home.lat + (i * MILE_METERS) / 111320;  // meters → degrees lat
+        const labelLat = home.lat + (i * stepMeters) / 111320;  // meters → degrees lat
         L.marker([labelLat, home.lon], {
           icon: L.divIcon({
             className: "ring-label",
-            html: `${i} mi`,
+            html: `${i} ${unitLabel}`,
             iconSize: [40, 12],
             iconAnchor: [20, 6],
           }),
@@ -1196,9 +1216,8 @@
 
       // Stats row: altitude · speed · node-id. Skip components that don't
       // have data so we don't render dangling '·' separators.
-      const altFt = metersToFtAGL(evt.alt ?? evt.altitude_geo);
-      const altText = altFt != null ? `${altFt} ft AGL` : null;
-      const spdText = speedLabel(evt.speed);
+      const altText = formatAltitude(evt);
+      const spdText = formatSpeed(evt.speed);
       const nodeText = state.nodeId || "this-node";
       const statsParts = [altText, spdText, nodeText].filter(Boolean);
       const statsHTML = statsParts.length
@@ -1414,11 +1433,18 @@
         }
 
         // Home location may change on mobile nodes as the GPS fix moves.
-        // Only redraw if the location actually changed (avoids tearing down
-        // the rings every 2 seconds for static nodes).
+        // Static nodes: strict equality is fine (config-file source, never
+        // wobbles). Mobile nodes: even a stationary GPS drifts ±3-10 m
+        // every poll, so we ignore movement smaller than ~10 m to keep
+        // the rings from tearing down twice per second. Anything larger
+        // than the threshold is a real move worth redrawing.
         if (s.home) {
           const cur = state.lastHome;
-          if (!cur || cur.lat !== s.home.lat || cur.lon !== s.home.lon) {
+          const HOME_MOVE_THRESHOLD_DEG = 0.0001;   // ~11 m at mid-latitude
+          const moved = !cur
+            || Math.abs(cur.lat - s.home.lat) > HOME_MOVE_THRESHOLD_DEG
+            || Math.abs(cur.lon - s.home.lon) > HOME_MOVE_THRESHOLD_DEG;
+          if (moved) {
             drawHomeView(s.home);
             state.lastHome = { lat: s.home.lat, lon: s.home.lon };
           }
@@ -1484,14 +1510,29 @@
       12: "Rocket",    13: "Tethered Powered", 14: "Ground Obstacle",
     };
 
-    function metersToFtAGL(meters) {
-      if (typeof meters !== "number") return null;
-      return Math.round(meters * 3.28084);
+    // Altitude — prefer height_agl (ASTM RID Location bytes 17-18, real AGL
+    // or above-takeoff depending on the drone's height_type flag) over the
+    // geometric MSL/WGS84 altitude that was previously used and mislabeled.
+    // Silent fallback: if height_agl is absent we still label "AGL" — a
+    // small minority of drones only broadcast geometric altitude, and the
+    // current behavior is preserved for them.
+    function altitudeSource(evt) {
+      if (typeof evt.height_agl === "number") return evt.height_agl;
+      if (typeof evt.alt === "number") return evt.alt;
+      if (typeof evt.altitude_geo === "number") return evt.altitude_geo;
+      return null;
     }
-    function speedLabel(mps) {
+    function formatAltitude(evt) {
+      const m = altitudeSource(evt);
+      if (m == null) return null;
+      if (state.units === "metric") return `${Math.round(m)} m AGL`;
+      return `${Math.round(m * 3.28084)} ft AGL`;
+    }
+    function formatSpeed(mps) {
       if (typeof mps !== "number") return null;
       if (mps < 1.0) return "Hovering";
-      return `${(mps * 3.6).toFixed(1)} km/h`;
+      if (state.units === "metric") return `${(mps * 3.6).toFixed(1)} km/h`;
+      return `${(mps * 2.23694).toFixed(1)} mph`;
     }
 
     function buildPopupHTML(mac) {
@@ -1513,8 +1554,8 @@
           ${evt.faa_documented ? '<span class="da-popup-badge">FAA DOC</span>' : ""}
         </div>` : "";
 
-      const altFt = metersToFtAGL(evt.alt ?? evt.altitude_geo);
-      const speedTxt = speedLabel(evt.speed);
+      const altTxt = formatAltitude(evt);
+      const speedTxt = formatSpeed(evt.speed);
       const typeTxt = UA_TYPES[evt.ua_type] || evt.type || "—";
       const headingTxt = (evt.hdg != null) ? `${evt.hdg}°`
                        : (evt.heading != null) ? `${evt.heading}°`
@@ -1542,7 +1583,7 @@
             <div class="da-popup-label">Type</div>
             <div class="da-popup-value">${escapeHtml(typeTxt)}</div>
             <div class="da-popup-label">Altitude</div>
-            <div class="da-popup-value">${altFt != null ? altFt + " ft AGL" : "—"}</div>
+            <div class="da-popup-value">${altTxt || "—"}</div>
             <div class="da-popup-label">Speed</div>
             <div class="da-popup-value">${speedTxt || "—"}</div>
           </div>
@@ -1585,15 +1626,20 @@
       state.map.closePopup();
     }
 
-    function renderTrailPolyline(entry, color) {
+    // Flight-path trail — fixed bright yellow, decoupled from the
+    // drone's freshness tier. Freshness is already communicated by the
+    // marker color; the trail's job is to be visually distinct against
+    // any basemap so the operator can trace the full flight at a glance.
+    // Ignores the `color` argument passed by callers (kept for compat).
+    const TRAIL_COLOR = "#FFD400";
+    function renderTrailPolyline(entry, _color) {
       if (!entry.trail || entry.trail.length < 2) return;
       if (!entry.polyline) {
         entry.polyline = L.polyline(entry.trail, {
-          color, weight: 2, opacity: 0.75, interactive: false,
+          color: TRAIL_COLOR, weight: 4, opacity: 1.0, interactive: false,
         }).addTo(state.map);
       } else {
         entry.polyline.setLatLngs(entry.trail);
-        entry.polyline.setStyle({ color });
       }
     }
 
@@ -1658,6 +1704,31 @@
       applyMapTheme();
     }
 
+    /* ----- Units toggle (imperial / metric) ----- */
+    function updateUnitsButton() {
+      const btn = document.getElementById("btn-units");
+      if (!btn) return;
+      btn.textContent = state.units === "metric" ? "m" : "ft";
+      btn.title = `Units: ${state.units} — click to switch`;
+    }
+    function applyUnits() {
+      // Rebuild every sidebar card so altitude/speed swap units.
+      for (const mac of state.macs.keys()) renderCard(mac);
+      applyFilters();
+      // Redraw home rings so 1mi → 1km (or vice versa).
+      if (state.home) drawHomeView(state.home);
+      // If a popup is open, close and reopen so the new units show in it.
+      // Popup content is generated inline at open time — closing is enough
+      // for a subsequent click to render with the new units.
+      if (state.map) state.map.closePopup();
+    }
+    function toggleUnits() {
+      state.units = state.units === "imperial" ? "metric" : "imperial";
+      try { localStorage.setItem("da_units", state.units); } catch (_) {}
+      updateUnitsButton();
+      applyUnits();
+    }
+
     /* ----- Filter chip wiring ----- */
     function initFilters() {
       document.querySelectorAll(".chip").forEach(chip => {
@@ -1685,7 +1756,9 @@
       loadTheme();
       initMap();
       initFilters();
+      updateUnitsButton();
       document.getElementById("btn-theme").addEventListener("click", toggleTheme);
+      document.getElementById("btn-units").addEventListener("click", toggleUnits);
 
       // Network transitions → swap the basemap source. CartoDB if we're
       // online (full street-level detail), bundled local tiles when

--- a/web_ui.py
+++ b/web_ui.py
@@ -272,7 +272,9 @@ class DetectionStore:
                 merged: dict = {}
                 # Trail: chronological list of unique lat/lon positions
                 # across this MAC's retained events. Capped at the last
-                # 60 unique positions. Lets the frontend reconstruct
+                # 10,000 unique positions (~2.8h at 1Hz Location broadcasts,
+                # comfortably beyond any single-sortie flight and within
+                # the 12h stale window). Lets the frontend reconstruct
                 # the flight-path polyline immediately on snapshot load
                 # — without this, trails are client-only state that
                 # gets lost on web_ui restart or browser reload.
@@ -297,7 +299,7 @@ class DetectionStore:
                     "last_seen":    latest_ts,
                     "age_sec":      now - latest_ts,
                     "event_count":  len(dq),
-                    "trail":        trail[-60:],
+                    "trail":        trail[-10000:],
                 })
             total_events = sum(len(dq) for dq in self._by_mac.values())
             return {


### PR DESCRIPTION
## Summary

Five operator-reported Local Web UI issues, one release. All changes are frontend / in-memory store bounds — no feeder, protocol, or server contract changes.

**1. Trail truncation** — flight path only showed the last ~60 seconds. `Store.snapshot()` capped per-MAC trail at `trail[-60:]`; ASTM RID Location messages broadcast at ~1 Hz, so the polyline slid forward silently on any flight longer than a minute. Bumped to `[-10000:]` (~2.8h at 1 Hz, within the 12h stale window). Payload per MAC stays under ~150 KB.

**2. Altitude label lied about what it was showing.** The card and popup labeled altitude "ft AGL" but read `altitude_geo` (WGS84 ellipsoid MSL). Real AGL travels on a separate ODID field (`height_agl`, Location bytes 17-18). Verified on live tmpfs: a grounded drone had `alt: -14.0` (MSL) and `height_agl: 0.0` — UI was rendering "-46 ft AGL" for a drone on the ground. Now prefers `height_agl` when the drone broadcasts it; silent fallback to `altitude_geo` for drones that only send geometric altitude.

**3. Metric / imperial unit toggle.** Prior release mixed units (ft AGL + km/h). Added a header **ft** ↔ **m** button that flips every unit at once. Default imperial; preference persists via `localStorage`. Covers altitude (`ft AGL` ↔ `m AGL`), speed (`mph` ↔ `km/h`), and home rings (`1-10 mi` ↔ `1-10 km`, redrawn on toggle).

**4. Flight-path trail** — bright yellow, wider. Trail was previously freshness-tier color (cyan/orange/red) at weight 2 opacity 0.75. Freshness is already communicated by the drone marker, so trail now renders fixed bright yellow (`#FFD400`) weight 4 opacity 1.0 — decoupled from freshness so the two signals don't overload each other.

**5. Mobile Web UI jitter** — map recentered every 2s from GPS noise. Old strict-equality guard treated every GPS micro-drift (±3-10 m stationary) as a real move, triggering `drawHomeView()` → `setView(center, 11)` which wiped any manual pan/zoom. Two guards: ignore movement < ~11 m at the status-poll layer, and only call `setView()` on the FIRST home draw (later redraws move marker/rings without touching the view).

## Files changed

- `web_ui.py` — `snapshot()` trail slice `[-60:]` → `[-10000:]` plus docstring.
- `web_static/index.html` — altitude/speed helpers refactored around a `state.units` flag; `height_agl` preferred over `altitude_geo`; header units button + toggle handler; home-ring step/label made unit-aware; trail polyline color/weight/opacity fixed; `drawHomeView()` skips `setView` after first draw; status-refresh guard gains a ~11 m movement threshold.
- `CHANGELOG.md` — v1.4.9 entry.

## Not in this release

- Server-side CSV export dropping data — server session territory.
- Alert cooldown reset-on-inactivity + fleet allowlist — server session backlog.
- WiFi adapter identification fragility + dual-adapter dual-band scanning — full v1.5.0 scope.