### PR TITLE
v1.5.0: multi-radio + adapter-identification fragility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,184 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.0] — Unreleased
+
+**Multi-radio milestone.** Adapter-identification fragility fixed for
+good, dual-adapter dual-band scanning shipped, per-band feeder
+visibility everywhere.
+
+### The headline change
+
+Nodes with **two USB monitor adapters** now scan **both bands
+continuously**, not alternately. One adapter locks to 2.4 GHz (channel
+hop), the other locks to 5 GHz channel 149. No dwelling, no context-
+switch latency, no missed drones flying through the "wrong" band during
+the switch window. Nodes with one adapter still work exactly as before
+(single-adapter dwell mode).
+
+### Adapter identification is now MAC-based
+
+Root cause of the adapter-fragility bug reported by an operator:
+`WIFI_ADAPTER=wlan1` in `config.env` broke every time USB enumeration
+reshuffled `wlanN` assignments (adding hardware, moving cables between
+ports, hot-plug). The Pi's onboard WiFi could end up at wlan1 and get
+seized as monitor, breaking SSH. v1.5.0 rebuilds this from the ground
+up:
+
+- **All adapter identification uses MAC**, not interface name. MAC is
+  a physical property; wlanN is a kernel-assignment artifact that
+  shuffles.
+- **Onboard is unpickable as monitor.** Hard filter via
+  driver (`brcmfmac`) + bus (`sdio`/`mmc`) blocks all resolution paths
+  from returning the Pi onboard, even if config explicitly points at
+  its MAC. Choosing onboard = self-inflicted SSH lockout, so we refuse.
+- **Classifier + role assignment** built into wifi_feeder. Enumerates
+  all wlan interfaces, filters to USB-only monitor-capable adapters,
+  assigns 5 GHz / 2.4 GHz roles under capability constraints (a
+  2.4-only adapter cannot take the 5 GHz role — this is a hard
+  constraint, not a preference).
+- **NetworkManager config auto-regenerated** from resolved MAC(s).
+  `/etc/NetworkManager/conf.d/droneaware.conf` no longer stales when
+  the operator swaps adapters — a subsequent `sudo droneaware refresh`
+  or `sudo droneaware update` rewrites it.
+
+### New: `sudo droneaware refresh`
+
+Operator-visible orchestration command. Re-detects hardware (WiFi
+adapters, GPS protocol/gpsd conflict), migrates config, regenerates NM
+config, and switches systemd unit topology if the number of monitor
+adapters changed. Idempotent — safe to run repeatedly. Doesn't require
+a new release (unlike `droneaware update`).
+
+Mental model:
+- **New release available** → `sudo droneaware update`
+- **Changed hardware or want to re-verify state** → `sudo droneaware refresh`
+
+Both call the same underlying migration logic; `update` adds the
+binary-download step.
+
+### New: dual-adapter systemd units
+
+Two new services ship alongside the existing `droneaware-wifi.service`:
+
+- `droneaware-wifi-2g.service` — dedicated 2.4 GHz feeder, hops
+  1/6/11, reads `WIFI_ADAPTER_2G_MAC`
+- `droneaware-wifi-5g.service` — dedicated 5 GHz feeder, locked to
+  channel 149, reads `WIFI_ADAPTER_5G_MAC`
+- `droneaware-wifi.service` — unchanged single-adapter unit for nodes
+  with only one monitor adapter (dwells across bands if capable)
+
+The three units are mutually exclusive (`Conflicts=` in unit files).
+Mode-switching is automatic: the classifier detects the number of
+monitor-capable USB adapters and enables the appropriate service(s).
+
+### Per-band heartbeat + dashboard visibility
+
+- Every v1.5.0+ node emits **three heartbeats per interval**: `ble`,
+  `wifi_2g`, `wifi_5g` (previously just two: `ble`, `wifi`).
+- New heartbeat fields: `feeder` (discriminator), `scan_mode`
+  (`lock` | `dwell` | `absent`), `wifi_adapter_mac`,
+  `wifi_adapter_id` (USB vendor:product).
+- **My Nodes dashboard renders three rows per node** — matches the
+  three heartbeat feeders, shows scan_mode per band. Operators see
+  immediately when 5 GHz coverage is absent (informational nudge on
+  first observation; no recurring alerts).
+- Single-adapter dwell mode still emits both heartbeats (with
+  `scan_mode=dwell`) so the dashboard shape is uniform across node
+  topologies.
+
+### Offline Web UI: Feeders panel
+
+The local `http://<pi-ip>:5000/` dashboard gains a three-row Feeders
+panel (BLE / 2.4 GHz / 5 GHz) mirroring the My Nodes layout. Data
+sourced from per-band state files
+(`/run/droneaware/wifi_state_{2g,5g}.json`) that each feeder process
+writes on every heartbeat cycle, plus a systemd active-check for BLE.
+
+### Unplug-safety in dual-adapter mode
+
+Real scenario: operator unplugs one of the two USB adapters mid-run.
+Without safety, the split feeder whose adapter went away would fall
+back to the classifier's only remaining monitor candidate — the peer
+adapter — and contend for the same physical device.
+
+v1.5.0 fix: when `--band` is set (dual-adapter mode) and the band-
+specific MAC becomes unresolvable, the feeder refuses to fall through
+to any other adapter. Enters FAULT cleanly, peer band's service keeps
+running, dashboard shows one row absent. Recovery: plug the adapter
+back in (service restarts automatically) or run `sudo droneaware
+refresh` to switch modes.
+
+### GPS ownership in dual-adapter mode
+
+Two wifi_feeder processes both trying to read `/dev/ttyUSB0` for GPS
+would corrupt the NMEA stream (Linux tty devices don't do exclusive
+locking by default). v1.5.0 assigns ownership: `--band=2g` and
+`--band=auto` (single-adapter) own the GPS reader; `--band=5g` skips
+it. Deterministic, no coordination protocol needed.
+
+### CLI additions
+
+- `sudo droneaware refresh` — new orchestration command (above)
+- `WIFI_ADAPTER_MAC` config key — MAC-based single-adapter identifier
+- `WIFI_ADAPTER_2G_MAC` + `WIFI_ADAPTER_5G_MAC` config keys — dual-adapter
+- `--band {auto|2g|5g}` argument on `wifi_feeder`
+
+### Backward compatibility
+
+- **Legacy `WIFI_ADAPTER=wlanN` config keys** honored as fallback when
+  MAC-based keys aren't set. `migrate_config_env` (run on every
+  `droneaware update`) reads the legacy wlanN, resolves it to a MAC,
+  writes the new `WIFI_ADAPTER_MAC` key. Legacy key retained for one
+  release cycle, dropped in v1.6.0.
+- **Single-adapter operators (existing fleet majority)** experience
+  zero functional changes on upgrade: mode-switch orchestration
+  detects 1 monitor adapter and keeps the existing single-service
+  topology. Adapter identification silently upgrades from wlanN to MAC.
+- **Pre-v1.5.0 heartbeat shape** continues to work — the legacy `wifi`
+  feeder heartbeat is accepted indefinitely.
+
+### Config.env changes
+
+- `WIFI_DWELL_2G_SEC` / `WIFI_DWELL_5G_SEC` documentation updated to
+  clarify these values apply only in single-adapter dwell mode.
+  Ignored (with no warning) in dual-adapter mode — each adapter is
+  locked to one band, no dwelling to schedule.
+
+### Files changed
+
+- `wifi_feeder.py` — classifier, role assignment, `--band` arg,
+  `LockedChannelHopper`, MAC-based iface resolution, hard-filter
+  onboard, unplug-safety, band-scoped heartbeat emit, per-band
+  state file writes, GPS ownership
+- `droneaware` (CLI) — `_orchestrate_wifi_mode`,
+  `_regenerate_nm_monitor_config`, `_classify_wifi_adapters`,
+  `cmd_refresh`, `_set_cfg_key`, config migration for MAC keys
+- `install.sh` — ships `droneaware-wifi-2g.service` +
+  `droneaware-wifi-5g.service`
+- `droneaware-wifi-2g.service` (new) — 2.4 GHz systemd unit
+- `droneaware-wifi-5g.service` (new) — 5 GHz systemd unit
+- `web_ui.py` — `_read_feeder_states`, `/api/status.feeders`
+- `web_static/index.html` — Feeders panel HTML/CSS/JS
+
+### Validated
+
+Real hardware: Pi 3B + dual-band USB adapter (MediaTek MT7612U) +
+2.4-only USB adapter (Ralink RT3070). Scenarios covered:
+
+- Single-adapter mode → dual-adapter mode via config edit
+- Dual-adapter mode → single-adapter mode via adapter unplug + refresh
+- MAC-based tracking survives USB port shuffle (adapters swapped
+  between ports, roles stay on same physical adapters)
+- Onboard-refusal fired for both explicit MAC config and legacy
+  `WIFI_ADAPTER=wlan0` — SSH stayed alive through both tests
+- Unplug-safety: one adapter removed mid-run, peer band unaffected,
+  dashboard shows one row FAULT
+- Refresh command idempotent — no-op when hardware unchanged, mode-
+  switches only when adapter count changes
+
+---
+
 ## [1.4.12.2] — Unreleased
 
 Two small fixes for `_gps_sanity_check_update` (invoked from

--- a/droneaware
+++ b/droneaware
@@ -186,10 +186,19 @@ EOF
         cat >> "$cfg" <<'EOF'
 
 # ─── Dual-band dwell times (added by droneaware update for v1.4.6+) ───
-# Applies only when a dual-band adapter is in use (WIFI_5G_ENABLED=auto
-# and adapter supports 5 GHz, OR WIFI_5G_ENABLED=true). Ignored on
-# single-band setups. The feeder cycles: WIFI_DWELL_2G_SEC on ch6 →
-# WIFI_DWELL_5G_SEC on ch149 → repeat. Total cycle = sum of the two.
+# Applies ONLY in single-adapter mode with a dual-band card (droneaware-
+# wifi.service, one physical adapter alternating between bands). The
+# feeder cycles: WIFI_DWELL_2G_SEC on ch6 → WIFI_DWELL_5G_SEC on ch149
+# → repeat. Total cycle = sum of the two.
+#
+# IGNORED in v1.5.0+ dual-adapter mode (droneaware-wifi-2g +
+# droneaware-wifi-5g services): each adapter is dedicated to one band
+# and locked to its channel — no dwelling, no hopping. Adjusting
+# these values does nothing when two monitor-capable USB adapters are
+# present. Run 'sudo droneaware refresh' to detect current mode.
+#
+# Also ignored on single-band-only setups (2.4-only adapter, no 5 GHz
+# card): feeder hops within 2.4 GHz, no dwell alternation to schedule.
 #
 # v1.4.6 slashed defaults from 20s / 10s (30s cycle) to 3s / 2s
 # (5s cycle) after operator feedback: a drone at 20 m/s cruise covers
@@ -212,6 +221,47 @@ EOF
         info "Added v1.4.6 dual-band dwell time options to config.env"
     fi
 
+    # ─── WIFI_ADAPTER_MAC (added by droneaware update for v1.5.0+) ───
+    # MAC-based adapter identification. WIFI_ADAPTER=wlanN is fragile:
+    # kernel enumeration reshuffles wlanN assignments when USB ports get
+    # reordered or hardware is added (this is the "Chris fragility bug"
+    # v1.5.0 fixes). MAC is stable across enumeration changes.
+    #
+    # Migration semantics:
+    #   - If WIFI_ADAPTER_MAC is already set → no-op (already migrated)
+    #   - If WIFI_ADAPTER=wlanN is set AND wlanN exists in /sys/class/net →
+    #     resolve wlanN to its current MAC and append WIFI_ADAPTER_MAC=<mac>
+    #   - If WIFI_ADAPTER is empty OR wlanN doesn't exist → skip; wifi_feeder's
+    #     runtime classifier (v1.5.0 step 3) will auto-discover at startup
+    #
+    # Both keys coexist during the transition. WIFI_ADAPTER_MAC takes
+    # precedence when both are present (per step 3 behavior). A future
+    # release drops the legacy WIFI_ADAPTER key.
+    if ! grep -q '^WIFI_ADAPTER_MAC=' "$cfg"; then
+        local legacy_iface legacy_mac
+        legacy_iface=$(_cfg_get "$cfg" WIFI_ADAPTER)
+        if [[ -n "$legacy_iface" && -e "/sys/class/net/${legacy_iface}/address" ]]; then
+            legacy_mac=$(cat "/sys/class/net/${legacy_iface}/address" 2>/dev/null | tr -d '[:space:]')
+        fi
+        if [[ -n "${legacy_mac:-}" ]]; then
+            [[ "$backed_up" == "0" ]] && cp "$cfg" "${cfg}.bak.$(date +%s)" && backed_up=1
+            cat >> "$cfg" <<EOF
+
+# ─── WIFI_ADAPTER_MAC (added by droneaware update for v1.5.0+) ───
+# MAC-based adapter identification. Survives kernel USB enumeration
+# reshuffling — WIFI_ADAPTER=wlanN can change if USB ports get reordered
+# or hardware is added. In v1.5.0+ this key takes precedence over
+# WIFI_ADAPTER; the legacy key is retained for backward compat.
+#
+# Auto-migrated from WIFI_ADAPTER=${legacy_iface} (MAC ${legacy_mac}).
+WIFI_ADAPTER_MAC=${legacy_mac}
+EOF
+            info "Added v1.5.0 WIFI_ADAPTER_MAC (migrated ${legacy_iface} → ${legacy_mac})"
+        else
+            info "v1.5.0 WIFI_ADAPTER_MAC not migrated — no resolvable legacy wlanN; feeder classifier will auto-discover at startup"
+        fi
+    fi
+
     # Future release migration blocks go here.
     # Pattern:
     #   if ! grep -q '^NEW_FIELD=' "$cfg"; then
@@ -221,6 +271,89 @@ EOF
     # EOF
     #       info "Added vX.Y.Z options to config.env"
     #   fi
+
+    # v1.5.0+ — detect present monitor-capable USB adapters and set the
+    # right adapter mode (single vs dual). Populates the appropriate
+    # WIFI_ADAPTER_MAC / WIFI_ADAPTER_2G_MAC / WIFI_ADAPTER_5G_MAC keys,
+    # enables/disables the corresponding systemd units. Idempotent —
+    # safe to call repeatedly, only takes action when actual state
+    # differs from desired.
+    _orchestrate_wifi_mode "$cfg"
+
+    # v1.5.0+ — regenerate the NetworkManager monitor-adapter config
+    # (/etc/NetworkManager/conf.d/droneaware.conf) from whichever MAC
+    # keys are currently in config.env. Idempotent: no rewrite if the
+    # generated content matches what's already on disk. Runs AFTER
+    # _orchestrate_wifi_mode so it picks up any freshly-populated MAC keys.
+    _regenerate_nm_monitor_config "$cfg"
+}
+
+# ---------------------------------------------------------------------------
+# NM monitor-adapter config regenerator (v1.5.0+)
+# ---------------------------------------------------------------------------
+# Writes /etc/NetworkManager/conf.d/droneaware.conf with unmanaged-devices
+# listing whichever adapter MAC(s) are currently configured as the
+# monitor role(s). Rewrites on every `droneaware update` so a changed
+# WIFI_ADAPTER_MAC in config.env is reflected in NM's view of the world
+# on the next update run.
+#
+# Precedence (matches wifi_feeder's resolve_monitor_iface logic):
+#   1. Dual-adapter mode: WIFI_ADAPTER_2G_MAC + WIFI_ADAPTER_5G_MAC
+#      both set → unmanage both
+#   2. Single-adapter mode: WIFI_ADAPTER_MAC set → unmanage it
+#   3. Neither set → skip regen (don't wipe an operator's manual overrides;
+#      wifi_feeder's runtime `nmcli device set unmanaged no` still works
+#      as belt-and-suspenders when the feeder starts)
+#
+# Idempotent: writes only if generated content differs from what's on
+# disk. Prevents mtime churn on every update.
+_regenerate_nm_monitor_config() {
+    local cfg="$1"
+    local nm_conf="/etc/NetworkManager/conf.d/droneaware.conf"
+    local mac_single mac_2g mac_5g macs_spec
+
+    mac_single=$(_cfg_get "$cfg" WIFI_ADAPTER_MAC)
+    mac_2g=$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC)
+    mac_5g=$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC)
+
+    if [[ -n "$mac_2g" && -n "$mac_5g" ]]; then
+        macs_spec="mac:${mac_2g};mac:${mac_5g}"
+    elif [[ -n "$mac_single" ]]; then
+        macs_spec="mac:${mac_single}"
+    else
+        # Nothing to write. Leave whatever's on disk alone.
+        return 0
+    fi
+
+    local desired="# DroneAware — prevent NetworkManager from managing the monitor
+# adapter(s). Auto-regenerated by 'droneaware update' from the
+# WIFI_ADAPTER_MAC / WIFI_ADAPTER_2G_MAC / WIFI_ADAPTER_5G_MAC keys
+# in /opt/droneaware/config.env. Do not edit by hand — your changes
+# will be overwritten on the next update.
+#
+# If NM manages a monitor interface it fights the feeder's monitor
+# mode setup, causing zero packet capture and intermittent SSH
+# instability. Managed adapters (Pi onboard for backhaul, etc.) are
+# left alone.
+[keyfile]
+unmanaged-devices=${macs_spec}
+"
+
+    # Idempotency: skip write if content already matches byte-for-byte.
+    # Note: `$(cat file)` strips trailing newlines in bash, which would
+    # cause false diffs against $desired (which ends in a newline). Use
+    # `cmp -s` for byte-exact comparison via stdin instead.
+    if [[ -r "$nm_conf" ]] && printf '%s' "$desired" | cmp -s - "$nm_conf"; then
+        return 0
+    fi
+
+    printf '%s' "$desired" > "$nm_conf"
+    chmod 644 "$nm_conf"
+    # Reload NM to pick up the new rule. Doesn't disconnect managed
+    # interfaces — just updates the unmanaged-device rules. Soft-fail
+    # if NM isn't running (e.g. during install.sh's initial run).
+    nmcli general reload 2>/dev/null || systemctl reload NetworkManager 2>/dev/null || true
+    info "Regenerated NM monitor config (${nm_conf}) → unmanaged: ${macs_spec}"
 }
 
 # ---------------------------------------------------------------------------
