### PR TITLE
v1.5.0.6: adapter-mode correctness + installer failure visibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,14 @@ on:
       publish:
         default: false
         type: boolean
+      # v1.5.0.6: cut a validation build without touching the "Latest"
+      # pointer. GitHub auto-promotes the newest non-prerelease release to
+      # Latest, which is what the standard install snippet resolves to —
+      # so before this input existed, publishing a release candidate to
+      # test on real hardware immediately exposed it to every new operator.
+      prerelease:
+        default: false
+        type: boolean
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -71,6 +79,13 @@ jobs:
       - name: Create Release
         run: |
           [[ "$VERSION" =~ ^v ]] || VERSION="v$VERSION"
+          # A pre-release is never auto-promoted to "Latest", so the
+          # install snippet keeps resolving to the current stable release.
+          RELEASE_FLAGS=(--generate-notes)
+          if [[ "$PRERELEASE" == "true" ]]; then
+            RELEASE_FLAGS+=(--prerelease)
+            echo "Publishing ${VERSION} as a PRE-RELEASE — 'Latest' is unchanged."
+          fi
           gh release create "${VERSION}" "${DL_PATH}/ble_feeder" \
             "${DL_PATH}/wifi_feeder" \
             "${DL_PATH}/web_ui" \
@@ -83,10 +98,11 @@ jobs:
             droneaware-wifi-2g.service \
             droneaware-wifi-5g.service \
             droneaware-web.service \
-            --generate-notes
+            "${RELEASE_FLAGS[@]}"
         env:
           VERSION: ${{ inputs.version }}
           DL_PATH: ${{ steps.download.outputs.download-path }}
+          PRERELEASE: ${{ inputs.prerelease }}
           GH_TOKEN: ${{ github.token }}
       - name: Append SHA256 checksums to release notes
         # Lower-barrier verification path than `gh attestation verify` (which

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ on:
         default: true
         type: boolean
         description: Whether to publish the release on GitHub (defaults to true)
+      prerelease:
+        default: false
+        type: boolean
+        description: Mark as pre-release — does NOT become "Latest". Use for validation builds tested on real hardware before promoting.
 jobs:
   build-and-publish:
     uses: ./.github/workflows/build.yaml
@@ -21,3 +25,4 @@ jobs:
     with:
       version: ${{ inputs.version }}
       publish: ${{ inputs.publish }}
+      prerelease: ${{ inputs.prerelease }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,38 @@ this path was missed.
 Fix: the restart is mode-aware, routed through
 `_start_wifi_services_for_current_mode`.
 
+### Re-running the installer left both adapter modes enabled
+
+`install_services` unconditionally runs `systemctl enable
+droneaware-wifi`. The dual-mode switch only disabled it when the split
+units were **not** already enabled — true on a first install, false when
+re-running the installer on a node already in dual mode. That node ended
+up with `droneaware-wifi` enabled alongside `droneaware-wifi-2g` and
+`droneaware-wifi-5g`, so all three start on the next boot and fight over
+`Conflicts=`. install.sh tells operators to re-run it after an
+interrupted install, so this is reachable in the field.
+
+Fix: both mode-switch functions now state the desired enable-state and
+enforce it, rather than reacting to a transition they happened to
+observe — the same principle as clearing the stale band keys. The
+restart decision moved to a single place so the log no longer reports an
+action that install-time suppression skipped.
+
+### Web UI binary could never be replaced once installed
+
+`install_webui` wrote over `/opt/droneaware/web_ui` without stopping
+`droneaware-web`. A running process holds its own binary as its text
+image, so the write failed with `ETXTBSY`. In LOCAL_INSTALL mode the copy
+was additionally wrapped in `2>/dev/null`, so the real error was
+discarded and the operator was told `Web UI binary not found in local
+dist` — pointed at a missing file that was present the whole time.
+
+`download_binaries` stops the feeders but never this unit, and
+`cmd_update`'s equivalent stop was never mirrored here.
+
+Fix: stop `droneaware-web` before replacing its binary, and report the
+actual error instead of discarding it.
+
 ### `update` ignored pre-release status, so rollbacks did not reach nodes
 
 `cmd_update` read tag names from `GET /releases` and never looked at the
@@ -154,7 +186,8 @@ continue/cancel prompt. Silent on `0x0`, and skipped entirely where
   `_start_wifi_services_for_current_mode`; new `_service_start_suppressed`
   helper guarding every start/restart in both mode-switch functions;
   split units added to the `cmd_update` stop list; mode-aware feeder
-  restart in `cmd_install_webui`; stable-release selection in `cmd_update`
+  restart in `cmd_install_webui`; enable-state enforcement in both
+  mode-switch functions; stable-release selection in `cmd_update`
   with `DRONEAWARE_ALLOW_PRERELEASE=1` opt-in.
 - `.github/workflows/release.yaml`, `.github/workflows/build.yaml` — new
   `prerelease` input, so a validation build can be published and tested on
@@ -163,7 +196,8 @@ continue/cancel prompt. Silent on `0x0`, and skipped entirely where
 - `install.sh` — apt failure handling with explicit rollback; non-fatal
   bluetooth setup; split units added to the `download_binaries` stop list;
   `DRONEAWARE_NO_SERVICE_START=1` on the `__migrate` call; new
-  `_check_undervoltage` pre-flight.
+  `_check_undervoltage` pre-flight; `droneaware-web` stopped before its
+  binary is replaced, with the real error surfaced.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,10 @@ continue/cancel prompt. Silent on `0x0`, and skipped entirely where
   helper guarding every start/restart in both mode-switch functions;
   split units added to the `cmd_update` stop list; mode-aware feeder
   restart in `cmd_install_webui`.
+- `.github/workflows/release.yaml`, `.github/workflows/build.yaml` — new
+  `prerelease` input, so a validation build can be published and tested on
+  real hardware without becoming the `Latest` release that the install
+  snippet resolves to.
 - `install.sh` — apt failure handling with explicit rollback; non-fatal
   bluetooth setup; split units added to the `download_binaries` stop list;
   `DRONEAWARE_NO_SERVICE_START=1` on the `__migrate` call; new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,34 @@ this path was missed.
 Fix: the restart is mode-aware, routed through
 `_start_wifi_services_for_current_mode`.
 
+### `update` ignored pre-release status, so rollbacks did not reach nodes
+
+`cmd_update` read tag names from `GET /releases` and never looked at the
+`prerelease` flag. Marking a release as a pre-release on GitHub moves the
+`Latest` pointer that fresh installs resolve to, but it did not keep
+existing nodes off that release — `sudo droneaware update` would still
+select it. A withdrawn release therefore remained installable on every
+node in the field, and a rollback only ever protected new installs.
+
+The same loop also issued one additional API call per candidate tag,
+against GitHub's 60-requests-per-hour unauthenticated limit.
+
+Fix: a single API call, parsed properly, skipping drafts and
+pre-releases and requiring the `ble_feeder` asset. Sorting is done on
+`published_at` rather than trusting the API's list order, which is not
+stable once pre-releases are present.
+
+The asset test deliberately checks for `ble_feeder` only. Requiring the
+full v1.5.0 asset set would make every pre-v1.5.0 release unselectable
+and remove the ability to roll the fleet back to one.
+
+Release candidates can still be installed on a test node by opting in
+explicitly:
+
+```
+sudo DRONEAWARE_ALLOW_PRERELEASE=1 droneaware update
+```
+
 ### Added: under-voltage pre-flight
 
 `install.sh` now reads `vcgencmd get_throttled` before running apt. A Pi
@@ -126,7 +154,8 @@ continue/cancel prompt. Silent on `0x0`, and skipped entirely where
   `_start_wifi_services_for_current_mode`; new `_service_start_suppressed`
   helper guarding every start/restart in both mode-switch functions;
   split units added to the `cmd_update` stop list; mode-aware feeder
-  restart in `cmd_install_webui`.
+  restart in `cmd_install_webui`; stable-release selection in `cmd_update`
+  with `DRONEAWARE_ALLOW_PRERELEASE=1` opt-in.
 - `.github/workflows/release.yaml`, `.github/workflows/build.yaml` — new
   `prerelease` input, so a validation build can be published and tested on
   real hardware without becoming the `Latest` release that the install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,130 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.0.6] — Unreleased
