### PR TITLE
v1.4.11: replace bash-interpolated enrollment JSON with python3 json.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,80 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.11] — Unreleased
+
+Installer hardening: `install.sh` no longer builds the enrollment request
+body via bash string interpolation. Zero change to what gets sent on the
+wire on nominal input — byte-for-byte identical body — but a whole class
+of "silently-malformed request" bugs is now eliminated.
+
+### Why
+
+Discovered 2026-07-28 during a cross-session audit of a user enrollment
+failure. Server-side observed 39 rejected `POST /api/node/enroll`
+attempts from a single user with 5 distinct malformed body shapes,
+including `{"has_gps":,...}` (empty value — invalid JSON). Server
+correctly concluded the requests were hand-rolled clients missing
+`Content-Type: application/json` (verified empirically via the Pydantic
+`model_attributes_type` vs `json_invalid` error split). The official
+installer was **not** the source of that user's failure.
+
+But the audit surfaced that the installer had been building the body via
+bash template — `curl -d "{\"node_id\":\"${NODE_ID}\",...}"` — since
+v1.0.19. Under defensive coding in enroll_node() no shipped path leaves
+a variable empty, but that guarantee is one careless future edit away
+from producing exactly the malformed JSON shape the incident report
+showed. Replacing the template with a real serializer removes the
+whole bug class permanently.
+
+### What changed
+
+- New `_build_enroll_body()` helper — uses `python3 -c` + `json.dumps`
+  with values passed via `sys.argv` (never interpolated into the Python
+  source, so shell metacharacters in `node_id`/`enrollment_token`
+  can't affect the code).
+- Explicit type conversion: `mobile`/`has_gps` become real booleans
+  (not `"true"`/`"false"` strings — old bash could not have emitted
+  strings either, but the new code fails loudly if a caller passes
+  anything other than the literal `"true"`/`"false"`).
+- `lat`/`lon` become real JSON numbers, or `null` for absent — same
+  sentinel string convention (`"null"`) as before, converted inside
+  the helper.
+- `curl -d` → `curl --data-binary` so no whitespace stripping is applied
+  to the serialized body.
+- Uses `json.dumps(..., separators=(",", ":"))` so the compact
+  format matches what the old bash template produced byte-for-byte
+  on valid input — server logs see no shape change.
+
+### Verified
+
+Standalone tests confirm the helper:
+- Byte-for-byte-matches the pre-fix installer output for valid input.
+- Correctly escapes `"`, `;`, `--`, and other shell metacharacters
+  that would have broken the old template.
+- Handles unicode in `node_id` without ceremony.
+- **Fails loudly** on empty/malformed booleans and non-numeric coords
+  — previously these would have produced silently-malformed JSON.
+
+### Not in this release (still queued for v1.5.0)
+
+- `agreement_version` missing from enrollment body — every version
+  since v1.0.19. Server defaults it to `"1.0"` and records that in
+  the audit trail regardless of what the operator actually accepted.
+  Compliance-adjacent; needs coordination with server-side session
+  and legal input before shipping.
+- `elevation_agl_m` missing — data-completeness gap only.
+- Broader installer overhaul (multi-radio adapter identification,
+  pre-flight hardware/OS checks, uninstall command) — see
+  pending-changes memory.
+
+### Files changed
+
+- `install.sh` — new `_build_enroll_body()` helper; `enroll_node()`
+  refactored to call it and use `curl --data-binary`.
+
+---
+
 ## [1.4.10] — Unreleased
 
 Hotfix for v1.4.9's trail-truncation fix. Same-day operator test flight

--- a/install.sh
+++ b/install.sh
@@ -721,6 +721,46 @@ migrate_config() {
 # ---------------------------------------------------------------------------
 # 10. Enroll node — requires a logged-in DroneAware account
 # ---------------------------------------------------------------------------
+
+# Serialize the enrollment request body via python3's json.dumps. Callers
+# hand in string values; this converts them to correctly-typed JSON. Values
+# arrive via argv (never interpolated into the Python source), so shell
+# metacharacters in node_id/token cannot affect the code. Fails loudly on
+# unexpected inputs — a bug elsewhere that leaves a variable empty should
+# surface as an install failure, not a silently-malformed request.
+#
+# Args (positional):
+#   $1  node_id           — arbitrary string
+#   $2  enrollment_token  — arbitrary string
+#   $3  mobile            — "true" | "false"
+#   $4  has_gps           — "true" | "false"
+#   $5  lat               — decimal number as string, or "null" for absent
+#   $6  lon               — decimal number as string, or "null" for absent
+#
+# Prints the JSON body to stdout. Exits nonzero (under set -e propagates up)
+# if python3 is missing, an argument has the wrong shape, or json.dumps fails.
+_build_enroll_body() {
+    python3 -c '
+import json, sys
+node_id, token, mobile, has_gps, lat, lon = sys.argv[1:7]
+def _num(s):
+    if s in ("null", ""): return None
+    return float(s)
+def _bool(name, s):
+    if s == "true":  return True
+    if s == "false": return False
+    raise SystemExit(f"_build_enroll_body: {name} must be \"true\" or \"false\", got {s!r}")
+sys.stdout.write(json.dumps({
+    "node_id":          node_id,
+    "enrollment_token": token,
+    "mobile":           _bool("mobile", mobile),
+    "has_gps":          _bool("has_gps", has_gps),
+    "lat":              _num(lat),
+    "lon":              _num(lon),
+}, separators=(",", ":")))
+' "$@"
+}
+
 enroll_node() {
     heading "Node Enrollment"
     echo ""
@@ -741,7 +781,11 @@ enroll_node() {
         warn "Enrollment token cannot be empty."
     done
 
-    # Build JSON-safe values for optional numeric/boolean fields
+    # Build JSON-safe values for optional numeric/boolean fields.
+    # These strings are handed to _build_enroll_body (python3 + json.dumps),
+    # which converts them to real typed JSON values. Lat/lon use the literal
+    # string "null" as a sentinel for "not set"; booleans are literal
+    # "true"/"false" strings that _build_enroll_body converts to real bool.
     local lat_json lon_json has_gps_json
     if [[ -n "${NODE_LAT:-}" ]]; then
         lat_json="${NODE_LAT}"
@@ -752,6 +796,20 @@ enroll_node() {
     fi
     [[ -n "${GPS_DEVICE:-}" ]] && has_gps_json="true" || has_gps_json="false"
 
+    # Serialize the request body via python3's json.dumps. Never hand-roll
+    # JSON in bash — string interpolation can silently produce malformed
+    # output when a variable is empty (e.g. `"has_gps":,`) and can't safely
+    # escape arbitrary characters in node_id or the enrollment token.
+    # Values are passed via argv so shell metacharacters can't affect the
+    # Python code itself. If this ever fails (python3 missing, json module
+    # missing) the script exits under `set -e` rather than sending garbage.
+    local body
+    if ! body=$(_build_enroll_body \
+        "$NODE_ID" "$enrollment_token" "$NODE_MOBILE" \
+        "$has_gps_json" "$lat_json" "$lon_json"); then
+        fatal "Failed to serialize enrollment body. Confirm python3 is installed: 'sudo apt install python3'"
+    fi
+
     while true; do
         echo ""
         echo "  Contacting DroneAware network..."
@@ -761,7 +819,7 @@ enroll_node() {
             -o /tmp/droneaware_enroll.json \
             -w "%{http_code}" \
             -H "Content-Type: application/json" \
-            -d "{\"node_id\":\"${NODE_ID}\",\"enrollment_token\":\"${enrollment_token}\",\"mobile\":${NODE_MOBILE},\"has_gps\":${has_gps_json},\"lat\":${lat_json},\"lon\":${lon_json}}" \
+            --data-binary "$body" \
             "${SERVER_URL}/node/enroll" 2>/dev/null) || true
         response=$(cat /tmp/droneaware_enroll.json 2>/dev/null || true)
 


### PR DESCRIPTION
Zero change to what gets sent on the wire on nominal input — byte-for- byte identical body — but a whole class of "silently-malformed request" bugs is now eliminated.

Discovered 2026-07-28 during a cross-session audit of a user enrollment failure. Server-side observed 39 rejected POST /api/node/enroll attempts from a single user with 5 distinct malformed body shapes, including {"has_gps":,...} (empty value = invalid JSON).

The audit surfaced that install.sh had built the enroll body via bash string interpolation since v1.0.19:
  -d "{\"node_id\":\"${NODE_ID}\",\"has_gps\":${has_gps_json},...}"

Changes:
- New _build_enroll_body() helper — uses python3 -c + json.dumps with values passed via sys.argv (never interpolated into the Python source, so shell metacharacters in node_id/enrollment_token can't affect the code).
- Explicit type conversion: mobile/has_gps become real booleans, lat/lon become real JSON numbers or null. Fails loudly on unexpected inputs rather than emitting silently-malformed JSON.
- curl -d → curl --data-binary so no whitespace stripping is applied.
- json.dumps(..., separators=(",", ":")) so the byte shape matches what the old bash template produced on valid input — server logs see no shape change.

Verified via standalone tests:
- Byte-for-byte match with pre-fix output on valid input
- Correctly escapes ", ;, --, and other shell metacharacters
- Fails loudly on empty booleans, non-numeric coords, quoted-string bools (all previously silent-corruption modes)