@@ -407,6 +540,236 @@ _gps_sanity_check_update() {
     heading "GPS Configuration Check"
     _check_gpsd_conflict
     _check_gps_protocol "$gps_dev"
+}
+
+# ---------------------------------------------------------------------------
+# WiFi adapter mode-switch orchestration (v1.5.0+)
+# ---------------------------------------------------------------------------
+# Runs the same classifier logic that wifi_feeder uses at startup, then
+# decides based on how many monitor-capable USB adapters are present:
+#
+#   ≥2 adapters → dual-adapter mode
+#     - Populate WIFI_ADAPTER_2G_MAC + WIFI_ADAPTER_5G_MAC from the
+#       classifier's constraint-based role assignment
+#     - Enable droneaware-wifi-2g + droneaware-wifi-5g services
+#     - Disable droneaware-wifi.service (single-adapter unit)
+#
+#   1 adapter → single-adapter mode
+#     - Populate WIFI_ADAPTER_MAC
+#     - Enable droneaware-wifi.service
+#     - Disable the split units
+#
+#   0 adapters → leave mode untouched (fresh install with no hardware
+#     yet, or all adapters unplugged). Whichever service is enabled will
+#     enter FAULT until an adapter appears.
+#
+# Idempotent — every action is gated on the current state differing
+# from the desired state. Called from migrate_config_env (which runs
+# on every `droneaware update`) and from cmd_refresh (which operators
+# run after any hardware change).
+
+# Enumerate + classify wlan interfaces. Prints shell-sourceable KEY=VALUE
+# lines to stdout: MONITOR_COUNT, ROLE_2G_MAC, ROLE_5G_MAC. Kept in sync
+# with wifi_feeder.py's wclassifier_enumerate / wclassifier_assign_roles.
+_classify_wifi_adapters() {
+    python3 <<'PY'
+import glob, os, re, subprocess
+IW = "/usr/sbin/iw" if os.path.exists("/usr/sbin/iw") else (
+    "/sbin/iw" if os.path.exists("/sbin/iw") else "iw")
+
+def _read(p):
+    try: return open(p).read().strip()
+    except (OSError, UnicodeDecodeError): return None
+
+def _link(p):
+    try: return os.path.basename(os.readlink(p))
+    except OSError: return None
+
+def _bands(info):
+    b = set()
+    for line in info.splitlines():
+        m = re.search(r"\*\s+(\d{4})\.\d+\s+MHz\s+\[\d+\]", line)
+        if m:
+            f = int(m.group(1))
+            if 2400 <= f <= 2500: b.add("2.4")
+            elif 5000 <= f <= 6000: b.add("5")
+    return sorted(b)
+
+adapters = []
+for path in sorted(glob.glob("/sys/class/net/wlan*")):
+    iface = os.path.basename(path)
+    a = {
+        "iface": iface,
+        "mac": (_read(f"{path}/address") or "?").lower(),
+        "driver": _link(f"{path}/device/driver") or "?",
+        "bus": _link(f"{path}/device/subsystem") or "?",
+        "bands": [], "supports_monitor": False, "classification": "unknown",
+    }
+    phy = _read(f"{path}/phy80211/name")
+    if phy:
+        try:
+            r = subprocess.run([IW, "phy", phy, "info"],
+                               capture_output=True, text=True, timeout=5)
+            a["bands"] = _bands(r.stdout)
+            a["supports_monitor"] = bool(re.search(r"^\s*\*\s+monitor$",
+                                                    r.stdout, re.MULTILINE))
+        except Exception:
+            pass
+    if a["driver"] == "brcmfmac" or a["bus"] in ("sdio", "mmc"):
+        a["classification"] = "onboard"
+    elif a["bus"] == "usb":
+        a["classification"] = "usb-monitor" if a["supports_monitor"] else "usb-no-monitor"
+    adapters.append(a)
+
+monitor = sorted([a for a in adapters if a["classification"] == "usb-monitor"],
+                 key=lambda a: a["mac"])
+role_5g = role_24g = None
+if len(monitor) == 1:
+    only = monitor[0]
+    if "2.4" in only["bands"]: role_24g = only
+    if "5"   in only["bands"]: role_5g  = only
+elif len(monitor) >= 2:
+    fiveg = [a for a in monitor if "5" in a["bands"]]
+    twofour_only = [a for a in monitor if "2.4" in a["bands"] and "5" not in a["bands"]]
+    if fiveg and twofour_only:
+        role_5g  = fiveg[0]
+        role_24g = twofour_only[0]
+    elif fiveg:
+        role_5g = fiveg[0]
+        for a in monitor:
+            if a is not role_5g and "2.4" in a["bands"]:
+                role_24g = a
+                break
+    else:
+        twofour = [a for a in monitor if "2.4" in a["bands"]]
+        if twofour:
+            role_24g = twofour[0]
+
+print(f"MONITOR_COUNT={len(monitor)}")
+print(f"ROLE_2G_MAC={role_24g['mac'] if role_24g else ''}")
+print(f"ROLE_5G_MAC={role_5g['mac'] if role_5g else ''}")
+PY
+}
+
+# Set-or-add a config.env key. Idempotent — only touches the file when
+# the value actually differs. Uses sed -i for existing keys, append for
+# new ones. Handles empty-string values by writing them literally.
+_set_cfg_key() {
+    local cfg="$1" key="$2" value="$3"
+    if grep -q "^${key}=" "$cfg"; then
+        local current
+        current=$(_cfg_get "$cfg" "$key")
+        if [[ "$current" != "$value" ]]; then
+            sed -i "s|^${key}=.*|${key}=${value}|" "$cfg"
+        fi
+    else
+        echo "${key}=${value}" >> "$cfg"
+    fi
+}
+
+_orchestrate_wifi_mode() {
+    local cfg="$1"
+    local MONITOR_COUNT="" ROLE_2G_MAC="" ROLE_5G_MAC=""
+    eval "$(_classify_wifi_adapters 2>/dev/null)"
+
+    if [[ -z "$MONITOR_COUNT" ]]; then
+        warn "v1.5.0 mode-detect: classifier failed — leaving adapter mode unchanged"
+        return 0
+    fi
+
+    info "v1.5.0 mode-detect: ${MONITOR_COUNT} monitor-capable USB adapter(s) present"
+
+    if [[ "$MONITOR_COUNT" -ge 2 && -n "$ROLE_2G_MAC" && -n "$ROLE_5G_MAC" ]]; then
+        _switch_to_dual_adapter_mode "$cfg" "$ROLE_2G_MAC" "$ROLE_5G_MAC"
+    elif [[ "$MONITOR_COUNT" -ge 1 ]]; then
+        local single_mac="${ROLE_2G_MAC:-$ROLE_5G_MAC}"
+        _switch_to_single_adapter_mode "$cfg" "$single_mac"
+    else
+        info "v1.5.0 mode-detect: no monitor-capable USB adapters — feeder will FAULT until one is plugged in"
+    fi
+}
+
+_switch_to_dual_adapter_mode() {
+    local cfg="$1" mac_2g="$2" mac_5g="$3"
+    local prev_2g prev_5g
+    prev_2g=$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC)
+    prev_5g=$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC)
+
+    _set_cfg_key "$cfg" WIFI_ADAPTER_2G_MAC "$mac_2g"
+    _set_cfg_key "$cfg" WIFI_ADAPTER_5G_MAC "$mac_5g"
+
+    # Detect if we were previously in single-adapter mode (droneaware-wifi
+    # enabled and split units not enabled). Also detect if either MAC changed.
+    local mode_changed=0
+    if systemctl is-enabled droneaware-wifi.service >/dev/null 2>&1 \
+       && ! systemctl is-enabled droneaware-wifi-2g.service >/dev/null 2>&1; then
+        mode_changed=1
+    fi
+    local macs_changed=0
+    if [[ "$prev_2g" != "$mac_2g" || "$prev_5g" != "$mac_5g" ]]; then
+        macs_changed=1
+    fi
+
+    if [[ "$mode_changed" == "1" ]]; then
+        info "v1.5.0 mode-switch: single-adapter → dual-adapter (2g=${mac_2g}, 5g=${mac_5g})"
+        systemctl stop droneaware-wifi 2>/dev/null || true
+        systemctl disable droneaware-wifi 2>/dev/null || true
+        systemctl enable droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+        systemctl start droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+    elif [[ "$macs_changed" == "1" ]]; then
+        info "v1.5.0 dual-adapter MACs changed — restarting split units"
+        systemctl restart droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+    fi
+}
+
+_switch_to_single_adapter_mode() {
+    local cfg="$1" mac="$2"
+    local prev_mac
+    prev_mac=$(_cfg_get "$cfg" WIFI_ADAPTER_MAC)
+    _set_cfg_key "$cfg" WIFI_ADAPTER_MAC "$mac"
+
+    local mode_changed=0
+    if systemctl is-enabled droneaware-wifi-2g.service >/dev/null 2>&1 \
+       || systemctl is-enabled droneaware-wifi-5g.service >/dev/null 2>&1; then
+        mode_changed=1
+    fi
+    local mac_changed=0
+    [[ "$prev_mac" != "$mac" ]] && mac_changed=1
+
+    if [[ "$mode_changed" == "1" ]]; then
+        info "v1.5.0 mode-switch: dual-adapter → single-adapter (${mac})"
+        systemctl stop droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+        systemctl disable droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+        systemctl enable droneaware-wifi 2>/dev/null || true
+        systemctl start droneaware-wifi 2>/dev/null || true
+    elif [[ "$mac_changed" == "1" ]]; then
+        info "v1.5.0 single-adapter MAC changed — restarting service"
+        systemctl restart droneaware-wifi 2>/dev/null || true
+    fi
+}
+
+cmd_refresh() {
+    require_root "refresh"
+    echo ""
+    echo -e "${BOLD}DroneAware Refresh${NC}"
+    echo ""
+    echo "  Re-detecting hardware and syncing configuration..."
+    echo "  (WiFi adapters, GPS protocol, gpsd conflict, NM config, service topology)"
+    echo ""
+    migrate_config_env
+    echo ""
+    info "Refresh complete."
+    echo ""
+    info "Current WiFi mode:"
+    if systemctl is-active droneaware-wifi-2g.service >/dev/null 2>&1 \
+       && systemctl is-active droneaware-wifi-5g.service >/dev/null 2>&1; then
+        echo "    dual-adapter (droneaware-wifi-2g + droneaware-wifi-5g)"
+    elif systemctl is-active droneaware-wifi.service >/dev/null 2>&1; then
+        echo "    single-adapter (droneaware-wifi)"
+    else
+        echo "    no WiFi services active — check 'sudo droneaware gps-diagnose' and 'sudo droneaware status'"
+    fi
+    echo ""
 }
 
 cmd_update() {
@@ -1359,6 +1722,7 @@ case "$1" in
     test)           cmd_test "$@" ;;
     install-webui)  cmd_install_webui ;;
     gps-diagnose)   cmd_gps_diagnose ;;
