### PR TITLE
v1.4.12.2: fix heading() undefined + post-mask sleep for gpsd remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,51 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.4.12.2] — Unreleased
+
+Two small fixes for `_gps_sanity_check_update` (invoked from
+`cmd_update`), both surfaced during the v1.4.12.1 update on
+njpi-120hotfix.
+
+### Fixes
+
+1. **`heading: command not found` mid-update.** When
+   `_gps_sanity_check_update` was mirrored from install.sh into the
+   CLI, its call to `heading()` slipped through — that helper is
+   defined in install.sh but wasn't in the CLI. Update ran to
+   completion (the shell error didn't halt the sanity check) but
+   printed a misleading error line right where the section header
+   should have appeared. Fixed by adding a matching `heading()`
+   helper next to the CLI's existing `info` / `warn` / `fatal`.
+
+2. **Post-mask sleep before protocol sniff.** After
+   `_check_gpsd_conflict` stopped + masked + killed gpsd, the
+   immediately-following `_check_gps_protocol` sniff ran too fast:
+   the kernel hadn't fully released the tty, so the sniff saw an
+   empty/still-locked port and reported "unknown protocol." That
+   caused the diagnostic to falsely warn "GPS may not work" even
+   though the puck was healthy (verified by the very next
+   `gps-diagnose` run once the port had settled). Fixed by adding
+   a 3-second sleep between the pkill and the info line, in both
+   install.sh and the CLI's mirrored helper. 3s is empirically
+   enough for pl2303/ftdi/cdc-acm devices.
+
+### Note
+
+Full v1.4.12.1 feature scope confirmed working end-to-end during
+the same test run — every one of the six polish fixes was visible
+in the post-update `gps-diagnose` output. This release just cleans
+up the two rough edges observed during that validation.
+
+### Files changed
+
+- `droneaware` (CLI) — added `heading()` helper; 3-second sleep
+  after gpsd mask in `_check_gpsd_conflict`.
+- `install.sh` — same 3-second sleep after gpsd mask (keep-in-sync
+  pair with the CLI helper).
+
+---
+
 ## [1.4.12.1] — Unreleased
 
 **Cosmetic hotfix for v1.4.12's `gps-diagnose` command** — six issues

--- a/droneaware
+++ b/droneaware
@@ -7,9 +7,14 @@ INSTALL_DIR="/opt/droneaware"
 VERSION_FILE="${INSTALL_DIR}/version"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; NC='\033[0m'
-info()  { echo -e "  ${GREEN}✓${NC}  $*"; }
-warn()  { echo -e "  ${YELLOW}!${NC}  $*"; }
-fatal() { echo -e "\n  ${RED}✗  ERROR: $*${NC}\n"; exit 1; }
+info()    { echo -e "  ${GREEN}✓${NC}  $*"; }
+warn()    { echo -e "  ${YELLOW}!${NC}  $*"; }
+fatal()   { echo -e "\n  ${RED}✗  ERROR: $*${NC}\n"; exit 1; }
+# v1.4.12.2+: `heading` mirrors install.sh's helper — needed because
+# _gps_sanity_check_update was ported from install.sh and calls heading()
+# before its check runs. Missing definition previously threw
+# "heading: command not found" mid-update.
+heading() { echo -e "\n${BOLD}$*${NC}"; }
 
 require_root() { [[ $EUID -eq 0 ]] || fatal "Run with sudo: sudo droneaware $1"; }
 
@@ -323,6 +328,12 @@ _check_gpsd_conflict() {
     systemctl disable gpsd gpsd.socket 2>/dev/null || true
     systemctl mask gpsd gpsd.socket 2>/dev/null || true
     pkill -x gpsd 2>/dev/null || true
+    # v1.4.12.2+: give the kernel a moment to release the tty after
+    # gpsd's exit. Without this, the immediately-following protocol
+    # sniff sees an empty/still-locked port and misreports "unknown
+    # protocol" — surfaced during v1.4.12.1's cmd_update run on
+    # njpi-120hotfix. 3s is empirically enough for pl2303/ftdi/cdc-acm.
+    sleep 3
     info "gpsd stopped, disabled, and masked."
 }
 

--- a/install.sh
+++ b/install.sh
@@ -633,6 +633,11 @@ _check_gpsd_conflict() {
     systemctl disable gpsd gpsd.socket 2>/dev/null || true
     systemctl mask gpsd gpsd.socket 2>/dev/null || true
     pkill -x gpsd 2>/dev/null || true
+    # v1.4.12.2+: give the kernel a moment to release the tty after
+    # gpsd's exit. Without this, the immediately-following protocol
+    # sniff sees an empty/still-locked port and misreports "unknown
+    # protocol". 3s is empirically enough for pl2303/ftdi/cdc-acm.
+    sleep 3
     info "gpsd stopped, disabled, and masked."
 }
 


### PR DESCRIPTION
## Summary

Two small fixes for `_gps_sanity_check_update` (invoked from `cmd_update`), both surfaced during the v1.4.12.1 update on njpi-120hotfix.

## Fixes

**1. `heading: command not found` mid-update.** When `_gps_sanity_check_update` was mirrored from install.sh into the CLI, its call to `heading()` slipped through — that helper is defined in install.sh but wasn't in the CLI. Update ran to completion (the shell error didn't halt the sanity check) but printed a misleading error line where the section header should have appeared. Fixed by adding a matching `heading()` helper next to the CLI's existing `info` / `warn` / `fatal`.

**2. Post-mask sleep before protocol sniff.** After `_check_gpsd_conflict` stopped + masked + killed gpsd, the immediately-following `_check_gps_protocol` sniff ran too fast: the kernel hadn't fully released the tty, so the sniff saw an empty/still-locked port and reported "unknown protocol." Diagnostic then falsely warned "GPS may not work" even though the puck was healthy (verified by the very next `gps-diagnose` once the port had settled). Fixed by adding a 3-second sleep between the `pkill` and the info line, in both install.sh and the CLI's mirrored helper. 3s is empirically enough for pl2303/ftdi/cdc-acm devices.

## Files changed

- `droneaware` (CLI) — added `heading()` helper; 3-second sleep after gpsd mask in `_check_gpsd_conflict`.
- `install.sh` — same 3-second sleep after gpsd mask (keep-in-sync pair with the CLI helper).
- `CHANGELOG.md` — v1.4.12.2 entry.

## Note

Full v1.4.12.1 feature scope confirmed working end-to-end during the same test run — every one of the six polish fixes was visible in the post-update `gps-diagnose` output. This release just cleans up the two rough edges observed during that validation.