### PR TITLE
v1.5.0.5: release workflow uploads dual-adapter unit files as assets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,6 +65,8 @@ jobs:
             droneaware-bt-select.service
             droneaware-ble.service
             droneaware-wifi.service
+            droneaware-wifi-2g.service
+            droneaware-wifi-5g.service
             droneaware-web.service
       - name: Create Release
         run: |
@@ -78,6 +80,8 @@ jobs:
             droneaware-bt-select.service \
             droneaware-ble.service \
             droneaware-wifi.service \
+            droneaware-wifi-2g.service \
+            droneaware-wifi-5g.service \
             droneaware-web.service \
             --generate-notes
         env:
@@ -102,6 +106,7 @@ jobs:
             for f in ble_feeder wifi_feeder web_ui install.sh droneaware \
                      droneaware-bt-select droneaware-bt-select.service \
                      droneaware-ble.service droneaware-wifi.service \
+                     droneaware-wifi-2g.service droneaware-wifi-5g.service \
                      droneaware-web.service; do
               src="${DL_PATH}/${f}"
               [[ -f "$src" ]] || src="${f}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.0.5] — Unreleased
+
+Release-workflow fix: `.github/workflows/build.yaml` now uploads the
+two dual-adapter systemd unit files (`droneaware-wifi-2g.service` and
+`droneaware-wifi-5g.service`) as release assets.
+
+### Background
+
+These files were introduced in v1.5.0 and consumed by `install.sh`,
+but the release workflow's three hardcoded asset lists (attest
+subject-path, `gh release create` args, SHA256 checksum loop) were
+never updated to include them. Result: v1.5.0 through v1.5.0.4
+shipped without these files as release assets — fresh installs 404'd
+in install.sh's download loop, and the v1.5.0.4 self-heal path
+(which downloads missing unit files from the current release URL)
+also 404'd until the files were manually uploaded to the v1.5.0.4
+release post-tagging.
+
+### Fix
+
+- `.github/workflows/build.yaml` — add `droneaware-wifi-2g.service`
+  and `droneaware-wifi-5g.service` to all three lists.
+
+### Files changed
+
+- `.github/workflows/build.yaml`
+
+### Impact
+
+v1.5.0.5 is the first release where CI ships the correct asset set
+end-to-end with no manual `gh release upload` step. All future
+releases inherit the fix.
+
+---
+
 ## [1.5.0.4] — Unreleased
 
 Critical fix for dual-adapter nodes that upgraded from v1.4.x to any


### PR DESCRIPTION
## Summary

Fixes the release-side gap that caused v1.5.0 through v1.5.0.4 to ship without \`droneaware-wifi-2g.service\` and \`droneaware-wifi-5g.service\` as release assets. Those files were added to \`install.sh\` in v1.5.0 and consumed by the v1.5.0.4 self-heal path, but the release workflow was never updated to upload them.

## The three lists

\`.github/workflows/build.yaml\` had three separate hardcoded asset lists that all needed updating:

1. Attest subject-path (line 65-68)
2. \`gh release create\` args (line 78-81)
3. SHA256 checksum loop (line 102-105)

All three are now updated to include both new files.

## Impact

v1.5.0.4 was released and then required a manual \`gh release upload\` step to attach the two missing files (otherwise the self-heal path 404'd). v1.5.0.5 is the first release where CI ships the correct asset set end-to-end.