+    refresh)        cmd_refresh ;;
     __migrate)
         # Internal subcommand used by cmd_update for post-install config
         # migration. The double-underscore prefix is a convention signaling
@@ -1385,6 +1749,7 @@ case "$1" in
         echo "    test --dry-run  Check rate-limit availability without transmitting"
         echo "    install-webui   Install the optional local Web UI (LAN dashboard)"
         echo "    gps-diagnose    Read-only GPS health check (device, port, protocol, state)"
+        echo "    refresh         Re-detect hardware (WiFi adapters, GPS) and sync services"
         echo ""
         ;;
 esac

--- a/droneaware-wifi-2g.service
+++ b/droneaware-wifi-2g.service
@@ -1,0 +1,33 @@
+[Unit]
+# v1.5.0+ dual-adapter mode: dedicated 2.4 GHz feeder. Uses the
+# WIFI_ADAPTER_2G_MAC config key to resolve which USB adapter to bind
+# for monitor mode. Runs alongside droneaware-wifi-5g.service, which
+# does the same for the 5 GHz-149 band.
+#
+# Conflicts with the single-adapter droneaware-wifi.service — only ONE
+# of the two modes is enabled on a given node at a time. Mode-switching
+# is handled by install.sh / cmd_update based on the number of monitor-
+# capable USB adapters detected on the node.
+Description=DroneAware WiFi Remote ID Feeder (2.4 GHz, dual-adapter mode)
+After=network-online.target droneaware-bt-select.service
+Wants=network-online.target
+Conflicts=droneaware-wifi.service
+
+[Service]
+Type=simple
+User=root
+EnvironmentFile=/opt/droneaware/config.env
+ExecStart=/opt/droneaware/wifi_feeder \
+    --node-id ${NODE_ID} \
+    --server ${SERVER_URL} \
+    --batch-size ${BATCH_SIZE} \
+    --flush-interval ${FLUSH_INTERVAL} \
+    --band 2g
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=droneaware-wifi-2g
+
+[Install]
+WantedBy=multi-user.target

--- a/droneaware-wifi-5g.service
+++ b/droneaware-wifi-5g.service
@@ -1,0 +1,33 @@
+[Unit]
+# v1.5.0+ dual-adapter mode: dedicated 5 GHz-149 feeder. Uses the
+# WIFI_ADAPTER_5G_MAC config key to resolve which USB adapter to bind
+# for monitor mode. Locks to channel 149 (no hopping, no dwelling).
+# Runs alongside droneaware-wifi-2g.service.
+#
+# Conflicts with the single-adapter droneaware-wifi.service — only ONE
+# of the two modes is enabled on a given node at a time. Mode-switching
+# is handled by install.sh / cmd_update based on the number of monitor-
+# capable USB adapters detected on the node.
+Description=DroneAware WiFi Remote ID Feeder (5 GHz-149, dual-adapter mode)
+After=network-online.target droneaware-bt-select.service
+Wants=network-online.target
+Conflicts=droneaware-wifi.service
+
+[Service]
+Type=simple
+User=root
+EnvironmentFile=/opt/droneaware/config.env
+ExecStart=/opt/droneaware/wifi_feeder \
+    --node-id ${NODE_ID} \
+    --server ${SERVER_URL} \
+    --batch-size ${BATCH_SIZE} \
+    --flush-interval ${FLUSH_INTERVAL} \
+    --band 5g
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=droneaware-wifi-5g
+
+[Install]
+WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -771,8 +771,16 @@ install_services() {
     chmod +x "${CLI_DIR}/droneaware-bt-select"
     info "droneaware-bt-select installed."
 
-    # Systemd service files
-    for svc in droneaware-bt-select.service droneaware-ble.service droneaware-wifi.service; do
+    # Systemd service files. droneaware-wifi-2g.service +
+    # droneaware-wifi-5g.service (added v1.5.0+) are the dual-adapter
+    # mode counterparts to droneaware-wifi.service. Only one mode is
+    # enabled per node — orchestration is handled by cmd_update /
+    # install.sh based on the number of monitor-capable USB adapters
+    # detected. All three files are shipped so the mode can be
+    # switched later without needing a fresh install.
+    for svc in droneaware-bt-select.service droneaware-ble.service \
+               droneaware-wifi.service \
+               droneaware-wifi-2g.service droneaware-wifi-5g.service; do
         if [[ "$LOCAL_INSTALL" == "1" ]]; then
             cp "${local_root}/${svc}" "/etc/systemd/system/${svc}"
         else

--- a/web_static/index.html
+++ b/web_static/index.html
@@ -176,6 +176,31 @@
       flex-wrap: wrap;
       gap: 6px;
     }
