### PR TITLE
v1.4.12: GPS observability + auto-remediation (gpsd conflict + SiRF/UBX → NMEA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,131 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.12] — Unreleased
+
+**GPS observability & auto-remediation release.** Two independent
+operator incidents in a week (BU-353S4 puck stuck in SiRF binary mode
+after gpsd probed it; second operator hit gpsd holding the port at
+install time) drove a coordinated fix across the runtime, installer,
+update path, and a new diagnostic command. All changes are additive —
+no protocol or server contract touches.
+
+**Note on v1.4.11:** shipped as its own tag but was installer-only
+(hardened the enrollment body via python3 `json.dumps`). Existing
+operators upgrading via `sudo droneaware update` see no runtime
+difference from v1.4.11 — the fix only affects fresh installs. v1.4.12
+is the first release since v1.4.10 that reaches existing operators
+via `droneaware update`.
+
+### 1. Runtime — richer GPS state + protocol detection
+
+`wifi_feeder.py` now:
+- **Sniffs the GPS device's output protocol at startup** before opening
+  the read loop. Log-only — never modifies the chip. Categorizes as
+  `nmea` / `sirf` / `ubx` / `unknown` and writes to
+  `/run/droneaware/gps_state.json` so `droneaware status` and
+  `droneaware gps-diagnose` can guide the operator to the fix.
+- **Parses `$GPGGA` / `$GNGGA`** for fix quality (field 6) and
+  satellites-in-use (field 7). Persists alongside every state write
+  during the read loop.
+- New state field: `wrong_protocol` — surfaced when the sniff finds
+  SiRF / UBX / unknown instead of NMEA. Reader backs off 30s between
+  attempts (vs 10s for other errors) since the puck won't recover
+  without an out-of-band chip-mode change.
+
+`gps_state.json` schema additions (all optional — old CLI reads
+without breaking): `protocol`, `fix_quality`, `sats_in_use`.
+
+### 2. `sudo droneaware status` — sats, fix, protocol on one line
+
+Previous format:
+```
+GPS : /dev/ttyUSB0 @ 4800 baud — reading NMEA, no fix yet
+GPS : /dev/ttyUSB0 @ 4800 baud — fix acquired (lat=..., lon=...)
+```
+
+New format (shows sat count from GGA, calls out non-NMEA protocols
+explicitly with a pointer to the remediation command):
+```
+GPS : /dev/ttyUSB0 @ 4800 baud — NMEA, 8 sats, fix (lat=..., lon=...)
+GPS : /dev/ttyUSB0 @ 4800 baud — NMEA, 3 sats, no fix yet
+GPS : /dev/ttyUSB0 — SiRF binary detected, DroneAware needs NMEA
+      run 'sudo droneaware gps-diagnose' for remediation
+```
+
+### 3. `install.sh` — gpsd conflict prompt + protocol auto-fix
+
+New `gps_sanity_check` phase runs after `install_packages` and before
+binaries are downloaded (so gpsctl is available and no feeder is yet
+holding the port). Two checks:
+
+- **gpsd detection** (three signals — `systemctl is-enabled gpsd.socket`,
+  `systemctl is-active`, and `dpkg -l gpsd`). If present, prompt to
+  stop + disable + mask (default: yes). Uses the same 4-command
+  remediation sequence Dan had been giving operators one-off on
+  Discord: `stop → disable → mask → pkill -x gpsd`.
+- **Protocol sniff at 4800 / 9600 / 38400 baud** against the discovered
+  `GPS_DEVICE`. If NMEA, all good. If SiRF or UBX, prompt to auto-fix
+  with `gpsctl -f -n` (direct-to-device mode, no gpsd needed), verify
+  by re-sniffing, print manual instructions on failure.
+
+`install_packages` now installs `gpsd-clients --no-install-recommends`
+so `gpsctl` is available for the auto-fix. The `--no-install-recommends`
+flag is critical: without it, apt pulls `gpsd` as a Recommends, which
+would defeat the whole point.
+
+Skips entirely when no GPS device is configured (static nodes / mobile
+without a puck plugged in).
+
+### 4. `sudo droneaware update` — same remediation on existing nodes
+
+Mirrored the sanity-check helpers into the CLI so operators already on
+v1.4.10 / v1.4.11 pick up gpsd + protocol remediation on their next
+update. Runs after config migration but before service restart
+(feeders are stopped at that point, port is free). Same prompt UX as
+the installer.
+
+Existing operators with a broken GPS puck get an in-band fix without
+having to re-run install.sh.
+
+### 5. New command: `sudo droneaware gps-diagnose`
+
+Read-only diagnostic — sections:
+- **Config** — `GPS_DEVICE`, `GPS_BAUD`, `NODE_MOBILE` from config.env
+- **Device** — existence, permissions, best-effort driver hint from
+  dmesg (`ch341` / `pl2303` / `cp210` / `ftdi` / `cdc_acm`)
+- **Port ownership** — `fuser -v $GPS_DEVICE`; explicit ✗ for gpsd,
+  ✓ for wifi_feeder
+- **Protocol detection** — live sniff if port is free, or read from
+  state file if wifi_feeder holds the port
+- **Recent GPS state** — full dump from `/run/droneaware/gps_state.json`
+  with age, status, protocol, baud, fix_quality, sats_in_use, lat/lon
+- **Verdict** — canned remediation for the detected failure mode
+
+Designed so a Discord helper can ask "paste `sudo droneaware
+gps-diagnose`" and immediately see the failure mode without back-and-
+forth.
+
+### Files changed
+
+- `wifi_feeder.py` — `_write_gps_state()` schema (+ `protocol` /
+  `fix_quality` / `sats_in_use`); new `detect_gps_protocol()` helper;
+  `gps_reader_thread()` runs protocol sniff before baud detection and
+  parses GGA alongside RMC.
+- `droneaware` (CLI) — updated `cmd_status` GPS block; new helper
+  functions `_sniff_gps_protocol`, `_check_gpsd_conflict`,
+  `_check_gps_protocol`, `_print_protocol_manual_fix`,
+  `_gps_sanity_check_update`; `cmd_update` runs sanity check before
+  service restart; new `cmd_gps_diagnose` + case-dispatch entry.
+- `install.sh` — `install_packages` adds `gpsd-clients`; new
+  `_sniff_gps_protocol`, `_check_gpsd_conflict`, `_check_gps_protocol`,
+  `_print_protocol_manual_fix`, `gps_sanity_check` (mirrors CLI
+  helpers — kept intentionally duplicated with "keep in sync"
+  comments in both files); `gps_sanity_check` added to main() between
+  `install_packages` and `download_binaries`.
+
+---
+
 ## [1.4.11] — Unreleased
 
 Installer hardening: `install.sh` no longer builds the enrollment request

--- a/droneaware
+++ b/droneaware
@@ -218,6 +218,149 @@ EOF
     #   fi
 }
 
+# ---------------------------------------------------------------------------
+# GPS sanity check helpers (v1.4.12+)
+# ---------------------------------------------------------------------------
+# Mirrored from install.sh so cmd_update and cmd_gps_diagnose can run the
+# same remediation on already-installed nodes. KEEP IN SYNC with the
+# `_sniff_gps_protocol` / `_check_gpsd_conflict` / `_check_gps_protocol` /
+# `_print_protocol_manual_fix` functions in install.sh — any edit to one
+# must be applied to the other or the two paths will drift.
+
+_sniff_gps_protocol() {
+    local device="$1"
+    local proto="unknown" hit_baud=""
+    for baud in 4800 9600 38400; do
+        stty -F "$device" $baud raw 2>/dev/null || continue
+        local hex
+        hex=$(timeout 2 head -c 256 "$device" 2>/dev/null | xxd -p -c 256 | tr -d '\n')
+        [[ -z "$hex" ]] && continue
+        if [[ "$hex" =~ 2447[45][0-9a-f] ]]; then
+            proto="nmea"; hit_baud=$baud; break
+        elif [[ "$hex" =~ a0a2 ]]; then
+            proto="sirf"; hit_baud=$baud; break
+        elif [[ "$hex" =~ b562 ]]; then
+            proto="ubx"; hit_baud=$baud; break
+        fi
+    done
+    echo "$proto $hit_baud"
+}
+
+_print_protocol_manual_fix() {
+    local proto="$1" device="$2"
+    echo ""
+    echo "  Manual remediation:"
+    echo "    1. sudo gpsctl -f -n $device       # tells the chip to switch to NMEA"
+    echo "    2. sudo systemctl restart droneaware-wifi"
+    echo "    3. sudo droneaware status          # verify GPS shows NMEA"
+    echo ""
+    echo "  If gpsctl doesn't work for your chip, use the manufacturer's utility"
+    echo "  (SiRFDemo for SiRF, u-center for u-blox) to switch the chip to NMEA."
+    echo ""
+}
+
+_check_gpsd_conflict() {
+    local gpsd_present=no
+    if systemctl is-enabled gpsd.socket >/dev/null 2>&1 || \
+       systemctl is-active gpsd >/dev/null 2>&1 || \
+       systemctl is-active gpsd.socket >/dev/null 2>&1 || \
+       dpkg -l gpsd 2>/dev/null | grep -q '^ii'; then
+        gpsd_present=yes
+    fi
+    if [[ "$gpsd_present" == "no" ]]; then
+        info "gpsd not present — no conflict."
+        return 0
+    fi
+    echo ""
+    echo "  gpsd is installed on this system. gpsd would seize the GPS serial"
+    echo "  port, preventing DroneAware from reading GPS data. DroneAware reads"
+    echo "  /dev/tty* directly and does not need gpsd."
+    echo ""
+    local resp
+    read -rp "  Disable gpsd? [Y/n]: " resp </dev/tty
+    if [[ "${resp,,}" == "n" || "${resp,,}" == "no" ]]; then
+        warn "gpsd left running — GPS may not work in DroneAware."
+        return 0
+    fi
+    systemctl stop gpsd gpsd.socket 2>/dev/null || true
+    systemctl disable gpsd gpsd.socket 2>/dev/null || true
+    systemctl mask gpsd gpsd.socket 2>/dev/null || true
+    pkill -x gpsd 2>/dev/null || true
+    info "gpsd stopped, disabled, and masked."
+}
+
+_check_gps_protocol() {
+    local device="$1"
+    if [[ -z "$device" ]]; then
+        return 0
+    fi
+    if [[ ! -e "$device" ]]; then
+        warn "$device not present — skipping GPS protocol check."
+        return 0
+    fi
+
+    local sniff proto baud
+    sniff=$(_sniff_gps_protocol "$device")
+    proto=$(echo "$sniff" | awk '{print $1}')
+    baud=$(echo "$sniff" | awk '{print $2}')
+
+    if [[ "$proto" == "nmea" ]]; then
+        info "GPS protocol: NMEA at $baud baud — good."
+        return 0
+    fi
+    if [[ "$proto" == "unknown" ]]; then
+        warn "Could not identify GPS protocol on $device. Check wiring/power."
+        warn "GPS may not work — try 'sudo droneaware gps-diagnose' for more detail."
+        return 0
+    fi
+
+    echo ""
+    echo "  GPS on $device is speaking '$proto' binary protocol, not NMEA."
+    echo "  DroneAware requires NMEA output."
+    echo ""
+    local resp
+    read -rp "  Attempt to switch the chip to NMEA now? [Y/n]: " resp </dev/tty
+    if [[ "${resp,,}" == "n" || "${resp,,}" == "no" ]]; then
+        _print_protocol_manual_fix "$proto" "$device"
+        return 0
+    fi
+
+    info "Running: gpsctl -f -n $device"
+    if command -v gpsctl >/dev/null 2>&1 && gpsctl -f -n "$device" 2>/dev/null; then
+        sleep 3
+        local reverify rproto rbaud
+        reverify=$(_sniff_gps_protocol "$device")
+        rproto=$(echo "$reverify" | awk '{print $1}')
+        rbaud=$(echo "$reverify" | awk '{print $2}')
+        if [[ "$rproto" == "nmea" ]]; then
+            info "GPS switched to NMEA at $rbaud baud."
+            return 0
+        fi
+        warn "gpsctl completed but chip still not in NMEA mode."
+    else
+        if ! command -v gpsctl >/dev/null 2>&1; then
+            warn "gpsctl not found — install gpsd-clients: sudo apt install -y --no-install-recommends gpsd-clients"
+        else
+            warn "gpsctl auto-fix failed (gpsctl exited non-zero)."
+        fi
+    fi
+    _print_protocol_manual_fix "$proto" "$device"
+}
+
+# Called from cmd_update after binaries are staged but before services
+# start. Reads GPS_DEVICE from config.env; skips cleanly when not set.
+_gps_sanity_check_update() {
+    local cfg="${INSTALL_DIR}/config.env"
+    local gps_dev
+    gps_dev=$(grep '^GPS_DEVICE=' "$cfg" 2>/dev/null | cut -d= -f2 | tr -d '"' | tr -d "'")
+    if [[ -z "$gps_dev" ]]; then
+        return 0
+    fi
+    heading "GPS Configuration Check"
+    _check_gpsd_conflict
+    _check_gps_protocol "$gps_dev"
+}
+
 cmd_update() {
     require_root "update"
     echo ""
@@ -375,6 +518,11 @@ cmd_update() {
         migrate_config_env
     fi
 
+    # v1.4.12+: run GPS sanity check (gpsd conflict + protocol mode) NOW,
+    # while feeder services are still stopped (so nothing is holding the
+    # port). Skips cleanly on nodes without GPS_DEVICE configured.
+    _gps_sanity_check_update
+
     systemctl daemon-reload
     systemctl start droneaware-wifi
     if hciconfig 2>/dev/null | grep -q "hci"; then
@@ -451,13 +599,23 @@ except Exception as e:
     print(f"  GPS      : state file unreadable ({e})")
     sys.exit(0)
 
-status     = s.get("status", "unknown")
-device     = s.get("device")
-baud       = s.get("baud")
-lat        = s.get("lat")
-lon        = s.get("lon")
-updated_at = s.get("updated_at") or 0
-age        = time.time() - updated_at
+status      = s.get("status", "unknown")
+device      = s.get("device")
+baud        = s.get("baud")
+lat         = s.get("lat")
+lon         = s.get("lon")
+protocol    = s.get("protocol")     # v1.4.12+: nmea|sirf|ubx|unknown
+fix_quality = s.get("fix_quality")  # v1.4.12+: from $GxGGA field 6
+sats        = s.get("sats_in_use")  # v1.4.12+: from $GxGGA field 7
+updated_at  = s.get("updated_at") or 0
+age         = time.time() - updated_at
+
+def dev_prefix():
+    return f"{device} @ {baud} baud" if baud is not None else f"{device}"
+
+def sats_phrase():
+    # "N sats" only when we have a GGA-derived count; empty otherwise.
+    return f", {sats} sats" if sats is not None else ""
 
 if status == "not_configured":
     # Terminal state — wifi_feeder writes this once at startup (when
@@ -472,20 +630,25 @@ elif age > 120:
     print(f"  GPS      : state stale ({int(age)}s old — wifi_feeder may have stopped)")
 elif status == "device_missing":
     print(f"  GPS      : {device} — configured but device not present")
+elif status == "wrong_protocol":
+    # v1.4.12+: chip is speaking SiRF binary / UBX / something we can't
+    # parse. Refresh every 30s in the reader thread. Point the operator
+    # at gps-diagnose which knows how to auto-fix common cases.
+    proto_name = {"sirf": "SiRF binary", "ubx": "u-blox UBX",
+                  "unknown": "unknown binary protocol"}.get(protocol, protocol or "unknown")
+    print(f"  GPS      : {device} — {proto_name} detected, DroneAware needs NMEA")
+    print(f"             run 'sudo droneaware gps-diagnose' for remediation")
 elif status == "detecting_baud":
     print(f"  GPS      : {device} — detecting baud rate...")
 elif status == "no_nmea":
     print(f"  GPS      : {device} — device exists but no valid NMEA detected")
 elif status == "reading":
-    if baud is not None:
-        print(f"  GPS      : {device} @ {baud} baud — reading NMEA, no fix yet")
-    else:
-        print(f"  GPS      : {device} — reading NMEA, no fix yet")
+    # No fix yet. Show sats-in-use if we've seen a GGA, else fall back
+    # to the pre-v1.4.12 wording.
+    print(f"  GPS      : {dev_prefix()} — NMEA{sats_phrase()}, no fix yet")
 elif status == "fix":
-    if baud is not None:
-        print(f"  GPS      : {device} @ {baud} baud — fix acquired (lat={lat}, lon={lon})")
-    else:
-        print(f"  GPS      : {device} — fix acquired (lat={lat}, lon={lon})")
+    # Have a fix. Sats + lat/lon on one line.
+    print(f"  GPS      : {dev_prefix()} — NMEA{sats_phrase()}, fix (lat={lat}, lon={lon})")
 else:
     print(f"  GPS      : {status}")
 PYEOF
@@ -956,12 +1119,146 @@ cmd_install_webui() {
     fi
 }
 
+cmd_gps_diagnose() {
+    require_root "gps-diagnose"
+    echo ""
+    echo -e "${BOLD}DroneAware GPS Diagnostic${NC}"
+    echo ""
+
+    local cfg="${INSTALL_DIR}/config.env"
+    local gps_dev gps_baud node_mobile
+    gps_dev=$(grep '^GPS_DEVICE='   "$cfg" 2>/dev/null | cut -d= -f2 | tr -d '"' | tr -d "'")
+    gps_baud=$(grep '^GPS_BAUD='    "$cfg" 2>/dev/null | cut -d= -f2 | tr -d '"' | tr -d "'")
+    node_mobile=$(grep '^NODE_MOBILE=' "$cfg" 2>/dev/null | cut -d= -f2 | tr -d '"' | tr -d "'")
+
+    echo "  Config (${cfg}):"
+    printf  "    GPS_DEVICE   = %s\n" "${gps_dev:-<empty>}"
+    printf  "    GPS_BAUD     = %s\n" "${gps_baud:-<empty — will auto-detect>}"
+    printf  "    NODE_MOBILE  = %s\n" "${node_mobile:-<empty>}"
+    echo ""
+
+    if [[ -z "$gps_dev" ]]; then
+        warn "GPS_DEVICE not set — this is a static node without GPS, or GPS auto-discovery hasn't run yet."
+        warn "Nothing to diagnose. Re-run install.sh to configure GPS, or set GPS_DEVICE in ${cfg} manually."
+        echo ""
+        return 0
+    fi
+
+    echo "  Device:"
+    if [[ -e "$gps_dev" ]]; then
+        info "$gps_dev exists"
+    else
+        echo -e "    ${RED}✗${NC}  $gps_dev does NOT exist — puck unplugged? kernel driver missing?"
+        echo "    Recent USB messages: sudo dmesg | tail -20"
+        echo ""
+        return 0
+    fi
+    # Permissions — droneaware user needs dialout group to read /dev/tty*
+    if [[ -r "$gps_dev" ]]; then
+        info "readable"
+    else
+        warn "not readable by current user (this shouldn't matter — droneaware user access is what counts)"
+    fi
+    # Driver hint from dmesg (best effort)
+    local drv
+    drv=$(dmesg 2>/dev/null | grep -iE "ch341|pl2303|cp210|ftdi|cdc_acm" | tail -1)
+    [[ -n "$drv" ]] && echo "    kernel: $drv" | cut -c1-140
+    echo ""
+
+    echo "  Port ownership (fuser):"
+    local owners
+    owners=$(fuser -v "$gps_dev" 2>&1 | tail -n +2)
+    if [[ -z "$owners" ]]; then
+        info "no process holds the port"
+    else
+        # Look for gpsd or wifi_feeder in the ownership list
+        if echo "$owners" | grep -q gpsd; then
+            echo -e "    ${RED}✗${NC}  gpsd holds the port — DroneAware cannot read GPS"
+            echo "$owners" | sed 's/^/      /'
+            echo ""
+            echo "  Remediation:"
+            echo "    sudo systemctl stop gpsd gpsd.socket"
+            echo "    sudo systemctl mask gpsd gpsd.socket"
+            echo "    sudo pkill -x gpsd"
+            echo "    # then re-run this command"
+            echo ""
+            return 0
+        elif echo "$owners" | grep -qE "wifi_feeder|python"; then
+            info "held by wifi_feeder (expected)"
+            echo "$owners" | sed 's/^/      /'
+        else
+            warn "held by unknown process"
+            echo "$owners" | sed 's/^/      /'
+        fi
+    fi
+    echo ""
+
+    echo "  Protocol detection:"
+    # If wifi_feeder holds the port, skip live sniffing (would fail) and
+    # report from the state file instead. Otherwise probe fresh.
+    local proto="" baud=""
+    if echo "$owners" | grep -qE "wifi_feeder|python"; then
+        echo "    (port held by wifi_feeder — reporting from state file, not re-sniffing)"
+    else
+        local sniff
+        sniff=$(_sniff_gps_protocol "$gps_dev")
+        proto=$(echo "$sniff" | awk '{print $1}')
+        baud=$(echo "$sniff" | awk '{print $2}')
+        case "$proto" in
+            nmea)    info "NMEA detected at $baud baud" ;;
+            sirf)    warn "SiRF binary detected at $baud baud — DroneAware needs NMEA" ;;
+            ubx)     warn "u-blox UBX detected at $baud baud — DroneAware needs NMEA" ;;
+            unknown) warn "no known protocol detected at any baud (4800/9600/38400)" ;;
+        esac
+    fi
+    echo ""
+
+    echo "  Recent GPS state (/run/droneaware/gps_state.json):"
+    python3 - <<'PY'
+import json, time, sys
+try:
+    with open("/run/droneaware/gps_state.json") as f:
+        s = json.load(f)
+except FileNotFoundError:
+    print("    state file missing — wifi_feeder not running, or hasn't written yet")
+    sys.exit(0)
+except Exception as e:
+    print(f"    state file unreadable: {e}")
+    sys.exit(0)
+age = int(time.time() - (s.get("updated_at") or 0))
+print(f"    age:          {age}s")
+print(f"    status:       {s.get('status')}")
+print(f"    protocol:     {s.get('protocol')}")
+print(f"    baud:         {s.get('baud')}")
+print(f"    fix_quality:  {s.get('fix_quality')}")
+print(f"    sats_in_use:  {s.get('sats_in_use')}")
+print(f"    lat, lon:     {s.get('lat')}, {s.get('lon')}")
+PY
+    echo ""
+
+    # Verdict: quick reading of protocol + state.
+    echo "  Verdict:"
+    case "$proto" in
+        nmea)    echo -e "    ${GREEN}GPS looks healthy.${NC} If sats_in_use is 0, wait for sky view + satellite lock." ;;
+        sirf|ubx)
+            echo "    Puck is in binary mode — auto-fix with:"
+            echo "      sudo gpsctl -f -n $gps_dev"
+            echo "      sudo systemctl restart droneaware-wifi"
+            echo "      sudo droneaware gps-diagnose   # to re-verify"
+            ;;
+        unknown) echo "    Could not identify protocol. Check the puck's power/wiring and try 'sudo dmesg | tail -20'." ;;
+        "")      echo "    (protocol detection skipped — see above)" ;;
+    esac
+    echo ""
+}
+
 case "$1" in
     update)         cmd_update ;;
     status)         cmd_status ;;
     logs)           cmd_logs "$@" ;;
     test)           cmd_test "$@" ;;
     install-webui)  cmd_install_webui ;;
+    gps-diagnose)   cmd_gps_diagnose ;;
     __migrate)
         # Internal subcommand used by cmd_update for post-install config
         # migration. The double-underscore prefix is a convention signaling
@@ -987,6 +1284,7 @@ case "$1" in
         echo "    test            Transmit a 60-second test flight and verify detection"
         echo "    test --dry-run  Check rate-limit availability without transmitting"
         echo "    install-webui   Install the optional local Web UI (LAN dashboard)"
+        echo "    gps-diagnose    Read-only GPS health check (device, port, protocol, state)"
         echo ""
         ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -528,8 +528,13 @@ EOF
 install_packages() {
     heading "Installing System Packages"
     apt-get update -qq
+    # gpsd-clients gives us `gpsctl` for the GPS protocol auto-fix
+    # (SiRF/UBX → NMEA). --no-install-recommends is important: without it
+    # apt pulls gpsd itself, which would seize the GPS port and prevent
+    # DroneAware from reading it. gpsd-clients works standalone in the
+    # `gpsctl -f -n /dev/xxx` direct-to-device mode we use.
     apt-get install -y --no-install-recommends \
-        bluez bluetooth iw rfkill curl \
+        bluez bluetooth iw rfkill curl gpsd-clients \
         > /dev/null 2>&1
     systemctl enable bluetooth > /dev/null 2>&1
     systemctl start bluetooth  > /dev/null 2>&1
@@ -542,6 +547,158 @@ install_packages() {
     # Allow feeder to read GPS serial device without root
     usermod -aG dialout "$SUDO_USER" 2>/dev/null || true
     info "System packages ready."
+}
+
+# ---------------------------------------------------------------------------
+# 6.5. GPS sanity check (v1.4.12+)
+# ---------------------------------------------------------------------------
+# Runs after install_packages (so gpsctl is available) and before we start
+# services. Two independent checks — both skip cleanly if there's no GPS
+# device to configure (static nodes, mobile nodes without a puck yet):
+#
+#   1. gpsd detection: gpsd would seize the serial port and block
+#      DroneAware from reading GPS. Prompt to mask + kill it.
+#   2. Protocol check: puck may be in SiRF/UBX binary mode (common gotcha
+#      with BU-353S4 and similar). DroneAware needs NMEA. Attempt an
+#      auto-fix via `gpsctl -f -n`; print manual instructions if that
+#      doesn't take.
+#
+# Mirrored in the `droneaware` CLI's cmd_update path so existing operators
+# get the same remediation on their next update. Keep the logic in sync
+# between install.sh and the CLI.
+
+# Sniff the GPS device to identify its output protocol. Prints "proto baud"
+# on stdout (proto ∈ nmea|sirf|ubx|unknown; baud is empty on unknown).
+_sniff_gps_protocol() {
+    local device="$1"
+    local proto="unknown" hit_baud=""
+    for baud in 4800 9600 38400; do
+        stty -F "$device" $baud raw 2>/dev/null || continue
+        # Read up to 256 bytes with a 2s wall clock cap, hex-encode.
+        local hex
+        hex=$(timeout 2 head -c 256 "$device" 2>/dev/null | xxd -p -c 256 | tr -d '\n')
+        [[ -z "$hex" ]] && continue
+        # $G followed by an ASCII uppercase letter (0x40–0x5F).
+        if [[ "$hex" =~ 2447[45][0-9a-f] ]]; then
+            proto="nmea"; hit_baud=$baud; break
+        elif [[ "$hex" =~ a0a2 ]]; then
+            proto="sirf"; hit_baud=$baud; break
+        elif [[ "$hex" =~ b562 ]]; then
+            proto="ubx"; hit_baud=$baud; break
+        fi
+    done
+    echo "$proto $hit_baud"
+}
+
+_print_protocol_manual_fix() {
+    local proto="$1" device="$2"
+    echo ""
+    echo "  Manual remediation:"
+    echo "    1. sudo gpsctl -f -n $device       # tells the chip to switch to NMEA"
+    echo "    2. sudo systemctl restart droneaware-wifi"
+    echo "    3. sudo droneaware status          # verify GPS shows NMEA"
+    echo ""
+    echo "  If gpsctl doesn't work for your chip, use the manufacturer's utility"
+    echo "  (SiRFDemo for SiRF, u-center for u-blox) to switch the chip to NMEA."
+    echo ""
+}
+
+_check_gpsd_conflict() {
+    local gpsd_present=no
+    if systemctl is-enabled gpsd.socket >/dev/null 2>&1 || \
+       systemctl is-active gpsd >/dev/null 2>&1 || \
+       systemctl is-active gpsd.socket >/dev/null 2>&1 || \
+       dpkg -l gpsd 2>/dev/null | grep -q '^ii'; then
+        gpsd_present=yes
+    fi
+    if [[ "$gpsd_present" == "no" ]]; then
+        info "gpsd not present — no conflict."
+        return 0
+    fi
+    echo ""
+    echo "  gpsd is installed on this system. gpsd would seize the GPS serial"
+    echo "  port, preventing DroneAware from reading GPS data. DroneAware reads"
+    echo "  /dev/tty* directly and does not need gpsd."
+    echo ""
+    local resp
+    read -rp "  Disable gpsd? [Y/n]: " resp </dev/tty
+    if [[ "${resp,,}" == "n" || "${resp,,}" == "no" ]]; then
+        warn "gpsd left running — GPS may not work in DroneAware."
+        return 0
+    fi
+    systemctl stop gpsd gpsd.socket 2>/dev/null || true
+    systemctl disable gpsd gpsd.socket 2>/dev/null || true
+    systemctl mask gpsd gpsd.socket 2>/dev/null || true
+    pkill -x gpsd 2>/dev/null || true
+    info "gpsd stopped, disabled, and masked."
+}
+
+_check_gps_protocol() {
+    local device="${GPS_DEVICE:-}"
+    if [[ -z "$device" ]]; then
+        return 0
+    fi
+    if [[ ! -e "$device" ]]; then
+        warn "$device not present — skipping GPS protocol check."
+        return 0
+    fi
+
+    local sniff proto baud
+    sniff=$(_sniff_gps_protocol "$device")
+    proto=$(echo "$sniff" | awk '{print $1}')
+    baud=$(echo "$sniff" | awk '{print $2}')
+
+    if [[ "$proto" == "nmea" ]]; then
+        info "GPS protocol: NMEA at $baud baud — good."
+        return 0
+    fi
+    if [[ "$proto" == "unknown" ]]; then
+        warn "Could not identify GPS protocol on $device. Check wiring/power."
+        warn "GPS may not work — try 'sudo droneaware gps-diagnose' after install."
+        return 0
+    fi
+
+    # SiRF or UBX — offer auto-fix.
+    echo ""
+    echo "  GPS on $device is speaking '$proto' binary protocol, not NMEA."
+    echo "  DroneAware requires NMEA output."
+    echo ""
+    local resp
+    read -rp "  Attempt to switch the chip to NMEA now? [Y/n]: " resp </dev/tty
+    if [[ "${resp,,}" == "n" || "${resp,,}" == "no" ]]; then
+        _print_protocol_manual_fix "$proto" "$device"
+        return 0
+    fi
+
+    info "Running: gpsctl -f -n $device"
+    if gpsctl -f -n "$device" 2>/dev/null; then
+        # Chip may need a moment to switch modes; re-sniff to verify.
+        sleep 3
+        local reverify
+        reverify=$(_sniff_gps_protocol "$device")
+        local rproto rbaud
+        rproto=$(echo "$reverify" | awk '{print $1}')
+        rbaud=$(echo "$reverify" | awk '{print $2}')
+        if [[ "$rproto" == "nmea" ]]; then
+            info "GPS switched to NMEA at $rbaud baud."
+            return 0
+        fi
+        warn "gpsctl completed but chip still not in NMEA mode."
+    else
+        warn "gpsctl auto-fix failed (gpsctl exited non-zero)."
+    fi
+    _print_protocol_manual_fix "$proto" "$device"
+}
+
+gps_sanity_check() {
+    # No GPS device configured (static without GPS, or mobile with no puck
+    # plugged in yet) → nothing to check.
+    if [[ -z "${GPS_DEVICE:-}" ]]; then
+        return 0
+    fi
+    heading "GPS Configuration Check"
+    _check_gpsd_conflict
+    _check_gps_protocol
 }
 
 # ---------------------------------------------------------------------------
@@ -1042,6 +1199,7 @@ pin_wifi_unmanaged
 prompt_node_id
 prompt_location
 install_packages
+gps_sanity_check
 download_binaries
 install_services
 write_config

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -1405,7 +1405,10 @@ _GPS_STATE_PATH = "/run/droneaware/gps_state.json"
 
 def _write_gps_state(*, device: str | None = None, baud: int | None = None,
                      status: str = "unknown", last_nmea_at: float | None = None,
-                     lat: float | None = None, lon: float | None = None) -> None:
+                     lat: float | None = None, lon: float | None = None,
+                     protocol: str | None = None,
+                     fix_quality: int | None = None,
+                     sats_in_use: int | None = None) -> None:
     """Atomically write the current GPS state for the CLI to read.
     Soft-fails on any I/O error — state-file display is informational,
     feeder operation continues regardless of whether this succeeds.
@@ -1413,10 +1416,20 @@ def _write_gps_state(*, device: str | None = None, baud: int | None = None,
     Status values:
       not_configured  — no GPS device path found / configured
       device_missing  — configured/found device path does not exist on disk
+      wrong_protocol  — device speaks a non-NMEA protocol (SiRF, UBX) that
+                        DroneAware can't parse; protocol field carries which
       detecting_baud  — probing baud rates against the device
       no_nmea         — device opened but no valid NMEA sentences received
       reading         — serial port open, NMEA flowing, awaiting first fix
       fix             — most recent $GPRMC was "A" (active/valid); lat/lon populated
+
+    Extended fields (v1.4.12+):
+      protocol        — "nmea" | "sirf" | "ubx" | "unknown"; whatever the
+                        startup sniff identified. None until sniff has run.
+      fix_quality     — GGA field 6: 0=no fix, 1=GPS SPS, 2=DGPS, 4=RTK fixed,
+                        5=RTK float, 6=estimated. None if no GGA seen yet.
+      sats_in_use     — GGA field 7: satellites contributing to the fix.
+                        None if no GGA seen yet.
     """
     try:
         os.makedirs(os.path.dirname(_GPS_STATE_PATH), exist_ok=True)
@@ -1427,6 +1440,9 @@ def _write_gps_state(*, device: str | None = None, baud: int | None = None,
             "last_nmea_at": last_nmea_at,
             "lat":          lat,
             "lon":          lon,
+            "protocol":     protocol,
+            "fix_quality":  fix_quality,
+            "sats_in_use":  sats_in_use,
             "updated_at":   time.time(),
         }
         tmp = _GPS_STATE_PATH + ".tmp"
@@ -1435,6 +1451,49 @@ def _write_gps_state(*, device: str | None = None, baud: int | None = None,
         os.replace(tmp, _GPS_STATE_PATH)
     except Exception:
         pass
+
+
+# Non-NMEA GPS protocol magic bytes. These are the two most common
+# "not NMEA" cases we see in the fleet: SiRF binary (Star III/IV chipset,
+# e.g. BU-353S4) and u-blox UBX (NEO-6/7/8). Detection is best-effort —
+# other exotic protocols land in the "unknown" bucket, still surfacing
+# a diagnostic to the operator.
+_SIRF_SYNC = b"\xa0\xa2"    # SiRF binary frame start
+_UBX_SYNC  = b"\xb5\x62"    # u-blox UBX frame start
+
+
+def detect_gps_protocol(device: str) -> tuple[str, int | None]:
+    """Sniff the GPS device to identify its output protocol.
+
+    Returns (protocol, baud) where protocol is one of "nmea"/"sirf"/"ubx"/"unknown"
+    and baud is the rate at which the protocol was recognized (None on "unknown").
+
+    Runs before baud detection so the state file distinguishes "wrong
+    protocol" (SiRF/UBX — puck needs re-flashing back to NMEA) from "wrong
+    baud" from "no signal." NMEA is our only supported input — SiRF/UBX
+    pucks are auto-fixed by install.sh / cmd_update / gps-diagnose, but
+    the runtime just reports the state and lets those paths handle it.
+    Log-only at feeder startup: we never modify the chip from the reader.
+    """
+    for baud in GPS_BAUD_RATES:
+        try:
+            with serial.Serial(device, baudrate=baud, timeout=2) as ser:
+                sample = ser.read(512)
+                if not sample:
+                    continue
+                # NMEA sentences start with '$G' followed by two ASCII letters
+                # (GP, GN, GL, GA, GB — every talker prefix we care about).
+                # Any occurrence within the sample counts as a positive ID.
+                for i in range(len(sample) - 3):
+                    if sample[i:i+2] == b"$G" and sample[i+2:i+4].isalpha():
+                        return ("nmea", baud)
+                if _SIRF_SYNC in sample:
+                    return ("sirf", baud)
+                if _UBX_SYNC in sample:
+                    return ("ubx", baud)
+        except serial.SerialException:
+            continue
+    return ("unknown", None)
 
 
 def find_gps_device() -> str | None:
@@ -1536,9 +1595,30 @@ def gps_reader_thread(device: str):
                 time.sleep(10)
                 continue
 
-            _write_gps_state(device=device, status="detecting_baud")
+            # Protocol sniff BEFORE baud detection. Log-only — the reader
+            # never modifies the chip. If the puck is in SiRF/UBX mode we
+            # surface that in the state file so `droneaware status` /
+            # `droneaware gps-diagnose` can guide the operator to run the
+            # remediation path (installer / cmd_update / gps-diagnose --fix).
+            protocol, sniff_baud = detect_gps_protocol(device)
+            if protocol != "nmea":
+                _write_gps_state(device=device, status="wrong_protocol",
+                                 protocol=protocol, baud=sniff_baud)
+                log.warning(
+                    f"[GPS] Device {device} is in '{protocol}' mode, not NMEA — "
+                    "DroneAware cannot parse this. Run 'sudo droneaware gps-diagnose' "
+                    "for remediation. Retrying in 30s."
+                )
+                time.sleep(30)
+                continue
 
-            # Use GPS_BAUD from config.env if set, otherwise auto-detect
+            _write_gps_state(device=device, status="detecting_baud",
+                             protocol="nmea")
+
+            # Use GPS_BAUD from config.env if set, otherwise auto-detect.
+            # The protocol sniff already found the baud NMEA lives at, so
+            # prefer it when the config is empty (avoids a second full
+            # baud sweep for common cases).
             configured_baud = os.environ.get("GPS_BAUD", "").strip()
             if configured_baud:
                 try:
@@ -1546,21 +1626,44 @@ def gps_reader_thread(device: str):
                     log.info(f"[GPS] Using configured baud rate {baud}")
                 except ValueError:
                     log.warning(f"[GPS] Invalid GPS_BAUD value '{configured_baud}' — falling back to auto-detect")
-                    baud = detect_baud_rate(device)
+                    baud = sniff_baud or detect_baud_rate(device)
             else:
-                baud = detect_baud_rate(device)
+                baud = sniff_baud or detect_baud_rate(device)
 
             if baud is None:
-                _write_gps_state(device=device, status="no_nmea")
+                _write_gps_state(device=device, status="no_nmea",
+                                 protocol="nmea")
                 log.warning(f"[GPS] Could not detect baud rate on {device} — retrying in 10s")
                 time.sleep(10)
                 continue
+
+            # Latest GGA-derived metadata carried across every state write
+            # while the read loop is active. GGA sentences arrive at ~1 Hz
+            # alongside RMC; we store the most-recent values so status shows
+            # sats/fix quality even between RMC-triggered fix writes.
+            fix_quality: int | None = None
+            sats_in_use: int | None = None
+
             with serial.Serial(device, baudrate=baud, timeout=2) as ser:
                 log.info(f"[GPS] Reading from {device} at {baud} baud")
                 _write_gps_state(device=device, baud=baud, status="reading",
-                                 last_nmea_at=time.time())
+                                 last_nmea_at=time.time(), protocol="nmea")
                 while True:
                     line = ser.readline().decode('ascii', errors='ignore').strip()
+
+                    # GGA — fix quality + sats-in-use. Field layout:
+                    #   $GxGGA,time,lat,N,lon,W,fix_quality,sats,hdop,...
+                    #   0     1    2   3 4   5 6           7    8
+                    if line.startswith(('$GPGGA', '$GNGGA')):
+                        parts = line.split(',')
+                        if len(parts) >= 8:
+                            try:
+                                fix_quality = int(parts[6]) if parts[6] else 0
+                                sats_in_use = int(parts[7]) if parts[7] else 0
+                            except (ValueError, IndexError):
+                                pass
+                        continue
+
                     if not line.startswith(('$GPRMC', '$GNRMC')):
                         continue
                     parts = line.split(',')
@@ -1573,7 +1676,9 @@ def gps_reader_thread(device: str):
                             _gps_lat = lat
                             _gps_lon = lon
                         _write_gps_state(device=device, baud=baud, status="fix",
-                                         last_nmea_at=time.time(), lat=lat, lon=lon)
+                                         last_nmea_at=time.time(), lat=lat, lon=lon,
+                                         protocol="nmea", fix_quality=fix_quality,
+                                         sats_in_use=sats_in_use)
                     except (ValueError, IndexError):
                         continue
         except serial.SerialException as e:


### PR DESCRIPTION
## Summary

**GPS observability & auto-remediation release.** Two operator incidents in one week (BU-353S4 puck stuck in SiRF binary mode after gpsd probed it; second operator hit gpsd holding the port at install time) drove a coordinated fix across the runtime, installer, update path, and a new diagnostic command. All changes are additive — no protocol or server contract touches.

**Note on v1.4.11:** shipped as its own tag but was installer-only (python3 `json.dumps` for enrollment body). Existing operators upgrading via `sudo droneaware update` see no runtime difference from v1.4.11 — v1.4.12 is the first release since v1.4.10 that reaches existing operators via `droneaware update`.

## What's in this release

### 1. Runtime — richer GPS state + protocol detection (`wifi_feeder.py`)

- **Protocol sniff at startup** — categorizes as `nmea`/`sirf`/`ubx`/`unknown` before opening the read loop. **Log-only** (never modifies the chip). Writes `protocol` field to `/run/droneaware/gps_state.json`.
- **`$GxGGA` parsing** — extracts `fix_quality` (field 6) and `sats_in_use` (field 7); persists alongside every state write.
- **New status `wrong_protocol`** — 30s backoff (vs 10s) since chip can't recover without out-of-band mode change.

### 2. `sudo droneaware status` — sats, fix, protocol inline

```
GPS : /dev/ttyUSB0 @ 4800 baud — NMEA, 8 sats, fix (lat=..., lon=...)
GPS : /dev/ttyUSB0 @ 4800 baud — NMEA, 3 sats, no fix yet
GPS : /dev/ttyUSB0 — SiRF binary detected, DroneAware needs NMEA
      run 'sudo droneaware gps-diagnose' for remediation