+
+Installation and adapter-mode correctness. Five defects found in a code
+audit of the v1.5.0.x line following operator reports of failed installs
+and nodes that stopped scanning.
+
+### Nodes could end an update with no WiFi feeder running
+
+`_switch_to_single_adapter_mode` wrote `WIFI_ADAPTER_MAC` but never
+cleared `WIFI_ADAPTER_2G_MAC` / `WIFI_ADAPTER_5G_MAC`. Those two keys
+are how every other code path decides whether the node is in dual mode,
+so a node that had once had two adapters and later resolved to one kept
+being treated as dual. The result was a loop:
+
+1. `_orchestrate_wifi_mode` correctly selects single mode, disables the
+   split units and starts `droneaware-wifi`
+2. `_start_wifi_services_for_current_mode`, at the end of `cmd_update`,
+   re-reads the stale band keys, takes the dual branch, stops
+   `droneaware-wifi` and starts the split units — which were just
+   disabled, and on pre-v1.5.0.4 nodes were not installed at all
+3. the update finishes with no WiFi feeder running, and every later
+   `refresh` or `update` repeats the same sequence
+
+`cmd_status` read the same stale keys, so affected nodes also displayed
+two split-unit rows when they should have shown one.
+
+Fixes:
+- `_switch_to_single_adapter_mode` clears both band keys, so `config.env`
+  is an honest record of the mode. Only writes when a stale value is
+  actually present — a no-op on nodes that have only ever had one adapter.
+- `_start_wifi_services_for_current_mode` no longer takes the dual branch
+  when the split unit files are absent from `/etc/systemd/system/`. It
+  logs the mismatch and starts the single-adapter feeder instead, so a
+  configuration/filesystem disagreement can never leave the node dark.
+
+### The installer could fail silently
+
+`install_packages` sent both `apt-get` calls to `/dev/null 2>&1`. With
+`set -e` active, a non-zero exit aborted the script immediately; when the
+failure occurred before NetworkManager had been touched, the `ERR` trap
+printed nothing either. The installer simply stopped after the
+"Installing System Packages" heading with no message.
+
+The common trigger is an interrupted `dpkg` transaction, which makes apt
+refuse every subsequent operation until `dpkg --configure -a` is run —
+so the install then failed identically on every retry with no diagnostic.
+
+Fixes:
+- apt stderr is no longer discarded; stdout stays quiet.
+- Both apt calls have an explicit failure handler naming the likely
+  causes and the exact remediation command for each.
+- The handler performs the NetworkManager rollback explicitly, because
+  `fatal` exits directly and does not fire the `ERR` trap.
+- `systemctl enable/start bluetooth` are now non-fatal warnings. A node
+  with no Bluetooth hardware can still run the WiFi feeder; previously a
+  masked or absent unit aborted the entire install.
+
+### Fresh installs started feeders before enrollment
+
+`migrate_config` runs `__migrate`, which reaches `_orchestrate_wifi_mode`
+and started the WiFi unit(s) immediately. `enroll_node` — which writes
+`/etc/droneaware/token` — does not run until the following step, so every
+fresh install briefly ran a feeder with no credentials, crash-looping
+under `Restart=always` until the operator rebooted. This also contradicted
+install.sh's own design, in which units are enabled at install time and
+started by the reboot the summary asks for.
+
+Fix: install.sh sets `DRONEAWARE_NO_SERVICE_START=1` for its single
+`__migrate` call. Orchestration still writes config keys and sets
+enable/disable state; it just does not start anything. `refresh` and
+`update` leave the flag unset and start units as before.
+
+### Binaries could be overwritten while in use
+
+Both `install.sh` and `cmd_update` stopped only `droneaware-ble` and
+`droneaware-wifi` before replacing `/opt/droneaware/wifi_feeder`. On a
+dual-adapter node the two split feeders were still running, holding that
+inode as their text image — giving `ETXTBSY` or a truncated binary. In
+install.sh this additionally tripped the `ERR` trap and rolled back
+NetworkManager mid-install.
+
+Fix: both stop lists include `droneaware-wifi-2g` and
+`droneaware-wifi-5g`.
+
+### install-webui dropped dual-adapter nodes to one band
+
+`cmd_install_webui` ended with a hardcoded `systemctl restart
+droneaware-wifi`. On a dual-adapter node that trips the split units'
+`Conflicts=droneaware-wifi.service` clause and stops them, leaving the
+node scanning one band. Same defect class v1.5.0.1 fixed in `cmd_update`;
+this path was missed.
+
+Fix: the restart is mode-aware, routed through
+`_start_wifi_services_for_current_mode`.
+
+### Added: under-voltage pre-flight
+
+`install.sh` now reads `vcgencmd get_throttled` before running apt. A Pi
+on a marginal supply browns out under load, and apt — sustained SD writes
+plus CPU — is a frequent victim; the kernel kills it mid-transaction and
+`dpkg` is left interrupted, which is what makes the failure above recur
+on every retry.
+
+Only the under-voltage bits (`0x1`, `0x10000`) gate the install, since
+throttling alone may be thermal. On a non-zero reading the operator sees
+the decoded state, the recommended remedies, and an explicit
+continue/cancel prompt. Silent on `0x0`, and skipped entirely where
+`vcgencmd` is unavailable.
+
+### Files changed
+
+- `droneaware` (CLI) — band-key clearing in `_switch_to_single_adapter_mode`;
+  unit-file presence guard and start-suppression in
+  `_start_wifi_services_for_current_mode`; new `_service_start_suppressed`
+  helper guarding every start/restart in both mode-switch functions;
+  split units added to the `cmd_update` stop list; mode-aware feeder
+  restart in `cmd_install_webui`.
+- `install.sh` — apt failure handling with explicit rollback; non-fatal
+  bluetooth setup; split units added to the `download_binaries` stop list;
+  `DRONEAWARE_NO_SERVICE_START=1` on the `__migrate` call; new
+  `_check_undervoltage` pre-flight.
+
+---
+
 ## [1.5.0.5] — Unreleased
 
 Release-workflow fix: `.github/workflows/build.yaml` now uploads the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,24 @@ this path was missed.
 Fix: the restart is mode-aware, routed through
 `_start_wifi_services_for_current_mode`.
 