+    /* v1.5.0 Gap 3 — feeder-status panel (BLE + 2.4 + 5 rows, matching
+       My Nodes layout). Populated from /api/status.feeders on each poll. */
+    .feeders-panel {
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 12px;
+    }
+    .feeder-row {
+      display: grid;
+      grid-template-columns: 20px 60px 1fr;
+      gap: 8px;
+      align-items: center;
+      color: var(--text-dim);
+    }
+    .feeder-icon { text-align: center; opacity: 0.7; }
+    .feeder-label { font-weight: 600; color: var(--text-primary); }
+    .feeder-status { font-family: var(--font-mono, monospace); font-size: 11px; }
+    .feeder-status.ok      { color: var(--fresh-live); }
+    .feeder-status.warn    { color: var(--fresh-recent); }
+    .feeder-status.fault   { color: var(--fresh-older); }
+    .feeder-status.absent  { color: var(--text-muted); font-style: italic; }
+    .feeder-status.stale   { color: var(--text-muted); }
     .chip {
       display: inline-flex;
       align-items: center;
@@ -701,6 +726,27 @@
   <!-- Main: sidebar + map -->
   <div class="main">
     <div class="sidebar" id="sidebar">
+      <!-- v1.5.0 Gap 3: three-row feeder status matching My Nodes.
+           Populated from /api/status's `feeders` object (data comes
+           from /run/droneaware/wifi_state_{2g,5g}.json + a systemd
+           check for BLE). -->
+      <div class="feeders-panel" id="feeders-panel">
+        <div class="feeder-row" data-feeder="ble">
+          <span class="feeder-icon">📶</span>
+          <span class="feeder-label">BLE</span>
+          <span class="feeder-status" data-role="ble-status">—</span>
+        </div>
+        <div class="feeder-row" data-feeder="wifi_2g">
+          <span class="feeder-icon">📡</span>
+          <span class="feeder-label">2.4 GHz</span>
+          <span class="feeder-status" data-role="wifi_2g-status">—</span>
+        </div>
+        <div class="feeder-row" data-feeder="wifi_5g">
+          <span class="feeder-icon">📡</span>
+          <span class="feeder-label">5 GHz</span>
+          <span class="feeder-status" data-role="wifi_5g-status">—</span>
+        </div>
+      </div>
       <div class="sidebar-filters">
         <span class="chip on" data-filter="freshness" data-value="live">
           <span class="chip-dot" style="color: var(--fresh-live);"></span>&lt; 2 min
@@ -1405,11 +1451,51 @@
     }
 
     /* ----- Status bar ----- */
+    /* v1.5.0 Gap 3 — render the three-row feeder panel (BLE / 2.4 / 5)
+       from /api/status.feeders. Mirrors My Nodes' visual layout so the
+       operator sees consistent status whether they're on the online
+       dashboard or the offline node UI. */
+    function renderFeeders(feeders) {
+      if (!feeders) return;
+      const bands = [
+        { key: "ble",     label: "BLE" },
+        { key: "wifi_2g", label: "2.4 GHz" },
+        { key: "wifi_5g", label: "5 GHz" },
+      ];
+      for (const {key} of bands) {
+        const el = document.querySelector(`[data-role="${key}-status"]`);
+        if (!el) continue;
+        const f = feeders[key];
+        if (!f) { el.textContent = "unknown"; el.className = "feeder-status stale"; continue; }
+        if (f.stale) {
+          el.textContent = `stale (${f.age_sec}s)`;
+          el.className = "feeder-status stale";
+          continue;
+        }
+        const mode = f.scan_mode || "?";
+        const iface = f.iface ? ` (${f.iface})` : "";
+        if (mode === "absent") {
+          el.textContent = `Absent — no capable adapter`;
+          el.className = "feeder-status absent";
+        } else if (f.wifi_fault) {
+          el.textContent = `Fault: ${f.wifi_fault}${iface}`;
+          el.className = "feeder-status fault";
+        } else if (f.wifi_ok === false) {
+          el.textContent = `not scanning${iface}`;
+          el.className = "feeder-status warn";
+        } else {
+          el.textContent = `OK · ${mode}${iface}`;
+          el.className = "feeder-status ok";
+        }
+      }
+    }
+
     async function refreshStatus() {
       try {
         const r = await fetch("/api/status");
         if (!r.ok) return;
         const s = await r.json();
+        renderFeeders(s.feeders);
         document.getElementById("stat-buffer").textContent =
           `${s.buffer_pct}% (${(s.buffer_bytes / 1e6).toFixed(1)} MB)`;
         document.getElementById("stat-cpu").textContent =

--- a/web_ui.py
+++ b/web_ui.py
@@ -59,6 +59,7 @@ import logging
 import os
 import socket
 import sqlite3
+import subprocess
 import sys
 import threading
 import time
@@ -677,6 +678,52 @@ def api_detections():
     return jsonify(store.snapshot())
 
 
+def _read_feeder_states() -> dict:
+    """v1.5.0 Gap 3: read the per-band wifi state files written by the
+    wifi_feeder process(es). Returns a dict shaped:
+        {"wifi_2g": {...}, "wifi_5g": {...}}
+    Missing / stale / unreadable state files map to None entries so the
+    frontend can render "unknown" placeholders instead of crashing.
+
+    Also includes a static BLE entry — v1.5.0 doesn't yet have a BLE
+    state file (planned for v1.5.x), so we surface the systemd service
+    status as a coarse indicator until then.
+    """
+    out = {"ble": None, "wifi_2g": None, "wifi_5g": None}
+    for band in ("2g", "5g"):
+        path = f"/run/droneaware/wifi_state_{band}.json"
+        try:
+            with open(path) as f:
+                s = json.load(f)
+            age = time.time() - (s.get("updated_at") or 0)
+            s["age_sec"] = int(age)
+            # Stale if not refreshed in >180s (heartbeat cycle is 60s;
+            # 3 missed cycles = something is wrong)
+            s["stale"] = age > 180
+            out[f"wifi_{band}"] = s
+        except (OSError, ValueError, json.JSONDecodeError):
+            pass
+
+    # BLE — placeholder until BLE feeder gets its own state file. Check
+    # systemd for a rough "is it running" signal.
+    try:
+        r = subprocess.run(
+            ["systemctl", "is-active", "droneaware-ble.service"],
+            capture_output=True, text=True, timeout=2,
+        )
+        active = r.stdout.strip() == "active"
+    except Exception:
+        active = False
+    out["ble"] = {
+        "feeder": "ble",
+        "iface": "hci0",   # conventional — actual adapter may vary
+        "scan_mode": "lock",  # BLE is always "listening on all channels" — closest to lock
+        "wifi_ok": active,  # borrowing the field name for uniform frontend rendering
+        "stale": False,
+    }
+    return out
+
+
 @app.route("/api/status")
 def api_status():
     s = store.stats()
@@ -697,6 +744,9 @@ def api_status():
         # or 404s if CartoDB is unreachable.
         "tiles_local": _mbtiles_conn is not None,
         "tiles_local_max_zoom": WORLD_TILES_MAX_ZOOM if _mbtiles_conn else None,
+        # v1.5.0 Gap 3: per-feeder status for the three-row BLE/2.4/5
+        # panel in the offline UI (matching My Nodes layout).
+        "feeders":     _read_feeder_states(),
     })
     return jsonify(s)
 

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -30,6 +30,7 @@ import argparse
 import socket
 import glob
 import os
+import re
 import sys
 import collections
 import serial
@@ -595,6 +596,384 @@ _NM_CONF       = "/etc/NetworkManager/conf.d/droneaware.conf"
 _MONITOR_MACS  = "/opt/droneaware/monitor_macs"
 
 