```

### 3. `install.sh` — gpsd conflict prompt + protocol auto-fix

New `gps_sanity_check` phase between `install_packages` and `download_binaries`:
- **gpsd detection** via three signals (`systemctl is-enabled gpsd.socket`, `is-active`, `dpkg -l`). Prompts to `stop → disable → mask → pkill -x gpsd` (default `Y`).
- **Protocol sniff** at 4800/9600/38400 baud. If SiRF/UBX, prompts to auto-fix via `gpsctl -f -n`, verifies by re-sniff, falls back to printed manual instructions.
- Installs `gpsd-clients --no-install-recommends` — critical flag, without it apt pulls gpsd itself which defeats the purpose.

### 4. `sudo droneaware update` — mirrored remediation

Same sanity-check runs on existing nodes after config migration but before service restart. Existing operators with a broken GPS get an in-band fix on their next update.

**Known one-release lag:** since v1.4.11's `cmd_update` doesn't know about this check, the check only fires from v1.4.12 → v1.4.13+. v1.4.11 → v1.4.12 operators need `sudo droneaware gps-diagnose` to see + manually apply the remediation.

### 5. New: `sudo droneaware gps-diagnose`

Read-only diagnostic with sections for Config, Device, Port ownership (flags gpsd explicitly), Protocol detection, Recent GPS state, and canned Verdict + remediation. Designed so a Discord helper can ask "paste this output" and see the failure mode without back-and-forth.

## Files changed

- `wifi_feeder.py` — extended `_write_gps_state()` schema; new `detect_gps_protocol()`; `gps_reader_thread()` sniffs protocol before baud detection, parses GGA alongside RMC.
- `droneaware` (CLI) — updated `cmd_status` GPS block; new helper functions (`_sniff_gps_protocol`, `_check_gpsd_conflict`, `_check_gps_protocol`, `_print_protocol_manual_fix`, `_gps_sanity_check_update`); `cmd_update` runs sanity check; new `cmd_gps_diagnose` + case-dispatch entry.
- `install.sh` — `install_packages` adds `gpsd-clients`; new `gps_sanity_check` + helpers (mirrors CLI — kept intentionally duplicated with "keep in sync" comments).
- `CHANGELOG.md` — v1.4.12 entry.

## Verified locally

- Every CLI status branch renders correctly against synthetic state files (11 cases: `not_configured`, `state_stale`, `device_missing`, three `wrong_protocol` variants, `detecting_baud`, `no_nmea`, `reading` with/without sats, `fix_full`).
- `bash -n` clean for install.sh and droneaware CLI.
- `gps-diagnose` output verified on this node for `GPS_DEVICE=<empty>` and `GPS_DEVICE=/dev/ttyUSB99` (missing) branches.