+### `refresh` left a stopped feeder stopped
+
+The restart decision looked at enable-state, active-state of the *wrong*
+unit, and whether the adapter MACs had changed — but never at whether
+the desired feeder was actually running. A node whose config, enable
+flags and MACs were all correct but whose feeders were stopped (after a
+failed update, a manual stop, or a crash loop that exhausted its restart
+budget) got a `refresh` that reported success and changed nothing.
+
+That is the single most common reason an operator runs `refresh`, and it
+was the one case it did not handle. Pre-v1.5.0.6 had the same gap, so
+this is not a regression — but it defeats the documented purpose of the
+command.
+
+Fix: both mode-switch functions now treat "the units that should be
+running are not running" as a trigger, and say so in the output. Still a
+no-op when everything is already healthy.
+
 ### Re-running the installer left both adapter modes enabled
 
 `install_services` unconditionally runs `systemctl enable
@@ -187,7 +205,8 @@ continue/cancel prompt. Silent on `0x0`, and skipped entirely where
   helper guarding every start/restart in both mode-switch functions;
   split units added to the `cmd_update` stop list; mode-aware feeder
   restart in `cmd_install_webui`; enable-state enforcement in both
-  mode-switch functions; stable-release selection in `cmd_update`
+  mode-switch functions; not-running feeders started by `refresh`;
+  stable-release selection in `cmd_update`
   with `DRONEAWARE_ALLOW_PRERELEASE=1` opt-in.
 - `.github/workflows/release.yaml`, `.github/workflows/build.yaml` — new
   `prerelease` input, so a validation build can be published and tested on

--- a/droneaware
+++ b/droneaware
@@ -962,21 +962,66 @@ cmd_update() {
     CURRENT=$(cat "$VERSION_FILE" 2>/dev/null || echo "unknown")
     echo "  Checking latest release..."
 
-    # Find the most recent release that actually contains binaries.
+    # Find the newest STABLE release that actually contains binaries.
     # Installer-only releases (no ble_feeder asset) are skipped.
-    LATEST=""
-    while IFS= read -r tag; do
-        [[ -z "$tag" ]] && continue
-        has_binary=$(curl -sf "https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${tag}" \
-            | grep '"name"' | grep -c 'ble_feeder' || true)
-        if [[ "$has_binary" -gt 0 ]]; then
-            LATEST="$tag"
-            break
-        fi
-    done < <(curl -sf "https://api.github.com/repos/${GITHUB_REPO}/releases" \
-        | grep '"tag_name"' | cut -d'"' -f4)
+    #
+    # v1.5.0.6: pre-releases are now excluded, and the whole thing is one
+    # API call. Two problems with the previous implementation:
+    #
+    #   1. It read tag names from GET /releases and never looked at the
+    #      `prerelease` flag, so marking a release as a pre-release on
+    #      GitHub did NOT keep nodes off it. A withdrawn release stayed
+    #      installable via `droneaware update` even after the `Latest`
+    #      pointer had been moved back — the rollback only ever protected
+    #      fresh installs, not existing nodes.
+    #   2. It issued one extra API call per candidate tag against
+    #      GitHub's 60-requests-per-hour unauthenticated limit.
+    #
+    # Sorting is done here on published_at rather than trusting the API's
+    # list order, which is not stable once pre-releases are present.
+    #
+    # The asset test deliberately checks for ble_feeder ONLY. Requiring
+    # the full v1.5.0 asset set (including the dual-adapter unit files)
+    # would make every pre-v1.5.0 release unselectable and break the
+    # ability to roll the fleet back to one.
+    #
+    # To validate a release candidate on a test node, opt in explicitly:
+    #     sudo DRONEAWARE_ALLOW_PRERELEASE=1 droneaware update
+    LATEST=$(curl -sf "https://api.github.com/repos/${GITHUB_REPO}/releases" \
+        | ALLOW_PRE="${DRONEAWARE_ALLOW_PRERELEASE:-0}" python3 -c '
+import json, os, sys
+allow_pre = os.environ.get("ALLOW_PRE") == "1"
+try:
+    releases = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+if not isinstance(releases, list):
+    sys.exit(1)
+candidates = []
+for r in releases:
+    if not isinstance(r, dict) or r.get("draft"):
+        continue
+    if r.get("prerelease") and not allow_pre:
+        continue
+    if not any((a or {}).get("name") == "ble_feeder" for a in (r.get("assets") or [])):
+        continue
+    tag = r.get("tag_name")
+    if tag:
+        candidates.append((r.get("published_at") or r.get("created_at") or "", tag))
+if candidates:
+    candidates.sort(reverse=True)
+    print(candidates[0][1])
+' 2>/dev/null)
 
-    [[ -n "$LATEST" ]] || fatal "Could not reach GitHub or no binary release found — check internet connection."
+    if [[ -z "$LATEST" ]]; then
+        if [[ "${DRONEAWARE_ALLOW_PRERELEASE:-0}" == "1" ]]; then
+            fatal "Could not reach GitHub or no release with binaries found — check internet connection."
+        fi
+        fatal "Could not reach GitHub or no stable release with binaries found. If you are testing a release candidate, use: sudo DRONEAWARE_ALLOW_PRERELEASE=1 droneaware update"
+    fi
+    if [[ "${DRONEAWARE_ALLOW_PRERELEASE:-0}" == "1" ]]; then
+        warn "Pre-releases enabled — ${LATEST} may be a release candidate."
+    fi
 
     echo "  Installed : ${CURRENT}"
     echo "  Latest    : ${LATEST}"

--- a/droneaware
+++ b/droneaware
@@ -667,6 +667,23 @@ _set_cfg_key() {
     fi
 }
 
+# v1.5.0.6 — install-time service-start suppression.
+#
+# install.sh deliberately does NOT start feeders itself: it enables the
+# units and tells the operator to reboot. The enrollment token is written
+# to /etc/droneaware/token AFTER migrate runs, so any feeder started
+# during migration comes up without credentials and crash-loops until the
+# reboot. Pre-v1.5.0.6 the orchestration reached from `__migrate` issued
+# `systemctl start` regardless of caller, so every fresh install raced
+# enrollment.
+#
+# install.sh now sets DRONEAWARE_NO_SERVICE_START=1 for its one __migrate
+# call. `refresh` and `update` leave it unset and start units normally —
+# on those paths the token already exists.
+_service_start_suppressed() {
+    [[ "${DRONEAWARE_NO_SERVICE_START:-0}" == "1" ]]
+}
+
 _orchestrate_wifi_mode() {
     local cfg="$1"
     local MONITOR_COUNT="" ROLE_2G_MAC="" ROLE_5G_MAC=""
@@ -781,14 +798,17 @@ _switch_to_dual_adapter_mode() {
         systemctl stop droneaware-wifi 2>/dev/null || true
         systemctl disable droneaware-wifi 2>/dev/null || true
         systemctl enable droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
-        systemctl start droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+        _service_start_suppressed \
+            || systemctl start droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
     elif [[ "$wrong_unit_active" == "1" ]]; then
         info "v1.5.0.1 self-heal: droneaware-wifi is active but dual-adapter mode is desired — switching"
         systemctl stop droneaware-wifi 2>/dev/null || true
-        systemctl start droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+        _service_start_suppressed \
+            || systemctl start droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
     elif [[ "$macs_changed" == "1" ]]; then
         info "v1.5.0 dual-adapter MACs changed — restarting split units"
-        systemctl restart droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+        _service_start_suppressed \
+            || systemctl restart droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
     fi
 }
 
@@ -797,6 +817,37 @@ _switch_to_single_adapter_mode() {
     local prev_mac
     prev_mac=$(_cfg_get "$cfg" WIFI_ADAPTER_MAC)
     _set_cfg_key "$cfg" WIFI_ADAPTER_MAC "$mac"
+
+    # v1.5.0.6: CLEAR the dual-adapter band keys. Pre-v1.5.0.6 this
+    # function wrote WIFI_ADAPTER_MAC but left WIFI_ADAPTER_2G_MAC /
+    # WIFI_ADAPTER_5G_MAC populated from whenever the node last had two
+    # adapters. Those keys are how every other code path decides "am I
+    # in dual mode", so a stale pair meant a node that had dropped to
+    # one adapter kept being treated as dual:
+    #
+    #   1. this function correctly disables the split units and starts
+    #      droneaware-wifi
+    #   2. _start_wifi_services_for_current_mode (end of cmd_update)
+    #      re-reads the STALE keys, takes the dual branch, stops
+    #      droneaware-wifi and starts the split units — which are now
+    #      disabled, and on pre-v1.5.0.4 nodes missing entirely
+    #   3. node ends the update with NO wifi feeder running, and every
+    #      subsequent refresh repeats the same thrash
+    #
+    # cmd_status read the same stale keys, so it listed two split rows
+    # for a node that should show one. Clearing here makes config.env
+    # an honest record of the mode and stops the loop at the source.
+    #
+    # Only writes when a stale value is actually present, so this is a
+    # true no-op on nodes that have only ever had one adapter.
+    local stale_2g stale_5g
+    stale_2g=$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC)
+    stale_5g=$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC)
+    if [[ -n "$stale_2g" || -n "$stale_5g" ]]; then
+        info "v1.5.0.6: clearing stale dual-adapter band keys (node resolved to single-adapter)"
+        _set_cfg_key "$cfg" WIFI_ADAPTER_2G_MAC ""
+        _set_cfg_key "$cfg" WIFI_ADAPTER_5G_MAC ""
+    fi
 
     local mode_needs_enable_flip=0
     if systemctl is-enabled droneaware-wifi-2g.service >/dev/null 2>&1 \
@@ -818,14 +869,17 @@ _switch_to_single_adapter_mode() {
         systemctl stop droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
         systemctl disable droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
         systemctl enable droneaware-wifi 2>/dev/null || true
-        systemctl start droneaware-wifi 2>/dev/null || true
+        _service_start_suppressed \
+            || systemctl start droneaware-wifi 2>/dev/null || true
     elif [[ "$wrong_unit_active" == "1" ]]; then
         info "v1.5.0.1 self-heal: split unit(s) active but single-adapter mode is desired — switching"
         systemctl stop droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
-        systemctl start droneaware-wifi 2>/dev/null || true
+        _service_start_suppressed \
+            || systemctl start droneaware-wifi 2>/dev/null || true
     elif [[ "$mac_changed" == "1" ]]; then
         info "v1.5.0 single-adapter MAC changed — restarting service"
-        systemctl restart droneaware-wifi 2>/dev/null || true
+        _service_start_suppressed \
+            || systemctl restart droneaware-wifi 2>/dev/null || true
     fi
 }
 
@@ -836,16 +890,38 @@ _switch_to_single_adapter_mode() {
 # pre-v1.5.0.1 bug was exactly that (hardcoded droneaware-wifi start
 # would auto-stop the split units via their Conflicts clause).
 _start_wifi_services_for_current_mode() {
+    if _service_start_suppressed; then
+        info "v1.5.0.6: service start suppressed (install-time) — units enabled, will start on reboot"
+        return 0
+    fi
+
     local cfg="${INSTALL_DIR}/config.env"
     local mac_2g mac_5g
     mac_2g=$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC)
     mac_5g=$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC)
-    if [[ -n "$mac_2g" && -n "$mac_5g" ]]; then
+
+    # v1.5.0.6: never stop a working single-adapter feeder in favour of
+    # split units that cannot run. Config alone used to decide this, so a
+    # node whose band keys said "dual" while the unit files were absent
+    # (the pre-v1.5.0.4 missing-asset case) would have droneaware-wifi
+    # stopped and nothing started in its place — silently dark, and the
+    # same thing happened again on every subsequent update.
+    local dual_units_present=0
+    if [[ -f /etc/systemd/system/droneaware-wifi-2g.service \
+       && -f /etc/systemd/system/droneaware-wifi-5g.service ]]; then
+        dual_units_present=1
+    fi
+
+    if [[ -n "$mac_2g" && -n "$mac_5g" && "$dual_units_present" == "1" ]]; then
         # Dual-adapter mode. Ensure single-mode unit is stopped, then
         # start the split units.
         systemctl stop droneaware-wifi 2>/dev/null || true
         systemctl start droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
     else
+        if [[ -n "$mac_2g" && -n "$mac_5g" ]]; then
+            warn "Dual-adapter configured but unit files are missing — starting single-adapter feeder instead."
+            warn "Run 'sudo droneaware refresh' to download the missing unit files."
+        fi
         # Single-adapter mode. Ensure split units are stopped, then
         # start the single unit.
         systemctl stop droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
@@ -959,7 +1035,13 @@ cmd_update() {
     fi
 
     echo "  Stopping services..."
-    systemctl stop droneaware-ble droneaware-wifi 2>/dev/null || true
+    # v1.5.0.6: stop the split units too. Pre-v1.5.0.6 this stopped only
+    # droneaware-ble + droneaware-wifi, so on a dual-adapter node both
+    # split feeders were still running when the `cp` below overwrote
+    # /opt/droneaware/wifi_feeder — the kernel holds that inode as their
+    # text image, giving ETXTBSY or a truncated binary.
+    systemctl stop droneaware-ble droneaware-wifi \
+        droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
     [[ "$update_webui" == "1" ]] && systemctl stop droneaware-web 2>/dev/null || true
 
     # Also update the droneaware CLI itself. NON-SILENT — earlier
@@ -1141,7 +1223,7 @@ cmd_status() {
         state=$(systemctl is-active "$svc" 2>/dev/null)
         # v1.5.0.4: distinguish missing-unit-file from inactive. systemctl
         # is-active returns "inactive" for both, making the pre-v1.5.0.4
-        # "not-found" case invisible (the_ninja / dallas-drones incident).
+        # "not-found" case invisible (surfaced by an operator report).
         # is-enabled returns "not-found" specifically when the unit file
         # doesn't exist on disk.
         local enabled
@@ -1690,7 +1772,13 @@ cmd_install_webui() {
     # the Web UI immediately (this is the post-install path — operator
     # has a running node, no reason to force a reboot).
     systemctl daemon-reload
-    systemctl restart droneaware-wifi 2>/dev/null || true
+    # v1.5.0.6: mode-aware feeder restart. A hardcoded `restart
+    # droneaware-wifi` on a dual-adapter node trips the split units'
+    # Conflicts=droneaware-wifi.service clause and stops them, leaving the
+    # node scanning one band instead of two. Same bug class v1.5.0.1 fixed
+    # in cmd_update — this path was missed.
+    systemctl stop droneaware-wifi droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+    _start_wifi_services_for_current_mode
     systemctl restart droneaware-ble  2>/dev/null || true
     systemctl enable  droneaware-web > /dev/null 2>&1
     systemctl start   droneaware-web