+# ============================================================================
+# WiFi adapter classifier (v1.5.0 Step 1 — LOGGING-ONLY)
+# ============================================================================
+# Discovers all wlan* interfaces and classifies each as onboard-Pi-WiFi
+# (brcmfmac driver OR sdio/mmc bus) vs external USB. For USB adapters,
+# probes monitor-mode support and band support via `iw phy info`. Then
+# assigns roles (5GHz-149 lock, 2.4GHz hopper) under capability
+# constraints — a 2.4-only adapter can never take the 5GHz role.
+#
+# Step 1 integration: LOG-ONLY. This code runs at startup and writes
+# what it discovers + what it would pick to the journal, but does NOT
+# change the actual iface selected by --iface. Steps 3+ later replace
+# the iface-based selection with MAC-based lookup driven by this
+# classifier. Split intentionally so we can validate the classifier's
+# picks on real hardware before consuming them.
+#
+# Prototype validated on njpi-120hotfix (Pi 3B + Alfa AWUS036ACM dual-band
+# + Alfa Ralink RT3070 2.4-only) across scenarios 1/2/3/5.
+
+_IW_PATH = "/usr/sbin/iw" if os.path.exists("/usr/sbin/iw") else (
+    "/sbin/iw" if os.path.exists("/sbin/iw") else "iw")
+
+
+def _wclassifier_read(path: str) -> str | None:
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _wclassifier_readlink_base(path: str) -> str | None:
+    try:
+        return os.path.basename(os.readlink(path))
+    except OSError:
+        return None
+
+
+def _wclassifier_parse_bands(iw_info: str) -> list:
+    """Parse `iw phy info` output for supported bands (2.4 / 5) via
+    frequency list. Frequencies appear as '* 2412.0 MHz [1] (...)' lines."""
+    bands = set()
+    for line in iw_info.splitlines():
+        m = re.search(r"\*\s+(\d{4})\.\d+\s+MHz\s+\[\d+\]", line)
+        if not m:
+            continue
+        freq = int(m.group(1))
+        if 2400 <= freq <= 2500:
+            bands.add("2.4")
+        elif 5000 <= freq <= 6000:
+            bands.add("5")
+    return sorted(bands)
+
+
+def wclassifier_enumerate() -> list:
+    """Return list of adapter dicts. See wifi_probe.py for schema."""
+    result = []
+    for path in sorted(glob.glob("/sys/class/net/wlan*")):
+        iface = os.path.basename(path)
+        a = {
+            "iface": iface,
+            "mac": _wclassifier_read(f"{path}/address") or "?",
+            "driver": _wclassifier_readlink_base(f"{path}/device/driver") or "?",
+            "bus": _wclassifier_readlink_base(f"{path}/device/subsystem") or "?",
+            "usb_vid": None, "usb_pid": None, "phy": None,
+            "bands": [], "supports_monitor": False, "classification": "unknown",
+        }
+        if a["bus"] == "usb":
+            a["usb_vid"] = _wclassifier_read(f"{path}/device/../idVendor")
+            a["usb_pid"] = _wclassifier_read(f"{path}/device/../idProduct")
+        a["phy"] = _wclassifier_read(f"{path}/phy80211/name")
+        if a["phy"]:
+            try:
+                info = subprocess.run(
+                    [_IW_PATH, "phy", a["phy"], "info"],
+                    capture_output=True, text=True, timeout=5
+                ).stdout
+                a["bands"] = _wclassifier_parse_bands(info)
+                a["supports_monitor"] = bool(
+                    re.search(r"^\s*\*\s+monitor$", info, re.MULTILINE)
+                )
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                pass
+        # v1.5.0 classification rule: brcmfmac driver OR sdio/mmc bus →
+        # onboard (never monitor). Other USB → monitor-candidate iff
+        # capable. Everything else marked "other".
+        if a["driver"] == "brcmfmac" or a["bus"] in ("sdio", "mmc"):
+            a["classification"] = "onboard"
+        elif a["bus"] == "usb":
+            a["classification"] = "usb-monitor" if a["supports_monitor"] else "usb-no-monitor"
+        else:
+            a["classification"] = "other"
+        result.append(a)
+    return result
+
+
+def wclassifier_assign_roles(adapters: list) -> dict:
+    """Assign 5GHz-149-lock and 2.4GHz-hopper roles under capability
+    constraints. See wifi_probe.py for rules R1-R6."""
+    warnings = []
+    monitor = sorted(
+        [a for a in adapters if a["classification"] == "usb-monitor"],
+        key=lambda a: a["mac"],
+    )
+    if not monitor:
+        warnings.append("no monitor-capable USB adapter present")
+        return {"role_5g": None, "role_24g": None, "warnings": warnings}
+
+    fiveg = [a for a in monitor if "5" in a["bands"]]
+    twofour = [a for a in monitor if "2.4" in a["bands"]]
+
+    if len(monitor) == 1:
+        only = monitor[0]
+        r5 = only if "5" in only["bands"] else None
+        r2 = only if "2.4" in only["bands"] else None
+        if r5 is None:
+            warnings.append(
+                f"{only['iface']} is 2.4GHz-only — 5GHz channel 149 lock "
+                "impossible; no 5GHz RID coverage"
+            )
+        if r2 is None:
+            warnings.append(
+                f"{only['iface']} is 5GHz-only — 2.4GHz hopping impossible; "
+                "no 2.4GHz RID coverage"
+            )
+        return {"role_5g": r5, "role_24g": r2, "warnings": warnings}
+
+    # ≥2 monitor-capable adapters — apply capability constraints
+    twofour_only = [a for a in twofour if a not in fiveg]
+    r5 = None
+    r2 = None
+    if fiveg and twofour_only:
+        # Forced assignment: 2.4-only can only take 2.4 role
+        r5 = fiveg[0]
+        r2 = twofour_only[0]
+    elif fiveg:
+        r5 = fiveg[0]
+        for a in monitor:
+            if a is not r5 and "2.4" in a["bands"]:
+                r2 = a
+                break
+    else:
+        warnings.append(
+            "no 5GHz-capable adapter present — 5GHz channel 149 lock "
+            "impossible; no 5GHz RID coverage"
+        )
+        r2 = twofour[0] if twofour else None
+    return {"role_5g": r5, "role_24g": r2, "warnings": warnings}
+
+
+def wclassifier_log_startup_snapshot(current_iface: str) -> None:
+    """v1.5.0 Step 1 — logging-only. Called at feeder startup to record
+    the classifier's view of the adapter landscape + its proposed role
+    assignment + a comparison against the currently-selected --iface.
+    Never modifies state. Enables safe validation on real nodes before
+    step 3 flips to MAC-based selection."""
+    try:
+        adapters = wclassifier_enumerate()
+    except Exception as e:
+        log.warning(f"[classifier v1.5.0] enumeration failed: {e}")
+        return
+    log.info(f"[classifier v1.5.0] discovered {len(adapters)} wlan interface(s):")
+    for a in adapters:
+        usb = f" usb={a['usb_vid']}:{a['usb_pid']}" if a['usb_vid'] else ""
+        bands = f"[{'+'.join(a['bands'])}]" if a['bands'] else "[?]"
+        mon = "monitor=yes" if a['supports_monitor'] else "monitor=no"
+        log.info(
+            f"[classifier v1.5.0]   {a['iface']} mac={a['mac']} "
+            f"driver={a['driver']} bus={a['bus']}{usb} bands={bands} "
+            f"{mon} → {a['classification']}"
+        )
+
+    roles = wclassifier_assign_roles(adapters)
+    r5 = roles["role_5g"]
+    r2 = roles["role_24g"]
+    r5s = f"{r5['iface']} ({r5['mac']})" if r5 else "UNASSIGNED"
+    r2s = f"{r2['iface']} ({r2['mac']})" if r2 else "UNASSIGNED"
+    log.info(f"[classifier v1.5.0] proposed roles — 5GHz={r5s} | 2.4GHz={r2s}")
+    for w in roles["warnings"]:
+        log.warning(f"[classifier v1.5.0] {w}")
+
+    # Comparison: does the currently-selected --iface show up in the
+    # classifier's assignment? If yes, we're aligned and step 3 should
+    # be safe. If no, we've found a real difference to investigate
+    # BEFORE flipping to MAC-based selection.
+    current_mac = _get_iface_mac(current_iface) if current_iface else None
+    picks = [a["mac"] for a in [r5, r2] if a]
+    if current_mac and current_mac in picks:
+        log.info(
+            f"[classifier v1.5.0] current --iface={current_iface} "
+            f"(mac={current_mac}) is in classifier assignment ✓"
+        )
+    elif current_mac:
+        log.warning(
+            f"[classifier v1.5.0] current --iface={current_iface} "
+            f"(mac={current_mac}) is NOT in classifier assignment — "
+            f"classifier picked MACs: {picks}. Investigate before step 3."
+        )
+    else:
+        log.warning(
+            f"[classifier v1.5.0] current --iface={current_iface} has no "
+            "MAC (interface may not exist)"
+        )
+
+
+def _is_onboard_iface(iface: str | None) -> bool:
+    """Return True if iface is a Pi onboard WiFi adapter (brcmfmac driver
+    OR sdio/mmc bus). Choosing an onboard adapter as the monitor is a
+    HARD no — it would put the Pi's SSH backhaul interface into monitor
+    mode and instantly break management access to the node.
+
+    Belt-and-suspenders check that complements the classifier's onboard
+    filter. Used by resolve_monitor_iface to reject any resolution path
+    (WIFI_ADAPTER_MAC, WIFI_ADAPTER, classifier pick) that would land
+    on an onboard adapter.
+    """
+    if not iface:
+        return False
+    try:
+        driver = os.path.basename(os.readlink(f"/sys/class/net/{iface}/device/driver"))
+    except OSError:
+        driver = ""
+    try:
+        bus = os.path.basename(os.readlink(f"/sys/class/net/{iface}/device/subsystem"))
+    except OSError:
+        bus = ""
+    return driver == "brcmfmac" or bus in ("sdio", "mmc")
+
+
+def resolve_monitor_iface(fallback_iface: str | None, band: str = "auto") -> str:
+    """v1.5.0 Step 3 — pick which wlanN the feeder monitors, applying the
+    new MAC-based selection with fallbacks to legacy behavior.
+
+    Resolution order (first match wins):
+      1. WIFI_ADAPTER_MAC env var (new-style config from v1.5.0 migration)
+         → scan /sys/class/net/wlan*/address for the matching interface
+      2. fallback_iface (from --iface CLI arg / WIFI_ADAPTER env var /
+         default "wlan1") → use if it currently exists in /sys/class/net
+      3. Classifier auto-pick → 2.4GHz role preferred (single-adapter
+         dwell mode covers both bands); else 5GHz role
+      4. Nothing worked → log a loud error listing operator remediation
+         options and return the fallback iface anyway (feeder enters
+         FAULT loop, surfaces the issue via wifi_ok=False heartbeats)
+
+    Logs the resolution decision loudly so operators can see which path
+    took effect (matters for triaging misconfigs after hardware changes).
+    """
+    # 1. New-style config. In dual-adapter mode (--band=2g|5g), read
+    # the band-specific MAC key first, then fall back to the shared
+    # WIFI_ADAPTER_MAC key for backward compat / single-adapter setups.
+    band_key = {"2g": "WIFI_ADAPTER_2G_MAC", "5g": "WIFI_ADAPTER_5G_MAC"}.get(band)
+    # Track whether the MAC came from a band-specific key — matters for
+    # the unplug-safety refusal at the bottom of Step 1.
+    band_specific_configured = False
+    configured_mac = ""
+    if band_key:
+        configured_mac = os.environ.get(band_key, "").strip().lower()
+        if configured_mac:
+            band_specific_configured = True
+            log.info(f"[iface v1.5.0] --band={band}: using {band_key}={configured_mac}")
+    if not configured_mac:
+        configured_mac = os.environ.get("WIFI_ADAPTER_MAC", "").strip().lower()
+    if configured_mac:
+        for path in sorted(glob.glob("/sys/class/net/wlan*")):
+            iface = os.path.basename(path)
+            try:
+                with open(f"{path}/address") as f:
+                    mac = f.read().strip().lower()
+            except OSError:
+                continue
+            if mac == configured_mac:
+                # v1.5.0 Step 5: hard-filter onboard. Even if the operator
+                # explicitly configured the Pi onboard's MAC as the monitor
+                # adapter, REFUSE — putting the SSH backhaul into monitor
+                # mode is a self-inflicted lockout of the node.
+                if _is_onboard_iface(iface):
+                    log.error(
+                        f"[iface v1.5.0] REFUSING — configured MAC {configured_mac} "
+                        f"points at Pi onboard adapter {iface} "
+                        "(brcmfmac/sdio). Choosing onboard as monitor would "
+                        "break SSH access to this node. Fix the MAC in "
+                        "/opt/droneaware/config.env."
+                    )
+                    if band_specific_configured:
+                        # Dual-adapter mode: don't fall through to classifier —
+                        # would pick peer band's adapter and cause contention.
+                        return ""
+                    break  # single-adapter mode — safe to fall through
+                log.info(
+                    f"[iface v1.5.0] resolved WIFI_ADAPTER_MAC={configured_mac} "
+                    f"→ {iface}"
+                )
+                return iface
+        else:
+            # for loop completed without `break` — meaning we scanned all
+            # wlan* and found no MAC match at all.
+            #
+            # UNPLUG-SAFETY (v1.5.0 Step 7e): in dual-adapter mode where the
+            # MAC came from a band-specific key (WIFI_ADAPTER_2G_MAC or
+            # WIFI_ADAPTER_5G_MAC), the peer band's service is running on a
+            # DIFFERENT adapter. Falling through to the classifier's auto-pick
+            # would return the peer's adapter (only remaining monitor candidate)
+            # and cause adapter contention. Refuse to fall through — return ""
+            # so the feeder enters FAULT cleanly. The peer band's service
+            # keeps running normally. Operator recovers by plugging the adapter
+            # back in, or by running `sudo droneaware refresh` to switch modes.
+            if band_specific_configured:
+                log.error(
+                    f"[iface v1.5.0] --band={band}: configured "
+                    f"{band_key}={configured_mac} not present — adapter may have "
+                    "been unplugged. Refusing to fall through to another "
+                    "adapter (would contend with the peer band's service). "
+                    "Feeder will enter FAULT. Recovery: plug the adapter back "
+                    "in, or run 'sudo droneaware refresh' to reconfigure "
+                    "for the new hardware topology."
+                )
+                return ""
+            log.warning(
+                f"[iface v1.5.0] WIFI_ADAPTER_MAC={configured_mac} does not "
+                "match any present wlan interface — adapter may have been "
+                "unplugged or MAC changed since config was written. Falling "
+                "through to legacy iface + classifier auto-pick."
+            )
+
+    # 2. Legacy config: --iface / WIFI_ADAPTER env / default wlan1
+    if fallback_iface and os.path.exists(f"/sys/class/net/{fallback_iface}"):
+        # v1.5.0 Step 5: also apply hard-filter here. Common misconfig on
+        # older nodes: WIFI_ADAPTER=wlan0 accidentally points at Pi onboard.
+        if _is_onboard_iface(fallback_iface):
+            log.error(
+                f"[iface v1.5.0] REFUSING — legacy WIFI_ADAPTER={fallback_iface} "
+                "points at Pi onboard adapter (brcmfmac/sdio). Choosing "
+                "onboard as monitor would break SSH access. Fix "
+                "WIFI_ADAPTER in /opt/droneaware/config.env. Falling "
+                "through to classifier."
+            )
+        else:
+            log.info(
+                f"[iface v1.5.0] using legacy iface {fallback_iface} "
+                "(from --iface / WIFI_ADAPTER)"
+            )
+            return fallback_iface
+
+    # 3. Classifier auto-pick — classifier already filters onboard via
+    # driver/bus, so this never returns an onboard adapter. But we keep
+    # the check here as defense-in-depth against future classifier changes.
+    try:
+        adapters = wclassifier_enumerate()
+        roles = wclassifier_assign_roles(adapters)
+        pick = roles["role_24g"] or roles["role_5g"]
+        if pick and not _is_onboard_iface(pick["iface"]):
+            log.warning(
+                f"[iface v1.5.0] no config match — auto-picked {pick['iface']} "
+                f"(mac={pick['mac']}) via classifier. Consider setting "
+                f"WIFI_ADAPTER_MAC={pick['mac']} in /opt/droneaware/config.env "
+                "to make this choice stable across reboots."
+            )
+            return pick["iface"]
+    except Exception as e:
+        log.warning(f"[iface v1.5.0] classifier auto-pick failed: {e}")
+
+    # 4. Nothing worked — return empty string so the feeder's existing
+    # FAULT path fires (see WiFiFeeder.run() — "adapter not present"
+    # check). Keeps BLE feeder running independently. This is the
+    # right outcome for BLE-only nodes: no monitor adapter is a valid
+    # hardware config, not a fatal error.
+    log.error(
+        "[iface v1.5.0] No usable WiFi monitor adapter found. Feeder will "
+        "enter FAULT loop (BLE unaffected). Remediation options:\n"
+        "  - Plug in a USB WiFi adapter that supports monitor mode\n"
+        "  - Set WIFI_ADAPTER_MAC=<mac> in /opt/droneaware/config.env "
+        "for stable identification\n"
+        "  - Or run this node as BLE-only (no action needed — WiFi feeder "
+        "just stays in FAULT and reports absent 2.4/5 GHz coverage)"
+    )
+    return ""
+
+
 def _get_backhaul_iface() -> str | None:
     """Return the interface currently carrying the default route."""
     try:
