### PR TITLE
v1.4.10: hotfix — raise client-side TRAIL_MAX to match v1.4.9 server-side cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.10] — Unreleased
+
+Hotfix for v1.4.9's trail-truncation fix. Same-day operator test flight
+still showed only ~60 trail points after installing v1.4.9.
+
+Root cause: v1.4.9 raised the **server-side** cap in `web_ui.py`'s
+`Store.snapshot()` from `[-60:]` → `[-10000:]`, but the frontend has
+an **independent** `TRAIL_MAX = 60` in `web_static/index.html`. On
+initial page load the client hydrates `entry.trail` from the server
+snapshot (up to 10,000 points) — but every subsequent SSE event calls
+`appendTrail()`, which trims the array back down to 60. Within a few
+seconds of live flight, only the last 60 positions remained.
+
+Fix: raise `TRAIL_MAX` to `10000` to match the server-side cap.
+Comment updated to note that the two caps must stay in sync — a
+browser refresh should not show a longer trail than the live stream
+will maintain.
+
+### Files changed
+
+- `web_static/index.html` — `TRAIL_MAX = 60` → `10000` plus comment
+  noting the server-side cap it must track.
+
+---
+
 ## [1.4.9] — Unreleased
 
 Local Web UI polish release: five operator-reported issues addressed

--- a/web_static/index.html
+++ b/web_static/index.html
@@ -1063,8 +1063,11 @@
 
     // Per-MAC position history for flight-path rendering. Capped at
     // TRAIL_MAX positions to keep memory bounded; older positions drop
-    // off the back of the trail as the drone moves.
-    const TRAIL_MAX = 60;
+    // off the back of the trail as the drone moves. Must match (or be
+    // ≤) the server-side `snapshot()` cap in web_ui.py so a browser
+    // refresh doesn't show a longer trail than the live stream will
+    // maintain — currently 10,000 (~2.8h of visible flight at 1 Hz).
+    const TRAIL_MAX = 10000;
 
     function appendTrail(entry, lat, lon) {
       if (!entry.trail) entry.trail = [];


### PR DESCRIPTION
## Summary

Same-day hotfix for v1.4.9. Operator test flight against v1.4.9 still showed only ~60 trail points.

v1.4.9 raised the **server-side** cap in `web_ui.py`'s `Store.snapshot()` from `[-60:]` → `[-10000:]`, but the frontend has an **independent** `TRAIL_MAX = 60` in `web_static/index.html`. On initial page load the client hydrates `entry.trail` from the server snapshot (up to 10,000 points) — but every subsequent SSE event calls `appendTrail()`, which trims the array back to 60. Within seconds of live flight, only the last 60 positions remained.

## Fix

- `TRAIL_MAX = 60` → `10000` — matches server-side cap.
- Comment updated to note the two caps must stay in sync so a browser refresh never shows more than the live stream will maintain.

## Files changed

- `web_static/index.html` — one constant + comment.
- `CHANGELOG.md` — v1.4.10 entry.