### PR TITLE
v1.5.0.3: mode-aware wifi service list in cmd_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.0.3] — Unreleased
+
+Cosmetic fix for `sudo droneaware status` on dual-adapter nodes.
+
+Pre-v1.5.0.3 `cmd_status` hardcoded `for svc in droneaware-ble
+droneaware-wifi` and displayed the state of each. In dual-adapter
+mode (both `WIFI_ADAPTER_2G_MAC` + `WIFI_ADAPTER_5G_MAC` set),
+`droneaware-wifi.service` is CORRECTLY inactive — the two split
+units `droneaware-wifi-2g` and `droneaware-wifi-5g` are the active
+ones. But status showed `droneaware-wifi` as red-inactive, which
+looked broken.
+
+Fix: mode-aware service list. Read config keys; if dual-mode keys
+set, show the two split units. Else show `droneaware-wifi` as
+before. Same one-adapter/two-adapter detection logic as
+`_start_wifi_services_for_current_mode` (v1.5.0.1) and
+`_orchestrate_wifi_mode`.
+
+Data was always correct — only the display was wrong.
+
+### Files changed
+
+- `droneaware` (CLI) — `cmd_status` service list becomes mode-aware.
+
+---
+
 ## [1.5.0.2] — Unreleased
 
 Post-update self-heal: `cmd_update` now re-execs the newly-installed

--- a/droneaware
+++ b/droneaware
@@ -1032,7 +1032,23 @@ cmd_status() {
     echo "  Firmware : ${ver}"
     echo "  Node ID  : $(_cfg_get "${INSTALL_DIR}/config.env" NODE_ID unknown)"
     echo ""
-    for svc in droneaware-ble droneaware-wifi; do
+    # v1.5.0.3: mode-aware WiFi service list. In dual-adapter mode
+    # (both WIFI_ADAPTER_2G_MAC + WIFI_ADAPTER_5G_MAC set),
+    # droneaware-wifi.service is CORRECTLY inactive (the two split
+    # units are the active ones). Pre-v1.5.0.3 status only checked
+    # droneaware-wifi and displayed it as red-inactive, misleading
+    # operators into thinking wifi was broken.
+    local svcs=(droneaware-ble)
+    local cfg="${INSTALL_DIR}/config.env"
+    local mac_2g mac_5g
+    mac_2g=$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC)
+    mac_5g=$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC)
+    if [[ -n "$mac_2g" && -n "$mac_5g" ]]; then
+        svcs+=(droneaware-wifi-2g droneaware-wifi-5g)
+    else
+        svcs+=(droneaware-wifi)
+    fi
+    for svc in "${svcs[@]}"; do
         local state
         state=$(systemctl is-active "$svc" 2>/dev/null)
         if [[ "$state" == "active" ]]; then


### PR DESCRIPTION
## Summary

Cosmetic fix for `sudo droneaware status` on dual-adapter nodes.

Pre-v1.5.0.3 `cmd_status` hardcoded `for svc in droneaware-ble droneaware-wifi` and displayed each service's state. In dual-adapter mode (both `WIFI_ADAPTER_2G_MAC` + `WIFI_ADAPTER_5G_MAC` set in config), `droneaware-wifi.service` is CORRECTLY inactive — the two split units `droneaware-wifi-2g` and `droneaware-wifi-5g` are the active ones. But status showed `droneaware-wifi` as red-inactive, which looked broken.

## Before / after

**Before** (dual-adapter node):
```
●  droneaware-ble  (activating)
●  droneaware-wifi  (inactive)      ← misleading — this is correct in dual mode
●  droneaware-web  (running)
```

**After**:
```
●  droneaware-ble  (running)
●  droneaware-wifi-2g  (running)
●  droneaware-wifi-5g  (running)
●  droneaware-web  (running)
```

## Fix

Mode-aware service list. Read config; if dual-mode keys set, show the two split units. Else show `droneaware-wifi` as before. Same detection logic as `_start_wifi_services_for_current_mode` (v1.5.0.1) and `_orchestrate_wifi_mode`.

Data was always correct — only the display was wrong.

## Files changed

- `droneaware` (CLI) — `cmd_status` service list becomes mode-aware.
- `CHANGELOG.md` — v1.5.0.3 entry.