@@ -958,6 +1337,39 @@ class AdaptiveChannelHopper(threading.Thread):
 
     def stop(self):
         self._stop.set()
+
+
+class LockedChannelHopper(threading.Thread):
+    """v1.5.0 dual-adapter mode: lock the adapter to one channel
+    permanently. Used when the wifi_feeder process is spawned with
+    `--band=5g` (locks to channel 149) so that a dedicated adapter
+    stays continuously tuned to the 5 GHz RID channel — no dwelling,
+    no hopping.
+
+    Contract-compatible with the other hopper classes (start/stop,
+    current_channel, target_channels, notify_detection). notify_detection
+    is a no-op because there's nothing to switch to.
+    """
+
+    def __init__(self, iface: str, channel: int):
+        super().__init__(daemon=True)
+        self.iface           = iface
+        self.channel         = channel
+        self.current_channel = channel
+        self.target_channels = [channel]
+        self._stop           = threading.Event()
+
+    def run(self):
+        set_channel(self.iface, self.channel)
+        log.info(f"Locked channel hopper: {self.iface} → ch{self.channel} (no hop)")
+        # Set once, then block. No tuning needed for the lifetime of the process.
+        self._stop.wait()
+
+    def stop(self):
+        self._stop.set()
+
+    def notify_detection(self, ch: int):
+        pass
 
 
 class DualBandHopper(threading.Thread):
@@ -1876,48 +2288,59 @@ class WiFiFeeder:
     def __init__(self, iface: str, node_id: str, server_url: str,
                  verbose: bool = False, batch_size: int = 10,
                  flush_interval: float = 2.0, channel_dwell: float = 0.2,
-                 token: str = ""):
+                 token: str = "", band: str = "auto"):
         self.iface       = iface
         self.node_id     = node_id
         self.verbose     = verbose
         self.token       = token
+        self.band        = band  # "auto" | "2g" | "5g" — v1.5.0 dual-adapter mode
         self.start_time  = time.time()
         self.forwarder   = Forwarder(server_url, node_id, batch_size, flush_interval, token)
         self.publisher   = LocalPublisher()
-        # ADAPTIVE_DWELL=false reverts to legacy flat 1–11 hop (A/B testing)
-        adaptive_dwell = os.environ.get("ADAPTIVE_DWELL", "true").strip().lower() \
-                            in ("true", "1", "yes", "on")
-        if not adaptive_dwell:
-            log.info("Hopper mode: flat (legacy even hop across 1–11)")
-            self.hopper = ChannelHopper(iface, CHANNELS_24, channel_dwell)
-        else:
-            wifi_5g = os.environ.get("WIFI_5G_ENABLED", "auto").strip().lower()
-            if wifi_5g in ("true", "1", "yes", "on"):
-                supports_5g = _adapter_supports_5g(iface) if iface else False
-                if not supports_5g:
-                    log.warning(
-                        f"WIFI_5G_ENABLED=true but {iface or '<none>'} does not "
-                        "expose channel 149 — falling back to 2.4 GHz only"
-                    )
-                enable_5g = supports_5g
-            elif wifi_5g in ("false", "0", "no", "off"):
-                enable_5g = False
-            else:  # "auto" (default) — detect at startup
-                enable_5g = _adapter_supports_5g(iface) if iface else False
-                if iface and enable_5g:
-                    log.info(f"Dual-band adapter detected on {iface} — enabling 5 GHz scanning")
-                elif iface:
-                    log.info(f"Single-band adapter on {iface} — 2.4 GHz only")
 
-            if enable_5g:
-                # Cycle length is per-instance (dwell env vars, v1.4.6+) so
-                # DON'T hardcode it here — the DualBandHopper's own startup
-                # log reports the actual timing after __init__ parses env.
-                log.info("Hopper mode: dual-band (ch6 + ch149)")
-                self.hopper = DualBandHopper(iface)
+        # v1.5.0 dual-adapter mode overrides hopper choice explicitly.
+        # --band=2g runs a dedicated 2.4 GHz hopper (no 5 GHz work at all).
+        # --band=5g locks to channel 149 (no dwelling, no 2.4 GHz work).
+        # --band=auto keeps the single-adapter behavior (may dwell or lock).
+        if band == "2g":
+            log.info(f"Hopper mode: 2g-only dedicated (band={band}, --band=2g)")
+            self.hopper = AdaptiveChannelHopper(iface)
+        elif band == "5g":
+            log.info(f"Hopper mode: 5g locked to ch149 (band={band}, --band=5g)")
+            self.hopper = LockedChannelHopper(iface, 149)
+        else:
+            # band == "auto" — existing single-adapter logic
+            # ADAPTIVE_DWELL=false reverts to legacy flat 1–11 hop (A/B testing)
+            adaptive_dwell = os.environ.get("ADAPTIVE_DWELL", "true").strip().lower() \
+                                in ("true", "1", "yes", "on")
+            if not adaptive_dwell:
+                log.info("Hopper mode: flat (legacy even hop across 1–11)")
+                self.hopper = ChannelHopper(iface, CHANNELS_24, channel_dwell)
             else:
-                log.info("Hopper mode: adaptive (sweep + sticky, channel-6 biased)")
-                self.hopper = AdaptiveChannelHopper(iface)
+                wifi_5g = os.environ.get("WIFI_5G_ENABLED", "auto").strip().lower()
+                if wifi_5g in ("true", "1", "yes", "on"):
+                    supports_5g = _adapter_supports_5g(iface) if iface else False
+                    if not supports_5g:
+                        log.warning(
+                            f"WIFI_5G_ENABLED=true but {iface or '<none>'} does not "
+                            "expose channel 149 — falling back to 2.4 GHz only"
+                        )
+                    enable_5g = supports_5g
+                elif wifi_5g in ("false", "0", "no", "off"):
+                    enable_5g = False
+                else:  # "auto" (default) — detect at startup
+                    enable_5g = _adapter_supports_5g(iface) if iface else False
+                    if iface and enable_5g:
+                        log.info(f"Dual-band adapter detected on {iface} — enabling 5 GHz scanning")
+                    elif iface:
+                        log.info(f"Single-band adapter on {iface} — 2.4 GHz only")
+
+                if enable_5g:
+                    log.info("Hopper mode: dual-band (ch6 + ch149)")
+                    self.hopper = DualBandHopper(iface)
+                else:
+                    log.info("Hopper mode: adaptive (sweep + sticky, channel-6 biased)")
+                    self.hopper = AdaptiveChannelHopper(iface)
         self.count       = 0
         self.nan_count   = 0
         self._scanning   = False
@@ -2077,6 +2500,200 @@ class WiFiFeeder:
                 f"sent={self.forwarder.sent_total}  failed={self.forwarder.failed_total}"
             )
 