--- a/droneaware
+++ b/droneaware
@@ -807,6 +807,17 @@ _switch_to_dual_adapter_mode() {
     if [[ "$prev_2g" != "$mac_2g" || "$prev_5g" != "$mac_5g" ]]; then
         macs_changed=1
     fi
+    # v1.5.0.6: also act when the desired units simply are not running.
+    # Config, enable-state and MACs can all be correct while the feeders
+    # are stopped — after a failed update, a manual stop, or a crash loop
+    # that exhausted its restart budget. Without this, `refresh` reported
+    # success and changed nothing, which defeats the whole reason
+    # operators are told to run it when a feeder is down.
+    local units_not_running=0
+    if ! systemctl is-active droneaware-wifi-2g.service >/dev/null 2>&1 \
+       || ! systemctl is-active droneaware-wifi-5g.service >/dev/null 2>&1; then
+        units_not_running=1
+    fi
 
     if [[ "$enable_state_wrong" == "1" ]]; then
         info "v1.5.0 unit topology → dual-adapter (2g=${mac_2g}, 5g=${mac_5g})"
@@ -818,11 +829,14 @@ _switch_to_dual_adapter_mode() {
     # One place decides whether the feeders need (re)starting, so the log
     # never claims an action that suppression skipped. `restart` covers
     # both cases — it starts a stopped unit.
-    if [[ "$enable_state_wrong" == "1" || "$wrong_unit_active" == "1" || "$macs_changed" == "1" ]]; then
+    if [[ "$enable_state_wrong" == "1" || "$wrong_unit_active" == "1" \
+       || "$macs_changed" == "1" || "$units_not_running" == "1" ]]; then
         systemctl stop droneaware-wifi 2>/dev/null || true
         if _service_start_suppressed; then
             info "v1.5.0.6: split units enabled — start deferred to reboot (install-time)"
         else
+            [[ "$units_not_running" == "1" ]] \
+                && info "v1.5.0.6: split unit(s) not running — starting"
             systemctl restart droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
         fi
     fi
@@ -884,6 +898,12 @@ _switch_to_single_adapter_mode() {
     fi
     local mac_changed=0
     [[ "$prev_mac" != "$mac" ]] && mac_changed=1
+    # v1.5.0.6: symmetric with dual mode — a correctly-configured but
+    # stopped feeder must be started by refresh.
+    local units_not_running=0
+    if ! systemctl is-active droneaware-wifi.service >/dev/null 2>&1; then
+        units_not_running=1
+    fi
 
     if [[ "$enable_state_wrong" == "1" ]]; then
         info "v1.5.0 unit topology → single-adapter (${mac})"
@@ -892,11 +912,14 @@ _switch_to_single_adapter_mode() {
         systemctl enable droneaware-wifi 2>/dev/null || true
     fi
 
-    if [[ "$enable_state_wrong" == "1" || "$wrong_unit_active" == "1" || "$mac_changed" == "1" ]]; then
+    if [[ "$enable_state_wrong" == "1" || "$wrong_unit_active" == "1" \
+       || "$mac_changed" == "1" || "$units_not_running" == "1" ]]; then
         systemctl stop droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
         if _service_start_suppressed; then
             info "v1.5.0.6: droneaware-wifi enabled — start deferred to reboot (install-time)"
         else
+            [[ "$units_not_running" == "1" ]] \
+                && info "v1.5.0.6: droneaware-wifi not running — starting"
             systemctl restart droneaware-wifi 2>/dev/null || true
         fi
     fi

--- a/droneaware
+++ b/droneaware
@@ -773,11 +773,26 @@ _switch_to_dual_adapter_mode() {
     # if the operator never runs another `update`.
     _ensure_dual_adapter_unit_files_installed
 
-    # Detect if the ENABLED unit topology is single-mode (needs enable/disable flip).
-    local mode_needs_enable_flip=0
+    # v1.5.0.6: enforce the enable-state for dual mode instead of only
+    # reacting to a detected single→dual transition.
+    #
+    # The old guard required droneaware-wifi enabled AND the split units
+    # NOT enabled. install.sh's install_services unconditionally runs
+    # `systemctl enable droneaware-wifi`, so on a RE-install of a node
+    # already in dual mode the split units were already enabled, the guard
+    # evaluated false, and droneaware-wifi was left enabled alongside them.
+    # Both modes then start on the next boot and fight over Conflicts=.
+    # install.sh explicitly tells operators to re-run it after an
+    # interrupted install, so this is reachable in the field.
+    #
+    # Stating the desired end state and enforcing it is the same principle
+    # as clearing the stale band keys above: derive from what the hardware
+    # is now, not from whether a transition happened to be observed.
+    local enable_state_wrong=0
     if systemctl is-enabled droneaware-wifi.service >/dev/null 2>&1 \
-       && ! systemctl is-enabled droneaware-wifi-2g.service >/dev/null 2>&1; then
-        mode_needs_enable_flip=1
+       || ! systemctl is-enabled droneaware-wifi-2g.service >/dev/null 2>&1 \
+       || ! systemctl is-enabled droneaware-wifi-5g.service >/dev/null 2>&1; then
+        enable_state_wrong=1
     fi
     # v1.5.0.1: detect ACTIVE-state mismatch too. Enabled state can be
     # correct (split units enabled) while droneaware-wifi is still running
@@ -793,22 +808,23 @@ _switch_to_dual_adapter_mode() {
         macs_changed=1
     fi
 
-    if [[ "$mode_needs_enable_flip" == "1" ]]; then
-        info "v1.5.0 mode-switch: single-adapter → dual-adapter (2g=${mac_2g}, 5g=${mac_5g})"
+    if [[ "$enable_state_wrong" == "1" ]]; then
+        info "v1.5.0 unit topology → dual-adapter (2g=${mac_2g}, 5g=${mac_5g})"
         systemctl stop droneaware-wifi 2>/dev/null || true
         systemctl disable droneaware-wifi 2>/dev/null || true
         systemctl enable droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
-        _service_start_suppressed \
-            || systemctl start droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
-    elif [[ "$wrong_unit_active" == "1" ]]; then
-        info "v1.5.0.1 self-heal: droneaware-wifi is active but dual-adapter mode is desired — switching"
+    fi
+
+    # One place decides whether the feeders need (re)starting, so the log
+    # never claims an action that suppression skipped. `restart` covers
+    # both cases — it starts a stopped unit.
+    if [[ "$enable_state_wrong" == "1" || "$wrong_unit_active" == "1" || "$macs_changed" == "1" ]]; then
         systemctl stop droneaware-wifi 2>/dev/null || true
-        _service_start_suppressed \
-            || systemctl start droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
-    elif [[ "$macs_changed" == "1" ]]; then
-        info "v1.5.0 dual-adapter MACs changed — restarting split units"
-        _service_start_suppressed \
-            || systemctl restart droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+        if _service_start_suppressed; then
+            info "v1.5.0.6: split units enabled — start deferred to reboot (install-time)"
+        else
+            systemctl restart droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+        fi
     fi
 }
 
@@ -849,10 +865,15 @@ _switch_to_single_adapter_mode() {
         _set_cfg_key "$cfg" WIFI_ADAPTER_5G_MAC ""
     fi
 
-    local mode_needs_enable_flip=0
+    # v1.5.0.6: enforce the enable-state for single mode, symmetric with
+    # the dual-mode path above — the desired end state is droneaware-wifi
+    # enabled and both split units disabled, regardless of whether a
+    # transition was observed.
+    local enable_state_wrong=0
     if systemctl is-enabled droneaware-wifi-2g.service >/dev/null 2>&1 \
-       || systemctl is-enabled droneaware-wifi-5g.service >/dev/null 2>&1; then
-        mode_needs_enable_flip=1
+       || systemctl is-enabled droneaware-wifi-5g.service >/dev/null 2>&1 \
+       || ! systemctl is-enabled droneaware-wifi.service >/dev/null 2>&1; then
+        enable_state_wrong=1
     fi
     # v1.5.0.1 self-heal symmetric to dual-mode: if a split unit is
     # currently active but single-adapter is desired, force the transition.
@@ -864,22 +885,20 @@ _switch_to_single_adapter_mode() {
     local mac_changed=0
     [[ "$prev_mac" != "$mac" ]] && mac_changed=1
 
-    if [[ "$mode_needs_enable_flip" == "1" ]]; then
-        info "v1.5.0 mode-switch: dual-adapter → single-adapter (${mac})"
+    if [[ "$enable_state_wrong" == "1" ]]; then
+        info "v1.5.0 unit topology → single-adapter (${mac})"
         systemctl stop droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
         systemctl disable droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
         systemctl enable droneaware-wifi 2>/dev/null || true
-        _service_start_suppressed \
-            || systemctl start droneaware-wifi 2>/dev/null || true
-    elif [[ "$wrong_unit_active" == "1" ]]; then
-        info "v1.5.0.1 self-heal: split unit(s) active but single-adapter mode is desired — switching"
+    fi
+
+    if [[ "$enable_state_wrong" == "1" || "$wrong_unit_active" == "1" || "$mac_changed" == "1" ]]; then
         systemctl stop droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
-        _service_start_suppressed \
-            || systemctl start droneaware-wifi 2>/dev/null || true
-    elif [[ "$mac_changed" == "1" ]]; then
-        info "v1.5.0 single-adapter MAC changed — restarting service"
-        _service_start_suppressed \
-            || systemctl restart droneaware-wifi 2>/dev/null || true
+        if _service_start_suppressed; then
+            info "v1.5.0.6: droneaware-wifi enabled — start deferred to reboot (install-time)"
+        else
+            systemctl restart droneaware-wifi 2>/dev/null || true
+        fi
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -525,9 +525,113 @@ EOF
 # ---------------------------------------------------------------------------
 # 6. System packages
 # ---------------------------------------------------------------------------
+# v1.5.0.6 — under-voltage pre-flight.
+#
+# A Pi running on a marginal PSU or a thin USB cable browns out under
+# load. apt is one of the heaviest things the installer does (sustained
+# SD writes plus CPU), so it is a common victim: the kernel kills it
+# mid-transaction and dpkg is left in an interrupted state. Every
+# subsequent apt call then fails until `dpkg --configure -a` is run, so
+# the install fails identically on every retry.
+#
+# `vcgencmd get_throttled` reports the PMIC's latched flags:
+#   0x1     under-voltage right now
+#   0x4     currently throttled
+#   0x10000 under-voltage has occurred since boot
+#   0x40000 throttling has occurred since boot
+# Throttling alone can be thermal, so only the under-voltage bits gate
+# the install; anything else is reported for information.
+#
+# Flags are latched since boot, so a freshly booted Pi that has not yet
+# drawn much current can still read 0x0 with an inadequate supply. This
+# catches the already-degraded case, which is the one that wedges dpkg.
+_check_undervoltage() {
+    command -v vcgencmd > /dev/null 2>&1 || return 0   # not a Pi, or vcgencmd absent
+
+    local raw bits
+    raw=$(vcgencmd get_throttled 2>/dev/null) || return 0
+    bits="${raw#throttled=}"
+    [[ "$bits" =~ ^0x[0-9a-fA-F]+$ ]] || return 0      # unexpected format — don't block
+    (( bits == 0 )) && return 0
+
+    if (( (bits & 0x1) == 0 && (bits & 0x10000) == 0 )); then
+        # Throttling without under-voltage — most likely thermal. Note it
+        # and continue; it does not put the package manager at risk.
+        warn "Pi reports throttling (${bits}) with no under-voltage — likely thermal. Continuing."
+        return 0
+    fi
+
+    echo ""
+    warn "POWER WARNING — this Pi has recorded under-voltage (${bits})."
+    echo ""
+    if (( (bits & 0x1) != 0 )); then
+        echo "    The supply is BELOW the safe threshold right now."
+    else
+        echo "    The supply dropped below the safe threshold earlier this boot."
+    fi
+    echo ""
+    echo "  Installing packages on an under-volted Pi can get apt killed"
+    echo "  mid-transaction, which leaves dpkg broken and makes every later"
+    echo "  install attempt fail. It can also drop USB WiFi adapters and"
+    echo "  your SSH session."
+    echo ""
+    echo "  Recommended before continuing:"
+    echo "    • Use the official Raspberry Pi PSU (15W USB-C / 12.5W micro-USB)"
+    echo "    • Use a short, thick power cable — thin cables lose voltage"
+    echo "    • Put external USB WiFi adapters on a POWERED USB hub"
+    echo ""
+    read -rp "  Continue anyway? [y/N]: " PWR_ACK </dev/tty
+    if [[ ! "${PWR_ACK,,}" =~ ^y(es)?$ ]]; then
+        fatal "Installation cancelled. Re-run once the power supply is sorted."
+    fi
+    warn "Continuing on an under-volted Pi at operator request."
+}
+
 install_packages() {
     heading "Installing System Packages"
-    apt-get update -qq
+
+    # v1.5.0.6: check power before apt — see _check_undervoltage above.
+    _check_undervoltage
+
+    # v1.5.0.6: apt failures used to be invisible. Both apt calls sent
+    # stderr to /dev/null, and with `set -e` active (line 9) a non-zero
+    # exit aborted the script instantly. When the failure happened before
+    # pin_wifi_unmanaged ran, NM_TOUCHED was still 0, so the ERR trap
+    # printed nothing either — the installer simply stopped after the
+    # "Installing System Packages" heading with no message at all.
+    #
+    # The common real-world trigger is an interrupted dpkg transaction
+    # (power loss, SIGKILL, Ctrl-C during an earlier apt run). apt then
+    # refuses every subsequent operation until `dpkg --configure -a` is
+    # run, so the installer fails identically on every retry and the
+    # operator has nothing to go on.
+    #
+    # Keep stdout quiet (progress bars are noise) but let stderr through,
+    # and handle failure explicitly with the remedy named.
+    _apt_failed() {
+        echo ""
+        warn "System package installation failed (see the apt error above)."
+        echo ""
+        echo "  Most common causes:"
+        echo "    • Interrupted dpkg transaction — fix with:"
+        echo "        sudo dpkg --configure -a"
+        echo "    • Another process holds the apt lock (unattended-upgrades"
+        echo "      runs automatically for a few minutes after first boot) —"
+        echo "      wait 5 minutes and re-run the installer"
+        echo "    • No internet route — check: ping -c3 deb.debian.org"
+        echo "    • Under-voltage killing apt mid-transaction — check:"
+        echo "        vcgencmd get_throttled     (0x0 is healthy)"
+        echo ""
+        # `fatal` exits directly, which does NOT fire the ERR trap, so the
+        # NetworkManager rollback the trap normally performs would be
+        # skipped. install_packages runs after pin_wifi_unmanaged, so
+        # NM_TOUCHED is already 1 by this point — roll back explicitly to
+        # preserve the pre-v1.5.0.6 failure behaviour.
+        _rollback_nm
+        fatal "Re-run this installer once the above is resolved."
+    }
+
+    apt-get update -qq || _apt_failed
     # gpsd-clients gives us `gpsctl` for the GPS protocol auto-fix
     # (SiRF/UBX → NMEA). --no-install-recommends is important: without it
     # apt pulls gpsd itself, which would seize the GPS port and prevent
@@ -535,9 +639,14 @@ install_packages() {
     # `gpsctl -f -n /dev/xxx` direct-to-device mode we use.
     apt-get install -y --no-install-recommends \
         bluez bluetooth iw rfkill curl gpsd-clients \
-        > /dev/null 2>&1
-    systemctl enable bluetooth > /dev/null 2>&1
-    systemctl start bluetooth  > /dev/null 2>&1
+        > /dev/null || _apt_failed
+    # Non-fatal: a node with no Bluetooth hardware can still run the WiFi
+    # feeder. Pre-v1.5.0.6 these were bare commands under `set -e`, so a
+    # masked or absent bluetooth unit aborted the whole install silently.
+    systemctl enable bluetooth > /dev/null 2>&1 \
+        || warn "Could not enable bluetooth.service — BLE feeder may not start."
+    systemctl start bluetooth  > /dev/null 2>&1 \
+        || warn "Could not start bluetooth.service — BLE feeder may not start."
 
     # Disable boot-delay services — reduces boot-to-SSH from ~15s to <5s
     systemctl disable cloud-init cloud-init-local cloud-init-main cloud-init-network > /dev/null 2>&1 || true
@@ -714,8 +823,15 @@ gps_sanity_check() {
 # ---------------------------------------------------------------------------
 download_binaries() {
     heading "Downloading DroneAware Binaries ($BINARY_VERSION)"
-    # Stop any running feeders so binaries aren't locked during download
-    systemctl stop droneaware-ble droneaware-wifi 2>/dev/null || true
+    # Stop any running feeders so binaries aren't locked during download.
+    # v1.5.0.6: include the dual-adapter split units. Re-running the
+    # installer on a node already in dual mode left droneaware-wifi-2g /
+    # -5g holding ${INSTALL_DIR}/wifi_feeder open, so the curl -o below
+    # failed with ETXTBSY. Because `set -e` is active and an ERR trap is
+    # installed, that aborted the install and rolled back NetworkManager
+    # mid-run.
+    systemctl stop droneaware-ble droneaware-wifi \
+        droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
     mkdir -p "$INSTALL_DIR" "$CLI_DIR"
 
     if [[ "$LOCAL_INSTALL" == "1" ]]; then
@@ -881,9 +997,24 @@ EOF
 # migrate is canonical; write_config only needs the minimum bootstrap.
 # Failure here is non-fatal — every release key has a code-side default.
 # ---------------------------------------------------------------------------
+#
+# v1.5.0.6: DRONEAWARE_NO_SERVICE_START=1 is set for this one call.
+# migrate_config_env runs _orchestrate_wifi_mode, which enables the
+# correct WiFi unit(s) for the detected adapter count AND — pre-v1.5.0.6
+# — started them immediately. That start happened here, at install.sh
+# line ~1222, while enroll_node (which writes /etc/droneaware/token) does
+# not run until the following step. So every fresh install briefly ran a
+# feeder with no credentials, crash-looping on Restart=always until the
+# operator rebooted.
+#
+# It also contradicted install.sh's own design: services are enabled at
+# install time and started by the reboot the summary asks for. The flag
+# restores that contract — orchestration still writes config keys and
+# sets enable/disable state, it just doesn't start anything. `refresh`
+# and `update` leave the flag unset and start units as before.
 migrate_config() {
     if [[ -x /usr/local/bin/droneaware ]]; then
-        if ! /usr/local/bin/droneaware __migrate; then
+        if ! DRONEAWARE_NO_SERVICE_START=1 /usr/local/bin/droneaware __migrate; then
             warn "Release config migration encountered issues — install continues. Run 'sudo droneaware __migrate' to retry."
         fi
     else

--- a/install.sh
+++ b/install.sh
@@ -1237,10 +1237,26 @@ install_webui() {
     local local_root
     local_root="$(dirname "${LOCAL_DIST}")"
 
-    echo "    Downloading web_ui binary..."
+    # v1.5.0.6: stop droneaware-web before replacing its binary. A running
+    # web_ui holds ${INSTALL_DIR}/web_ui as its text image, so writing over
+    # it fails with ETXTBSY ("Text file busy"). download_binaries stops the
+    # feeders but never this unit, and cmd_update's equivalent stop was
+    # never mirrored here — so re-running the installer on a node with the
+    # Web UI already installed always failed to update the binary.
+    systemctl stop droneaware-web 2>/dev/null || true
+
+    echo "    Installing web_ui binary..."
     if [[ "$LOCAL_INSTALL" == "1" ]]; then
-        cp "${LOCAL_DIST}/web_ui" "${INSTALL_DIR}/web_ui" 2>/dev/null \
-            || { warn "Web UI binary not found in local dist — skipping Web UI install."; return 0; }
+        # v1.5.0.6: do not discard the error. This previously used
+        # `2>/dev/null` and reported "not found in local dist" for ANY
+        # failure — including ETXTBSY, which is what actually happened,
+        # sending the operator looking for a missing file that was present
+        # the whole time.
+        if ! cp "${LOCAL_DIST}/web_ui" "${INSTALL_DIR}/web_ui"; then
+            warn "Could not install web_ui from ${LOCAL_DIST} (see error above) — skipping Web UI install."
+            warn "You can retry later with: sudo droneaware install-webui"
+            return 0
+        fi
     else
         if ! curl -fsSL --retry 3 "${base_url}/web_ui" -o "${INSTALL_DIR}/web_ui"; then
             warn "Web UI binary download failed — skipping Web UI install."

--- a/tools/validate-1506.sh
+++ b/tools/validate-1506.sh
@@ -148,11 +148,27 @@ stage_d() {
         bad "binary overwrite succeeds" "cp succeeds" "cp failed (ETXTBSY?)"
     fi
     rm -f /tmp/_wf_check
-    echo ""
-    note "restoring services..."
-    droneaware refresh > /dev/null 2>&1 || true
+
+    banner "refresh must bring the stopped feeders back"
+    echo "  A correctly-configured but stopped feeder is the most common"
+    echo "  reason an operator runs refresh. Before v1.5.0.6 nothing in the"
+    echo "  restart decision looked at whether the units were RUNNING, so"
+    echo "  refresh reported success and left them down."
+    droneaware refresh 2>&1 | sed 's/^/  /'
     systemctl start droneaware-ble 2>/dev/null || true
-    sleep 3
+    sleep 5
+
+    local m2 m5
+    m2=$(cfg WIFI_ADAPTER_2G_MAC); m5=$(cfg WIFI_ADAPTER_5G_MAC)
+    if [[ -n "$m2" && -n "$m5" ]]; then
+        want "droneaware-wifi-2g back up" "$(act droneaware-wifi-2g)" "active"
+        want "droneaware-wifi-5g back up" "$(act droneaware-wifi-5g)" "active"
+    else
+        want "droneaware-wifi back up" "$(act droneaware-wifi)" "active"
+    fi
+    want "droneaware-ble back up" "$(act droneaware-ble)" "active"
+
+    banner "final state"
     droneaware status 2>&1 | sed 's/^/  /'
 }
 

--- a/tools/validate-1506.sh
+++ b/tools/validate-1506.sh
@@ -172,13 +172,176 @@ stage_d() {
     droneaware status 2>&1 | sed 's/^/  /'
 }
 
+# Generic state check for adapter-permutation testing.
+#
+# Derives the EXPECTED mode from the hardware independently of the CLI's
+# own classifier — reimplementing the documented rules against `iw` — so
+# that a classifier bug cannot hide from its own test. Run after any
+# plug/unplug followed by `sudo droneaware refresh`.
+stage_check() {
+    banner "STATE CHECK — expectation derived independently from iw"
+    python3 - <<'PY'
+import glob, os, re, subprocess, sys
+
+IW = "/usr/sbin/iw" if os.path.exists("/usr/sbin/iw") else "iw"
+CFG = "/opt/droneaware/config.env"
+
+def read(p):
+    try: return open(p).read().strip()
+    except OSError: return None
+
+def link(p):
+    try: return os.path.basename(os.readlink(p))
+    except OSError: return None
+
+def cfg(key):
+    try:
+        for line in open(CFG):
+            if line.startswith(key + "="):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return ""
+
+def sysd(verb, unit):
+    r = subprocess.run(["systemctl", verb, unit], capture_output=True, text=True)
+    return r.stdout.strip()
+
+adapters = []
+for path in sorted(glob.glob("/sys/class/net/wlan*")):
+    a = {"iface": os.path.basename(path),
+         "mac": (read(f"{path}/address") or "?").lower(),
+         "driver": link(f"{path}/device/driver") or "?",
+         "bus": link(f"{path}/device/subsystem") or "?",
+         "bands": [], "monitor": False}
+    phy = read(f"{path}/phy80211/name")
+    if phy:
+        try:
+            out = subprocess.run([IW, "phy", phy, "info"], capture_output=True,
+                                 text=True, timeout=8).stdout
+            b = set()
+            for line in out.splitlines():
+                m = re.search(r"\*\s+(\d{4})\.\d+\s+MHz\s+\[\d+\]", line)
+                if m:
+                    f = int(m.group(1))
+                    if 2400 <= f <= 2500: b.add("2.4")
+                    elif 5000 <= f <= 6000: b.add("5")
+            a["bands"] = sorted(b)
+            a["monitor"] = bool(re.search(r"^\s*\*\s+monitor$", out, re.M))
+        except Exception:
+            pass
+    a["onboard"] = a["driver"] == "brcmfmac" or a["bus"] in ("sdio", "mmc")
+    adapters.append(a)
+
+print("  Adapters seen:")
+for a in adapters:
+    kind = "ONBOARD (never monitor)" if a["onboard"] else (
+        "usb-monitor" if a["bus"] == "usb" and a["monitor"] else "usb (no monitor)")
+    print(f"    {a['iface']:<7} {a['mac']}  bands={','.join(a['bands']) or '?':<8} {kind}")
+
+monitor = sorted([a for a in adapters if not a["onboard"]
+                  and a["bus"] == "usb" and a["monitor"]], key=lambda a: a["mac"])
+
+r24 = r5 = None
+if len(monitor) == 1:
+    only = monitor[0]
+    if "2.4" in only["bands"]: r24 = only
+    if "5" in only["bands"]:   r5 = only
+elif len(monitor) >= 2:
+    fiveg = [a for a in monitor if "5" in a["bands"]]
+    twofour_only = [a for a in monitor if "2.4" in a["bands"] and "5" not in a["bands"]]
+    if fiveg and twofour_only:
+        r5, r24 = fiveg[0], twofour_only[0]
+    elif fiveg:
+        r5 = fiveg[0]
+        r24 = next((a for a in monitor if a is not r5 and "2.4" in a["bands"]), None)
+    else:
+        r24 = next((a for a in monitor if "2.4" in a["bands"]), None)
+
+dual = len(monitor) >= 2 and r24 and r5
+mode = "dual" if dual else ("single" if monitor else "none")
+print(f"\n  Monitor-capable USB adapters: {len(monitor)}   -> EXPECTED MODE: {mode}")
+if dual:
+    print(f"    expect 2G role = {r24['mac']} ({r24['iface']}, bands={','.join(r24['bands'])})")
+    print(f"    expect 5G role = {r5['mac']} ({r5['iface']}, bands={','.join(r5['bands'])})")
+elif monitor:
+    single = r24 or r5
+    print(f"    expect single  = {single['mac']} ({single['iface']}, bands={','.join(single['bands'])})")
+    if single["bands"] == ["2.4"]:
+        print("    expect dashboard: 2.4 GHz lock / 5 GHz ABSENT")
+    elif "2.4" in single["bands"] and "5" in single["bands"]:
+        print("    expect dashboard: 2.4 GHz dwell / 5 GHz dwell")
+if dual:
+    print("    expect dashboard: 2.4 GHz lock / 5 GHz lock")
+
+if len(monitor) >= 2 and not dual:
+    print("\n  NOTE: 2+ monitor adapters but roles did not both resolve"
+          " (e.g. no 5 GHz-capable card) -> falls back to SINGLE, second"
+          " adapter idle. Known gap, not a v1.5.0.6 regression.")
+
+P = F = 0
+def ck(label, got, want):
+    global P, F
+    if got == want:
+        print(f"  PASS  {label}"); P += 1
+    else:
+        print(f"  FAIL  {label}\n        expected: {want!r}\n        actual:   {got!r}"); F += 1
+
+print()
+if mode == "none":
+    print("  (no monitor-capable adapters — orchestration leaves state unchanged)")
+elif dual:
+    ck("WIFI_ADAPTER_2G_MAC matches 2G role", cfg("WIFI_ADAPTER_2G_MAC"), r24["mac"])
+    ck("WIFI_ADAPTER_5G_MAC matches 5G role", cfg("WIFI_ADAPTER_5G_MAC"), r5["mac"])
+    ck("droneaware-wifi-2g enabled", sysd("is-enabled", "droneaware-wifi-2g"), "enabled")
+    ck("droneaware-wifi-5g enabled", sysd("is-enabled", "droneaware-wifi-5g"), "enabled")
+    ck("droneaware-wifi disabled",   sysd("is-enabled", "droneaware-wifi"),    "disabled")
+    ck("droneaware-wifi-2g active",  sysd("is-active",  "droneaware-wifi-2g"), "active")
+    ck("droneaware-wifi-5g active",  sysd("is-active",  "droneaware-wifi-5g"), "active")
+    ck("droneaware-wifi inactive",   sysd("is-active",  "droneaware-wifi"),    "inactive")
+else:
+    single = r24 or r5
+    ck("WIFI_ADAPTER_2G_MAC cleared", cfg("WIFI_ADAPTER_2G_MAC"), "")
+    ck("WIFI_ADAPTER_5G_MAC cleared", cfg("WIFI_ADAPTER_5G_MAC"), "")
+    ck("WIFI_ADAPTER_MAC matches adapter", cfg("WIFI_ADAPTER_MAC"), single["mac"])
+    ck("droneaware-wifi enabled",     sysd("is-enabled", "droneaware-wifi"),    "enabled")
+    ck("droneaware-wifi-2g disabled", sysd("is-enabled", "droneaware-wifi-2g"), "disabled")
+    ck("droneaware-wifi-5g disabled", sysd("is-enabled", "droneaware-wifi-5g"), "disabled")
+    ck("droneaware-wifi active",      sysd("is-active",  "droneaware-wifi"),    "active")
+    ck("droneaware-wifi-2g inactive", sysd("is-active",  "droneaware-wifi-2g"), "inactive")
+    ck("droneaware-wifi-5g inactive", sysd("is-active",  "droneaware-wifi-5g"), "inactive")
+
+# --- Bluetooth / UD100 -------------------------------------------------
+print("\n  Bluetooth:")
+hci = subprocess.run(["hciconfig"], capture_output=True, text=True).stdout
+for line in hci.splitlines():
+    if line.startswith("hci") or "BD Address" in line:
+        print("    " + line.strip())
+print(f"    config BLE_ADAPTER     = {cfg('BLE_ADAPTER')!r}")
+print(f"    config BLE_ADAPTER_MAC = {cfg('BLE_ADAPTER_MAC')!r}")
+ck("droneaware-ble active", sysd("is-active", "droneaware-ble"), "active")
+print("\n  NOTE: `refresh` does NOT re-run droneaware-bt-select, so plugging"
+      "\n  or removing a BT dongle needs a reboot (or: systemctl restart"
+      "\n  droneaware-bt-select && systemctl restart droneaware-ble).")
+
+print(f"\n  checks: PASS={P} FAIL={F}")
+sys.exit(1 if F else 0)
+PY
+    local rc=$?
+    if [[ $rc -eq 0 ]]; then ok "state matches hardware"; else bad "state matches hardware" "all checks pass" "see FAILs above"; fi
+}
+
 case "${1:-}" in
+    check) show_context; stage_check ;;
     a1) show_context; stage_a1 ;;
     a2) show_context; stage_a2 ;;
     b)  show_context; stage_b  ;;
     c)  show_context; stage_c  ;;
     d)  show_context; stage_d  ;;
-    *)  echo "usage: sudo bash $0 {a1|a2|b|c|d}"; exit 2 ;;
+    *)  echo "usage: sudo bash $0 {check|a1|a2|b|c|d}"
+        echo "  check   verify state against hardware (use after any plug/unplug + refresh)"
+        echo "  a1..d   install-flow stages"
+        exit 2 ;;
 esac
 
 echo ""

--- a/tools/validate-1506.sh
+++ b/tools/validate-1506.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# v1.5.0.6 hardware validation harness.
+#
+# Dev tooling, not shipped as a release asset. Run each stage on the test
+# node and paste the output back.
+#
+#   sudo bash validate-1506.sh a1     # fresh dual install, BEFORE reboot
+#   sudo bash validate-1506.sh a2     # after reboot
+#   sudo bash validate-1506.sh b      # after unplugging ONE adapter + refresh
+#   sudo bash validate-1506.sh c      # after replugging + refresh
+#   sudo bash validate-1506.sh d      # ETXTBSY / stop-list check (restarts feeders)
+#
+# Every check prints PASS or FAIL with what was expected, so a failure
+# says which defect regressed rather than just "something is wrong".
+
+set -uo pipefail
+
+CFG=/opt/droneaware/config.env
+SYSD=/etc/systemd/system
+PASS=0; FAIL=0
+
+ok()   { echo "  PASS  $1"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL  $1"; echo "        expected: $2"; echo "        actual:   $3"; FAIL=$((FAIL+1)); }
+note() { echo "  ....  $1"; }
+
+cfg()  { grep -E "^$1=" "$CFG" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '"'"'"' '; }
+act()  { systemctl is-active "$1" 2>/dev/null; }
+ena()  { systemctl is-enabled "$1" 2>/dev/null; }
+
+want() { # want <label> <actual> <expected>
+    [[ "$2" == "$3" ]] && ok "$1" || bad "$1" "$3" "${2:-<empty>}"
+}
+want_empty() {
+    [[ -z "$2" ]] && ok "$1" || bad "$1" "<empty>" "$2"
+}
+want_nonempty() {
+    [[ -n "$2" ]] && ok "$1" || bad "$1" "<non-empty>" "<empty>"
+}
+
+banner() { echo ""; echo "=== $* ==="; }
+
+show_context() {
+    banner "context"
+    note "version   : $(cat /opt/droneaware/version 2>/dev/null || echo '<none>')"
+    note "throttled : $(vcgencmd get_throttled 2>/dev/null || echo '<n/a>')"
+    note "adapters  : $(iw dev 2>/dev/null | awk '$1=="Interface"{printf "%s ", $2}')"
+    note "2G key    : '$(cfg WIFI_ADAPTER_2G_MAC)'"
+    note "5G key    : '$(cfg WIFI_ADAPTER_5G_MAC)'"
+    note "single key: '$(cfg WIFI_ADAPTER_MAC)'"
+    for u in droneaware-wifi droneaware-wifi-2g droneaware-wifi-5g droneaware-ble; do
+        note "$u: active=$(act $u) enabled=$(ena $u)"
+    done
+}
+
+unit_files_present() {
+    banner "unit files on disk"
+    for f in droneaware-ble.service droneaware-bt-select.service \
+             droneaware-wifi.service droneaware-wifi-2g.service \
+             droneaware-wifi-5g.service; do
+        [[ -f "$SYSD/$f" ]] && ok "$f present" || bad "$f present" "file exists" "missing"
+    done
+}
+
+stage_a1() {
+    banner "STAGE A1 — fresh dual-adapter install, BEFORE reboot"
+    echo "Validates: item 4 (no pre-token service start), item 3 (install completed)"
+    unit_files_present
+
+    banner "enrollment ran"
+    [[ -s /etc/droneaware/token ]] && ok "token written" || bad "token written" "non-empty /etc/droneaware/token" "missing/empty"
+
+    banner "dual-adapter config"
+    want_nonempty "WIFI_ADAPTER_2G_MAC set" "$(cfg WIFI_ADAPTER_2G_MAC)"
+    want_nonempty "WIFI_ADAPTER_5G_MAC set" "$(cfg WIFI_ADAPTER_5G_MAC)"
+
+    banner "unit topology: dual enabled, single disabled"
+    want "droneaware-wifi-2g enabled" "$(ena droneaware-wifi-2g)" "enabled"
+    want "droneaware-wifi-5g enabled" "$(ena droneaware-wifi-5g)" "enabled"
+    [[ "$(ena droneaware-wifi)" == "enabled" ]] \
+        && bad "droneaware-wifi disabled" "disabled" "enabled" \
+        || ok "droneaware-wifi not enabled ($(ena droneaware-wifi))"
+
+    banner "ITEM 4 — feeders must NOT be running yet"
+    echo "  (they start on reboot; starting here means a credential-less feeder)"
+    want "droneaware-wifi-2g inactive" "$(act droneaware-wifi-2g)" "inactive"
+    want "droneaware-wifi-5g inactive" "$(act droneaware-wifi-5g)" "inactive"
+}
+
+stage_a2() {
+    banner "STAGE A2 — after reboot"
+    echo "Validates: both split feeders come up with a token present"
+    want "droneaware-wifi-2g active" "$(act droneaware-wifi-2g)" "active"
+    want "droneaware-wifi-5g active" "$(act droneaware-wifi-5g)" "active"
+    want "droneaware-wifi inactive"  "$(act droneaware-wifi)"    "inactive"
+    banner "droneaware status"
+    droneaware status 2>&1 | sed 's/^/  /'
+}
+
+stage_b() {
+    banner "STAGE B — dual -> single (one adapter unplugged + refresh)"
+    echo "Validates: item 1. THIS IS THE CASE THAT TOOK A NODE DARK."
+    echo "Pre-fix behaviour: band keys stayed set, the split units were"
+    echo "started over the single unit, and nothing ended up running."
+
+    banner "band keys must be CLEARED"
+    want_empty "WIFI_ADAPTER_2G_MAC cleared" "$(cfg WIFI_ADAPTER_2G_MAC)"
+    want_empty "WIFI_ADAPTER_5G_MAC cleared" "$(cfg WIFI_ADAPTER_5G_MAC)"
+    want_nonempty "WIFI_ADAPTER_MAC set"     "$(cfg WIFI_ADAPTER_MAC)"
+
+    banner "single-adapter feeder must be RUNNING (not dark)"
+    want "droneaware-wifi active"      "$(act droneaware-wifi)"    "active"
+    want "droneaware-wifi-2g inactive" "$(act droneaware-wifi-2g)" "inactive"
+    want "droneaware-wifi-5g inactive" "$(act droneaware-wifi-5g)" "inactive"
+
+    banner "status shows ONE wifi row"
+    droneaware status 2>&1 | sed 's/^/  /'
+    local rows
+    rows=$(droneaware status 2>/dev/null | grep -c "droneaware-wifi")
+    want "one wifi row in status" "$rows" "1"
+}
+
+stage_c() {
+    banner "STAGE C — single -> dual (adapter replugged + refresh)"
+    echo "Validates: the transition is reversible, keys repopulate"
+    want_nonempty "WIFI_ADAPTER_2G_MAC repopulated" "$(cfg WIFI_ADAPTER_2G_MAC)"
+    want_nonempty "WIFI_ADAPTER_5G_MAC repopulated" "$(cfg WIFI_ADAPTER_5G_MAC)"
+    want "droneaware-wifi-2g active" "$(act droneaware-wifi-2g)" "active"
+    want "droneaware-wifi-5g active" "$(act droneaware-wifi-5g)" "active"
+    want "droneaware-wifi inactive"  "$(act droneaware-wifi)"    "inactive"
+}
+
+stage_d() {
+    banner "STAGE D — ETXTBSY / stop-list (item 2)"
+    echo "Validates: the v1.5.0.6 stop list releases the binary so an"
+    echo "update can overwrite it. This STOPS and RESTARTS your feeders."
+    echo ""
+    systemctl stop droneaware-ble droneaware-wifi \
+        droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+    sleep 2
+    local holders
+    holders=$(fuser /opt/droneaware/wifi_feeder 2>/dev/null | tr -s ' ')
+    want_empty "no process holds wifi_feeder" "$holders"
+
+    if cp /opt/droneaware/wifi_feeder /tmp/_wf_check 2>/dev/null \
+       && cp /tmp/_wf_check /opt/droneaware/wifi_feeder 2>/dev/null; then
+        ok "binary overwrite succeeds (no ETXTBSY)"
+    else
+        bad "binary overwrite succeeds" "cp succeeds" "cp failed (ETXTBSY?)"
+    fi
+    rm -f /tmp/_wf_check
+    echo ""
+    note "restoring services..."
+    droneaware refresh > /dev/null 2>&1 || true
+    systemctl start droneaware-ble 2>/dev/null || true
+    sleep 3
+    droneaware status 2>&1 | sed 's/^/  /'
+}
+
+case "${1:-}" in
+    a1) show_context; stage_a1 ;;
+    a2) show_context; stage_a2 ;;
+    b)  show_context; stage_b  ;;
+    c)  show_context; stage_c  ;;
+    d)  show_context; stage_d  ;;
+    *)  echo "usage: sudo bash $0 {a1|a2|b|c|d}"; exit 2 ;;
+esac
+
+echo ""
+echo "======================================"
+echo "  STAGE ${1} RESULT:  PASS=$PASS  FAIL=$FAIL"
+echo "======================================"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
Five defects found in a code audit of the v1.5.0.x line, after operator reports of failed installs and nodes that had stopped scanning. All are pre-existing in v1.5.0–v1.5.0.5.

