### PR TITLE
Fix Wi-Fi band detection for integer MHz output

### DIFF
--- a/droneaware
+++ b/droneaware
@@ -588,7 +588,7 @@ def _link(p):
 def _bands(info):
     b = set()
     for line in info.splitlines():
-        m = re.search(r"\*\s+(\d{4})\.\d+\s+MHz\s+\[\d+\]", line)
+        m = re.search(r"\*\s+(\d{4})(?:\.\d+)?\s+MHz\s+\[\d+\]", line)
         if m:
             f = int(m.group(1))
             if 2400 <= f <= 2500: b.add("2.4")

--- a/tests/test_wifi_band_parser.py
+++ b/tests/test_wifi_band_parser.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Regression coverage for iw frequency formats used by Wi-Fi classifiers."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PARSER_FILES = (
+    ROOT / "wifi_feeder.py",
+    ROOT / "droneaware",
+    ROOT / "tools" / "validate-1506.sh",
+)
+PATTERN_LITERAL = re.compile(r're\.search\(r"([^"]*MHz[^"]*)", line\)')
+
+
+class WifiBandParserTests(unittest.TestCase):
+    def test_all_classifiers_accept_integer_and_decimal_mhz(self) -> None:
+        integer_lines = ("* 2412 MHz [1]", "* 5180 MHz [36]")
+        decimal_lines = ("* 2412.0 MHz [1]", "* 5180.0 MHz [36]")
+
+        for path in PARSER_FILES:
+            source = path.read_text(encoding="utf-8")
+            patterns = PATTERN_LITERAL.findall(source)
+            self.assertEqual(
+                len(patterns),
+                1,
+                f"expected one Wi-Fi band parser pattern in {path.relative_to(ROOT)}",
+            )
+            parser = re.compile(patterns[0])
+            for line in integer_lines + decimal_lines:
+                with self.subTest(path=path.name, line=line):
+                    self.assertIsNotNone(parser.search(line))
+
+    def test_classifiers_reject_unrelated_frequency_text(self) -> None:
+        for path in PARSER_FILES:
+            source = path.read_text(encoding="utf-8")
+            parser = re.compile(PATTERN_LITERAL.findall(source)[0])
+            for line in ("2412 MHz", "* 2412 MHz", "* 2412 MHz channel 1"):
+                with self.subTest(path=path.name, line=line):
+                    self.assertIsNone(parser.search(line))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate-1506.sh
+++ b/tools/validate-1506.sh
@@ -221,7 +221,7 @@ for path in sorted(glob.glob("/sys/class/net/wlan*")):
                                  text=True, timeout=8).stdout
             b = set()
             for line in out.splitlines():
-                m = re.search(r"\*\s+(\d{4})\.\d+\s+MHz\s+\[\d+\]", line)
+                m = re.search(r"\*\s+(\d{4})(?:\.\d+)?\s+MHz\s+\[\d+\]", line)
                 if m:
                     f = int(m.group(1))
                     if 2400 <= f <= 2500: b.add("2.4")

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -636,10 +636,11 @@ def _wclassifier_readlink_base(path: str) -> str | None:
 
 def _wclassifier_parse_bands(iw_info: str) -> list:
     """Parse `iw phy info` output for supported bands (2.4 / 5) via
-    frequency list. Frequencies appear as '* 2412.0 MHz [1] (...)' lines."""
+    frequency list. Depending on the iw/kernel version, frequencies appear
+    as either '* 2412 MHz [1] (...)' or '* 2412.0 MHz [1] (...)' lines."""
     bands = set()
     for line in iw_info.splitlines():
-        m = re.search(r"\*\s+(\d{4})\.\d+\s+MHz\s+\[\d+\]", line)
+        m = re.search(r"\*\s+(\d{4})(?:\.\d+)?\s+MHz\s+\[\d+\]", line)
         if not m:
             continue
         freq = int(m.group(1))


### PR DESCRIPTION
## Summary

- accept both integer and decimal MHz values from `iw phy ... info`
- apply the same parser fix in `wifi_feeder.py`, the `droneaware` CLI, and the independent validation harness
- add regression coverage for 2.4 GHz, 5 GHz, and malformed lines

Some `iw` builds report frequencies as `2412 MHz` while the current regular expression requires `2412.0 MHz`. The adapter can still capture both bands, but the classifier reports them absent. Making only the decimal suffix optional preserves the existing range checks and avoids broadening the accepted format further.

## Validation

- `python3 -m unittest discover -s tests -v`
- Python compilation of the new test
- shell syntax checks for the modified CLI and validation harness
- `git diff --check`