+    # ------------------------------------------------------------------
+    # v1.5.0 heartbeat schema — feeder split (wifi_2g / wifi_5g / scan_mode)
+    # ------------------------------------------------------------------
+    # Server accepts the new schema as of 2026-08-05 (see project memory
+    # `project_v1_5_0_heartbeat_schema.md` for full sign-off). Emitter
+    # gated on WIFI_HEARTBEAT_SPLIT env var — defaults to "true" for
+    # v1.5.0+; can be flipped to "false" as an emergency escape hatch
+    # if server-side gets rolled back.
+    #
+    # Behavior:
+    #   flag=true (default v1.5.0+):
+    #     Single-adapter mode: emit TWO heartbeats per cycle — one with
+    #       feeder=wifi_2g and one with feeder=wifi_5g. scan_mode is
+    #       derived from the adapter's band capability:
+    #         - dual-band card (2.4+5): both scan_mode=dwell
+    #         - 2.4-only card: 2.4=lock, 5=absent
+    #         - 5-only card:   2.4=absent, 5=lock
+    #         - no usable adapter (FAULT): both absent (still emit — server
+    #           counts absent as "present" for freshness/online detection)
+    #   flag=false: single legacy heartbeat with feeder omitted (server
+    #     infers wifi from wifi_ok/ble_ok null-ness, as pre-v1.5.0 nodes do).
+    def _emit_wifi_heartbeats(self, common_payload: dict, wifi_ok: bool,
+                              wifi_adp: str | None, wifi_fault: str | None,
+                              scanning: bool):
+        """Send heartbeats using the v1.5.0 split schema (or legacy shape
+        if the env-var escape hatch is flipped off). Called from both the
+        normal cycle and the FAULT loop."""
+        # Base payload merges the common fields with wifi-specific status.
+        # In FAULT mode wifi_fault is set; in normal mode it's None.
+        base = dict(common_payload)
+        base["wifi_ok"]      = wifi_ok
+        base["wifi_adapter"] = wifi_adp
+        base["scanning"]     = scanning
+        if wifi_fault is not None:
+            base["wifi_fault"] = wifi_fault
+
+        split_on = os.environ.get("WIFI_HEARTBEAT_SPLIT", "true").strip().lower() == "true"
+        if not split_on:
+            # Legacy pre-v1.5.0 shape: one heartbeat, no feeder discriminator.
+            self._post_heartbeat_body(base)
+            return
+
+        # v1.5.0 dual-adapter mode: when --band is explicit, this process
+        # emits ONLY its own band's heartbeat. The peer process (started
+        # from the sibling systemd unit) handles the other band. Never
+        # emit `absent` from here — that would clobber the peer's real
+        # heartbeat via server-side rollup order.
+        if self.band == "2g":
+            mac = _get_iface_mac(self.iface) if self.iface else None
+            p24 = dict(base)
+            p24["feeder"] = "wifi_2g"
+            p24["scan_mode"] = "lock"  # dedicated adapter, this band only
+            p24["wifi_adapter_mac"] = mac
+            p24["wifi_adapter_id"]  = None  # TODO: could look up via classifier
+            log.info(f"[heartbeat v1.5.0] emitting: wifi_2g(lock, iface={self.iface})")
+            self._post_heartbeat_body(p24)
+            self._write_local_wifi_state("wifi_2g", "lock", mac, None, wifi_ok, wifi_fault)
+            return
+        if self.band == "5g":
+            mac = _get_iface_mac(self.iface) if self.iface else None
+            p5 = dict(base)
+            p5["feeder"] = "wifi_5g"
+            p5["scan_mode"] = "lock"
+            p5["wifi_adapter_mac"] = mac
+            p5["wifi_adapter_id"]  = None
+            log.info(f"[heartbeat v1.5.0] emitting: wifi_5g(lock, iface={self.iface})")
+            self._post_heartbeat_body(p5)
+            self._write_local_wifi_state("wifi_5g", "lock", mac, None, wifi_ok, wifi_fault)
+            return
+
+        # v1.5.0 split — figure out this adapter's band capability, then
+        # emit one heartbeat per band. Fall back to "both absent" if we
+        # can't identify the adapter (FAULT / iface missing / classifier
+        # enumeration error).
+        adapter_mac: str | None = None
+        adapter_id:  str | None = None
+        can_24 = False
+        can_5  = False
+        try:
+            current_mac = _get_iface_mac(self.iface) if self.iface else None
+            if current_mac:
+                for a in wclassifier_enumerate():
+                    if a["mac"] == current_mac:
+                        adapter_mac = a["mac"]
+                        if a["usb_vid"] and a["usb_pid"]:
+                            adapter_id = f"{a['usb_vid']}:{a['usb_pid']}"
+                        can_24 = "2.4" in a["bands"]
+                        can_5  = "5"   in a["bands"]
+                        break
+        except Exception as e:
+            log.warning(f"[heartbeat v1.5.0] adapter capability probe failed: {e}")
+
+        # Derive scan_mode per server-claude's vocabulary:
+        #   lock  = dedicated adapter continuously on one band
+        #   dwell = shared adapter visits the band fractionally
+        #   absent = no capable adapter present
+        if can_24 and can_5:
+            mode_24, mode_5 = "dwell", "dwell"
+        elif can_24:
+            mode_24, mode_5 = "lock", "absent"
+        elif can_5:
+            mode_24, mode_5 = "absent", "lock"
+        else:
+            mode_24, mode_5 = "absent", "absent"
+
+        log.info(
+            f"[heartbeat v1.5.0] emitting split: "
+            f"wifi_2g(mode={mode_24}, mac={adapter_mac if can_24 else None}) + "
+            f"wifi_5g(mode={mode_5}, mac={adapter_mac if can_5 else None})"
+        )
+
+        # wifi_2g heartbeat. When absent (no 2.4GHz-capable adapter),
+        # null out the LEGACY wifi_adapter field too — otherwise the
+        # server dashboard renders "(wlanN)" next to an absent row,
+        # which is misleading.
+        mac_24 = adapter_mac if can_24 else None
+        id_24  = adapter_id  if can_24 else None
+        p24 = dict(base)
+        p24["feeder"] = "wifi_2g"
+        p24["scan_mode"] = mode_24
+        p24["wifi_adapter_mac"] = mac_24
+        p24["wifi_adapter_id"]  = id_24
+        if not can_24:
+            p24["wifi_adapter"] = None
+        self._post_heartbeat_body(p24)
+        self._write_local_wifi_state("wifi_2g", mode_24, mac_24, id_24, wifi_ok, wifi_fault)
+
+        # wifi_5g heartbeat — same absent-nulling
+        mac_5 = adapter_mac if can_5 else None
+        id_5  = adapter_id  if can_5 else None
+        p5 = dict(base)
+        p5["feeder"] = "wifi_5g"
+        p5["scan_mode"] = mode_5
+        p5["wifi_adapter_mac"] = mac_5
+        p5["wifi_adapter_id"]  = id_5
+        if not can_5:
+            p5["wifi_adapter"] = None
+        self._post_heartbeat_body(p5)
+        self._write_local_wifi_state("wifi_5g", mode_5, mac_5, id_5, wifi_ok, wifi_fault)
+
+    def _write_local_wifi_state(self, feeder: str, scan_mode: str,
+                                adapter_mac: str | None, adapter_id: str | None,
+                                wifi_ok: bool, wifi_fault: str | None):
+        """v1.5.0 Gap 3: mirror the heartbeat's per-band status to a tmpfs
+        file so the offline Web UI can render feeder status (three-row
+        BLE/2.4/5 layout matching My Nodes) without a server round-trip.
+
+        One file per feeder (per band). Called from _emit_wifi_heartbeats
+        immediately after each per-band POST. Atomic write via tmpfile
+        + rename, same pattern as _write_gps_state — soft-fails silently
+        if the tmpfs isn't writable (dashboard just misses this refresh).
+        """
+        # File naming — matches the feeder identifier for clean lookup
+        # by the Web UI (wifi_state_2g.json, wifi_state_5g.json).
+        band_suffix = feeder.replace("wifi_", "")  # "2g" or "5g"
+        path = f"/run/droneaware/wifi_state_{band_suffix}.json"
+        try:
+            os.makedirs("/run/droneaware", exist_ok=True)
+            state = {
+                "feeder":       feeder,
+                "band":         band_suffix,
+                "iface":        self.iface or None,
+                "adapter_mac":  adapter_mac,
+                "adapter_id":   adapter_id,
+                "scan_mode":    scan_mode,
+                "current_channel": getattr(self.hopper, "current_channel", None)
+                                    if hasattr(self, "hopper") else None,
+                "wifi_ok":      wifi_ok,
+                "wifi_fault":   wifi_fault,
+                "sent_total":   self.forwarder.sent_total if hasattr(self, "forwarder") else 0,
+                "updated_at":   time.time(),
+            }
+            tmp = path + ".tmp"
+            with open(tmp, "w") as f:
+                json.dump(state, f)
+            os.replace(tmp, path)
+        except Exception:
+            # Non-fatal — the offline dashboard just misses this refresh
+            pass
+
+    def _post_heartbeat_body(self, payload: dict):
+        """POST a fully-assembled heartbeat body. Isolates the network
+        call so retry / logging changes only touch one place."""
+        try:
+            requests.post(
+                "https://api.droneaware.io/api/node/heartbeat",
+                json=payload,
+                headers={"X-Node-Token": self.token},
+                timeout=5,
+            )
+            log.debug(f"Heartbeat sent (feeder={payload.get('feeder', 'wifi[legacy]')})")
+        except requests.RequestException as e:
+            log.warning(f"Heartbeat failed (feeder={payload.get('feeder', 'wifi[legacy]')}): {e}")
+
     def _fault_loop(self, reason: str):
         """
         Degraded loop entered when no usable WiFi adapter is present.
@@ -2100,38 +2717,35 @@ class WiFiFeeder:
                 load_1m, load_5m, load_15m = get_cpu_load()
                 has_gps  = os.path.exists(os.environ.get("GPS_DEVICE", "/dev/ttyUSB0"))
                 mobile   = os.environ.get("NODE_MOBILE", "false").lower() == "true"
-                requests.post(
-                    "https://api.droneaware.io/api/node/heartbeat",
-                    json={
-                        # Per-feeder heartbeat: wifi_* fields only (see note above)
-                        "node_id":      self.node_id,
-                        "uptime_s":     int(time.time() - self.start_time),
-                        "fw_version":   FW_VERSION,
-                        "cpu_count":    os.cpu_count(),
-                        "cpu_temp_c":   cpu_temp,
-                        "cpu_percent":  cpu_pct,
-                        "load_1m":      load_1m,
-                        "load_5m":      load_5m,
-                        "load_15m":     load_15m,
-                        "wifi_ok":      False,
-                        "wifi_adapter": self.iface or None,
-                        "wifi_fault":   reason,
-                        "scanning":     False,
-                        "mobile":       mobile,
-                        "has_gps":      has_gps,
-                        "lat":          lat,
-                        "lon":          lon,
-                        # v1.4.8 telemetry — restart count is meaningful
-                        # even in FAULT loop (a crash-looping FAULT feeder
-                        # is worth surfacing). No forwarder in FAULT mode,
-                        # so no buffered/dropped fields.
-                        "restarts_since_boot": self.restart_count,
-                    },
-                    headers={"X-Node-Token": self.token},
-                    timeout=5,
+                common = {
+                    "node_id":      self.node_id,
+                    "uptime_s":     int(time.time() - self.start_time),
+                    "fw_version":   FW_VERSION,
+                    "cpu_count":    os.cpu_count(),
+                    "cpu_temp_c":   cpu_temp,
+                    "cpu_percent":  cpu_pct,
+                    "load_1m":      load_1m,
+                    "load_5m":      load_5m,
+                    "load_15m":     load_15m,
+                    "mobile":       mobile,
+                    "has_gps":      has_gps,
+                    "lat":          lat,
+                    "lon":          lon,
+                    # v1.4.8 telemetry — restart count is meaningful even
+                    # in FAULT loop. No forwarder in FAULT mode → no
+                    # buffered/dropped fields.
+                    "restarts_since_boot": self.restart_count,
+                }
+                # v1.5.0 split (or legacy single heartbeat if flag off).
+                # wifi_adapter carries the iface string for legacy compat;
+                # v1.5.0 also emits wifi_adapter_mac/id under split schema.
+                self._emit_wifi_heartbeats(
+                    common,
+                    wifi_ok=False,
+                    wifi_adp=self.iface or None,
+                    wifi_fault=reason,
+                    scanning=False,
                 )
-            except requests.RequestException as e:
-                log.warning(f"FAULT heartbeat failed: {e}")
             except Exception as e:
                 log.warning(f"FAULT loop error: {e}")
 
@@ -2163,43 +2777,45 @@ class WiFiFeeder:
                         cpu_temp          = get_cpu_temp()
                         has_gps           = os.path.exists(os.environ.get("GPS_DEVICE", "/dev/ttyUSB0"))
                         mobile            = os.environ.get("NODE_MOBILE", "false").lower() == "true"
-                        requests.post(
-                            "https://api.droneaware.io/api/node/heartbeat",
-                            json={
-                                # Per-feeder heartbeat: wifi_* fields only.
-                                # Do NOT include ble_ok or ble_fault — the server
-                                # uses presence of an ok-field to route the
-                                # heartbeat to that feeder's status row.
-                                "node_id":      self.node_id,
-                                "uptime_s":     int(time.time() - self.start_time),
-                                "fw_version":   FW_VERSION,
-                                "cpu_count":    os.cpu_count(),
-                                "cpu_temp_c":   cpu_temp,
-                                "cpu_percent":  cpu_pct,
-                                "load_1m":      load_1m,
-                                "load_5m":      load_5m,
-                                "load_15m":     load_15m,
-                                "wifi_ok":      wifi_ok,
-                                "wifi_adapter": wifi_adp,
-                                "scanning":     self._scanning,
-                                "mobile":       mobile,
-                                "has_gps":      has_gps,
-                                "lat":          lat,
-                                "lon":          lon,
-                                # v1.4.8 telemetry additions — mirror BLE.
-                                "buffered":            len(self.forwarder.buffer),
-                                "buffered_bytes":      self.forwarder.buffer_bytes,
-                                "dropped_total":       self.forwarder.dropped_total,
-                                "sent_total":          self.forwarder.sent_total,
-                                "restarts_since_boot": self.restart_count,
-                                # WiFi feeder is threading-based — no
-                                # equivalent event_loop_max_lag_ms metric.
-                            },
-                            headers={"X-Node-Token": self.token},
-                            timeout=5,
+                        common = {
+                            # Per-feeder heartbeat: wifi_* fields only.
+                            # Do NOT include ble_ok or ble_fault — the server
+                            # uses presence of an ok-field to route the
+                            # heartbeat to that feeder's status row.
+                            "node_id":      self.node_id,
+                            "uptime_s":     int(time.time() - self.start_time),
+                            "fw_version":   FW_VERSION,
+                            "cpu_count":    os.cpu_count(),
+                            "cpu_temp_c":   cpu_temp,
+                            "cpu_percent":  cpu_pct,
+                            "load_1m":      load_1m,
+                            "load_5m":      load_5m,
+                            "load_15m":     load_15m,
+                            "mobile":       mobile,
+                            "has_gps":      has_gps,
+                            "lat":          lat,
+                            "lon":          lon,
+                            # v1.4.8 telemetry additions — mirror BLE.
+                            "buffered":            len(self.forwarder.buffer),
+                            "buffered_bytes":      self.forwarder.buffer_bytes,
+                            "dropped_total":       self.forwarder.dropped_total,
+                            "sent_total":          self.forwarder.sent_total,
+                            "restarts_since_boot": self.restart_count,
+                            # WiFi feeder is threading-based — no
+                            # equivalent event_loop_max_lag_ms metric.
+                        }
+                        # v1.5.0 split — emits TWO heartbeats per cycle
+                        # (wifi_2g + wifi_5g with scan_mode) when the
+                        # WIFI_HEARTBEAT_SPLIT env var is on (default true).
+                        # Falls back to legacy single heartbeat when off.
+                        self._emit_wifi_heartbeats(
+                            common,
+                            wifi_ok=wifi_ok,
+                            wifi_adp=wifi_adp,
+                            wifi_fault=None,
+                            scanning=self._scanning,
                         )
-                        log.debug("Heartbeat sent to droneaware.io")
-                    except requests.RequestException as e:
+                    except Exception as e:
                         log.warning(f"Heartbeat failed: {e}")
 
 
@@ -2260,21 +2876,51 @@ def main():
         "--verbose", "-v", action="store_true",
         help="Log every decoded packet"
     )
+    parser.add_argument(
+        "--band", choices=["auto", "2g", "5g"], default="auto",
+        help="v1.5.0 dual-adapter mode. 'auto' (default) = single-adapter "
+             "behavior (may dwell dual-band or hop 2.4 only). '2g' = "
+             "dedicated 2.4 GHz feeder (uses WIFI_ADAPTER_2G_MAC). '5g' = "
+             "dedicated 5 GHz-149 lock (uses WIFI_ADAPTER_5G_MAC). "
+             "Split-band services set this explicitly."
+    )
     args = parser.parse_args()
+
+    # v1.5.0 Step 3 — MAC-based iface resolution (--band-aware for the
+    # dual-adapter split units). WIFI_ADAPTER_2G_MAC / WIFI_ADAPTER_5G_MAC
+    # win when --band is set explicitly; single-adapter WIFI_ADAPTER_MAC
+    # is the fallback.
+    args.iface = resolve_monitor_iface(args.iface, band=args.band)
+
+    # v1.5.0 Step 1 (logging-only): snapshot the classifier's view of
+    # adapters + proposed role assignment. Compares against --iface but
+    # does NOT change behavior. Enables validation on real nodes.
+    wclassifier_log_startup_snapshot(args.iface)
 
     token = resolve_token()
 
-    gps_device = find_gps_device()
-    if gps_device:
-        log.info(f"[GPS] Dongle detected at {gps_device}")
-        # Seed initial state so `droneaware status` has something to show
-        # before the reader thread has a chance to update it.
-        _write_gps_state(device=gps_device, status="detecting_baud")
-        t = threading.Thread(target=gps_reader_thread, args=(gps_device,), daemon=True)
-        t.start()
+    # v1.5.0 Gap 1 fix: in dual-adapter mode, only ONE process owns the
+    # GPS serial port. Two processes opening the same /dev/ttyUSB0
+    # corrupt the NMEA stream for both (Linux tty devices don't do
+    # exclusive locking by default). Convention: --band=2g owns GPS
+    # (arbitrary but deterministic); --band=5g skips the reader entirely
+    # and relies on the peer to update the shared /run/droneaware/gps_state.json.
+    # --band=auto (single-adapter mode) owns GPS as always.
+    if args.band == "5g":
+        log.info("[GPS] --band=5g: skipping GPS reader (peer 2g feeder owns "
+                 "the serial port; state file is shared)")
     else:
-        log.info("[GPS] No GPS dongle detected — position will not be reported")
-        _write_gps_state(status="not_configured")
+        gps_device = find_gps_device()
+        if gps_device:
+            log.info(f"[GPS] Dongle detected at {gps_device}")
+            # Seed initial state so `droneaware status` has something to show
+            # before the reader thread has a chance to update it.
+            _write_gps_state(device=gps_device, status="detecting_baud")
+            t = threading.Thread(target=gps_reader_thread, args=(gps_device,), daemon=True)
+            t.start()
+        else:
+            log.info("[GPS] No GPS dongle detected — position will not be reported")
+            _write_gps_state(status="not_configured")
 
     feeder = WiFiFeeder(
         iface=args.iface,
@@ -2285,6 +2931,7 @@ def main():
         flush_interval=args.flush_interval,
         channel_dwell=args.channel_dwell,
         token=token,
+        band=args.band,
     )
     feeder.run()
 


### PR DESCRIPTION
## Summary

**Multi-radio milestone.** Adapter-identification fragility fixed for good, dual-adapter dual-band scanning shipped, per-band feeder visibility across dashboards.

Requires the server-side heartbeat schema to be deployed BEFORE this firmware ships (feeder=wifi_2g/wifi_5g emitted instead of legacy feeder=wifi when in split mode).

## The headline change

Nodes with two USB monitor adapters now scan both bands **continuously**, not alternately:
- One adapter locks to 2.4 GHz (channel hop 1/6/11)
- Other adapter locks to 5 GHz channel 149
- No dwelling, no context-switch latency, no missed drones

Nodes with one adapter unchanged (single-adapter dwell mode).

## Adapter identification is now MAC-based

Root cause of adapter-fragility bug: `WIFI_ADAPTER=wlan1` in config.env broke whenever USB enumeration reshuffled `wlanN` (adding hardware, moving cables, hot-plug). Pi onboard WiFi could end up at wlan1 → seized as monitor → SSH broken.

- MAC-based, survives USB enumeration reshuffling
- **Onboard hard-filter**: brcmfmac driver OR sdio/mmc bus → refuse across ALL resolution paths (choosing onboard = self-inflicted SSH lockout)
- Classifier + capability-constrained role assignment: 2.4-only can't take 5 GHz-149 role, forced to 2.4 GHz hopper role
- NM config auto-regenerated from resolved MAC(s) via `_regenerate_nm_monitor_config`

## New: `sudo droneaware refresh`

Operator orchestration command — re-detects hardware, migrates config, regenerates NM config, switches systemd unit topology if adapter count changed. Idempotent, no binary download required.

Mental model:
- **New release available** → `sudo droneaware update`
- **Changed hardware / verify state** → `sudo droneaware refresh`

## New: dual-adapter systemd units

- `droneaware-wifi-2g.service` — dedicated 2.4 GHz, reads `WIFI_ADAPTER_2G_MAC`
- `droneaware-wifi-5g.service` — dedicated 5 GHz-149 lock, reads `WIFI_ADAPTER_5G_MAC`
- `droneaware-wifi.service` — unchanged single-adapter unit

Mutually exclusive via `Conflicts=`. Mode-switching automatic based on classifier's detection of monitor-capable adapter count.

## Per-band heartbeat schema

- Three heartbeats per interval: `ble`, `wifi_2g`, `wifi_5g` (was two: `ble`, `wifi`)
- New fields: `feeder` (discriminator), `scan_mode` (`lock`|`dwell`|`absent`), `wifi_adapter_mac`, `wifi_adapter_id`
- Dropped: `wifi_bands_scanned` (redundant with `feeder`)
- Absent heartbeats still count as "present" for freshness — 5 GHz-absent nodes report online
- My Nodes dashboard renders three rows per node

## Offline Web UI

New three-row Feeders panel (BLE / 2.4 GHz / 5 GHz) in `http://<pi-ip>:5000/` mirroring My Nodes layout. Data from per-band tmpfs state files each feeder writes on heartbeat cycles + systemd is-active for BLE.

## Safety additions

**Unplug-safety**: in dual-adapter mode, if the band-specific MAC becomes unresolvable (adapter removed), the feeder refuses to fall through to peer's adapter (would cause contention). Enters FAULT cleanly, peer band unaffected.

**GPS ownership**: two wifi_feeder processes both reading `/dev/ttyUSB0` would corrupt NMEA. `--band=5g` skips GPS reader; `--band=2g` and `--band=auto` own it. Deterministic.

## Backward compatibility

- Legacy `WIFI_ADAPTER=wlanN` honored as fallback. `migrate_config_env` reads legacy, resolves to MAC, writes `WIFI_ADAPTER_MAC`. Legacy retained one cycle, dropped v1.6.0.
- Single-adapter operators: zero functional change on upgrade, silent MAC upgrade
- Pre-v1.5.0 heartbeat shape (`feeder=wifi`) accepted indefinitely

## Files changed

- `wifi_feeder.py` — classifier, `--band` arg, `LockedChannelHopper`, MAC-based resolution, hard-filter onboard, unplug-safety, band-scoped heartbeat, per-band state files, GPS ownership
- `droneaware` (CLI) — `_orchestrate_wifi_mode`, `_regenerate_nm_monitor_config`, `_classify_wifi_adapters`, `cmd_refresh`, `_set_cfg_key`, MAC key migration
- `install.sh` — ships two new systemd unit files
- `droneaware-wifi-2g.service` (new)
- `droneaware-wifi-5g.service` (new)
- `web_ui.py` — `_read_feeder_states`, `/api/status.feeders`
- `web_static/index.html` — Feeders panel HTML/CSS/JS

## Validated on real hardware

Pi 3B + dual-band USB (MT7612U) + 2.4-only USB (RT3070). Scenarios covered:

- Single-adapter mode → dual-adapter mode via config edit
- Dual-adapter mode → single-adapter mode via adapter unplug + refresh
- MAC-based tracking survives USB port shuffle (adapters swapped between ports, roles stay on same physical adapters)
- Onboard-refusal fired for both explicit MAC config and legacy `WIFI_ADAPTER=wlan0` — SSH stayed alive through both tests
- Unplug-safety: one adapter removed mid-run, peer band unaffected, dashboard shows one row FAULT
- Refresh idempotent — no-op when hardware unchanged, mode-switches only when adapter count changes