## 1. Nodes could end an update with no WiFi feeder running

`_switch_to_single_adapter_mode` wrote `WIFI_ADAPTER_MAC` but never cleared `WIFI_ADAPTER_2G_MAC` / `WIFI_ADAPTER_5G_MAC`. Those keys are how every other path decides whether the node is dual, so a node that had once had two adapters and later resolved to one stayed latched in dual mode:

1. `_orchestrate_wifi_mode` correctly selects single, disables the split units, starts `droneaware-wifi`
2. `_start_wifi_services_for_current_mode` (end of `cmd_update`) re-reads the stale keys, takes the dual branch, stops `droneaware-wifi` and starts the split units — just disabled, and on pre-v1.5.0.4 nodes never installed
3. update finishes with nothing running; every later `refresh` repeats it

`cmd_status` read the same stale keys, so affected nodes also showed two split rows instead of one.

**Fix:** clear the band keys on single-mode switch (writes only when a stale value is present, so it is a no-op on single-adapter nodes), and refuse the dual branch in `_start_wifi_services_for_current_mode` when the split unit files are absent — warn and start the single feeder instead of leaving the node dark.

## 2. The installer could fail silently

`install_packages` sent both apt calls to `/dev/null 2>&1`. Under `set -e` a failure aborted instantly, and when it happened before `NM_TOUCHED` was set the `ERR` trap printed nothing either — the script stopped after the heading with no message. The usual trigger is an interrupted `dpkg` transaction, which then fails identically on every retry with no diagnostic.

**Fix:** stop discarding apt stderr; explicit failure handler naming likely causes and the exact remediation for each; handler calls `_rollback_nm` directly because `fatal` exits without firing the `ERR` trap. `systemctl enable/start bluetooth` are warnings now rather than aborts.

## 3. Fresh installs started feeders before enrollment

`migrate_config` runs `__migrate`, which started the WiFi unit(s) immediately, while `enroll_node` writes `/etc/droneaware/token` only in the following step. Every fresh install briefly ran a credential-less feeder crash-looping on `Restart=always`, and it contradicted install.sh's own contract of enabling at install time and starting on reboot.

**Fix:** `DRONEAWARE_NO_SERVICE_START=1` on that one `__migrate` call. Orchestration still writes config and sets enable/disable state; it just doesn't start. `refresh` and `update` unaffected.

## 4. Binaries could be overwritten while in use

Both `install.sh` and `cmd_update` stopped only `droneaware-ble` and `droneaware-wifi` before replacing `/opt/droneaware/wifi_feeder`. On a dual node the split feeders still held that inode — `ETXTBSY` or a truncated binary, and in install.sh an ERR-trap NM rollback mid-install. Both stop lists now include the split units.

## 5. install-webui dropped dual nodes to one band

`cmd_install_webui` ended with a hardcoded `systemctl restart droneaware-wifi`, tripping the split units' `Conflicts=` clause. Same class v1.5.0.1 fixed in `cmd_update`; this path was missed. Now mode-aware.

## Added: under-voltage pre-flight

`install.sh` reads `vcgencmd get_throttled` before apt — a browning-out Pi is what kills apt mid-transaction and wedges dpkg in the first place. Only the under-voltage bits (`0x1`, `0x10000`) gate the install, since throttling alone may be thermal. Silent on `0x0`; skipped where `vcgencmd` is unavailable.

## Validation so far

`bash -n` and `shellcheck -S warning` clean on both files. The changed helpers were extracted and exercised directly — 22 assertions, all passing:

- band-key clearing: stale keys cleared, single MAC and unrelated keys preserved, no line-count drift, byte-identical no-op on a node that never had band keys, mode re-derivation correct before and after
- start-suppression flag: unset → starts, `1` → suppressed, `0` → starts
- under-voltage decoding across `0x0`, `0x1`, `0x4`, `0x10000`, `0x40000`, `0x50000`, `0x60000`, `0x80008`, `0xF000F`, and an unparseable value (must not block the install)