### PR TITLE
v1.5.0.7: local reporting accuracy and bounded resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,87 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.0.7] — Unreleased
+
+Local reporting accuracy and bounded resources. Every surface on the node
+now reads health from the feeder that owns it, rather than inferring health
+from whether a process happens to be alive.
+
+### The offline UI could report BLE as down on a healthy node
+
+The web UI decided BLE health by running `systemctl is-active
+droneaware-ble` and treating any exception as "BLE down". It runs as an
+unprivileged user, so anything that made that subprocess fail became a red
+BLE row on a node that was scanning normally — reported by two operators
+whose CLI, server dashboard, and detection stream all disagreed with their
+own local UI.
+
+The deeper problem is that systemd only knows whether a process is alive.
+A feeder whose adapter has failed keeps running its FAULT loop, so
+`is-active` reports "active" indefinitely and the UI rendered green while
+the radio was dead.
+
+`ble_feeder` now publishes `/run/droneaware/ble_state.json` on the same
+pattern the WiFi feeder already uses for its per-band files: atomic
+replace, tmpfs so there is no SD card wear, an `updated_at` stamp for
+staleness, and non-fatal on error. It is written from the FAULT loop as
+well as the healthy heartbeat — a faulted feeder that writes nothing looks
+exactly like a healthy one — and before the token check in both, so nodes
+that have not enrolled still get a truthful local UI.
+
+The web UI reads that file and falls back to systemd only when it is
+absent, recording that the answer was inferred. If the fallback itself
+fails, the row is marked unknown and stale rather than shown as a
+confident colour it has not earned.
+
+### Faulted feeders showed green in `droneaware status`
+
+`status` reported systemd's view of each unit. A feeder whose adapter had
+been removed entered its FAULT loop and kept running, so the command showed
+green while the band was down — in one case for several days, while the
+server-side dashboard correctly showed the band as failed.
+
+`status` now reads each feeder's own state file and distinguishes a
+reported fault (red, with the feeder's own reason), a stale state file
+(amber — the feeder may be wedged), and healthy. A feeder that predates
+state files reports liveness only, as before, so a node midway through an
+upgrade is not shown as broken.
+
+### Distance rings were invisible on the light theme
+
+The offline map drew its range rings in a fixed cyan at low opacity for
+both themes, while the rest of the interface follows the active theme.
+Against the light basemap that is a contrast ratio of about 1.5:1 —
+effectively invisible, and reported by operators as being unable to see the
+rings at all.
+
+Ring colour and opacity now come from the active theme, giving roughly
+5.4:1 on the light theme, with a heavier stroke, a longer dash so the
+pattern reads as a line rather than dots, and larger semibold labels with a
+halo so they stay legible over both water and built-up areas.
+
+Because the map renders vector layers to a canvas, ring colours cannot be
+restyled by CSS the way the rest of the interface can. Switching themes
+previously left the rings drawn in the old theme's colour until something
+unrelated forced a redraw; theme changes now redraw them explicitly.
+
+### Feeder logs grew without bound
+
+Both feeders wrote to `/var/log/droneaware_*.log` through a handler that
+appends indefinitely and survives reboots, and nothing rotated them. On a
+long-running node this measured about 206 KB per day, dominated by routine
+heartbeat lines rather than detections — so growth continued at much the
+same rate whether or not the node was seeing traffic.
+
+Both now rotate with a hard 40 MB ceiling per feeder, roughly six months of
+history, overridable via `DRONEAWARE_LOG_MAX_BYTES`. No node in the field
+is near the cap; the ceiling matters for sustained bursts, where two log
+lines per detection could otherwise fill a small card in days.
+
+This is a rotation change only. The buffer that holds detections when the
+server is unreachable is separate, lives in memory, is bounded by its own
+setting, and is unaffected.
+
 ## [1.5.0.6] — Unreleased
 
 Installation and adapter-mode correctness. Five defects found in a code

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -990,6 +990,11 @@ class BLEFeeder:
                     f"[Heartbeat] FAULT — ble_ok=False  reason={reason}  "
                     f"temp={temp_str}  cpu={cpu_pct_str}  load={load_str}"
                 )
+                # Publish before the token check: a node without a token
+                # still has an offline UI, and that is exactly the operator
+                # who most needs to be told the radio is down.
+                self._write_ble_state(False, getattr(self, "adapter", None),
+                                      fault=reason)
                 if not self.token:
                     continue
                 requests.post(
@@ -1093,6 +1098,52 @@ class BLEFeeder:
             except (asyncio.CancelledError, Exception):
                 pass
 
+    def _write_ble_state(self, ble_ok: bool, adapter: str | None,
+                         fault: str | None = None):
+        """Publish BLE health to /run/droneaware/ble_state.json.
+
+        Mirrors the per-band state files wifi_feeder already writes, so
+        local surfaces can read feeder-authored health instead of inferring
+        it from systemd. Previously the offline UI shelled out to
+        `systemctl is-active droneaware-ble` and swallowed any failure as
+        "BLE down" — so it could report the radio as not scanning while the
+        CLI, the server, and the detection stream all showed it healthy.
+        systemd only knows whether the process is alive; it cannot know
+        whether the adapter is up.
+
+        Written from BOTH the healthy heartbeat and the FAULT loop. A
+        faulted feeder that writes nothing is indistinguishable from a
+        healthy one, and consumers would fall back to systemd — which
+        happily reports "active" for a process looping in FAULT. That is
+        precisely the failure this removes, so the FAULT path matters more
+        than the healthy one.
+
+        Lives on tmpfs: no SD card wear, gone on reboot. Non-fatal by
+        design — a failed write costs one refresh, never the feeder.
+        """
+        path = "/run/droneaware/ble_state.json"
+        try:
+            os.makedirs("/run/droneaware", exist_ok=True)
+            state = {
+                "feeder":     "ble",
+                "adapter":    adapter,
+                # BLE listens on all three advertising channels at once;
+                # "lock" is the closest scan_mode analogue to the WiFi rows.
+                "scan_mode":  "lock",
+                "ble_ok":     ble_ok,
+                "ble_fault":  fault,
+                "seen_total": getattr(self, "count", 0),
+                "sent_total": getattr(getattr(self, "forwarder", None),
+                                      "sent_total", 0),
+                "updated_at": time.time(),
+            }
+            tmp = path + ".tmp"
+            with open(tmp, "w") as f:
+                json.dump(state, f)
+            os.replace(tmp, path)          # atomic — readers never see a partial file
+        except Exception:
+            pass
+
     async def _heartbeat_loop(self):
         """v1.4.8: heartbeat runs here, in a dedicated asyncio task, so it
         cannot be starved by scanner-callback processing. Sends the same
@@ -1115,6 +1166,7 @@ class BLEFeeder:
                 cpu_pct         = get_cpu_percent()
                 load_1m, load_5m, load_15m = get_cpu_load()
                 ble_ok, ble_adp = get_ble_health(self.adapter)
+                self._write_ble_state(ble_ok, ble_adp)
                 temp_str    = f"{cpu_temp}°C" if cpu_temp is not None else "n/a"
                 cpu_pct_str = f"{cpu_pct:.1f}%" if cpu_pct is not None else "n/a"
                 load_str    = f"{load_1m:.2f}" if load_1m is not None else "n/a"

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -19,6 +19,7 @@ Requirements:
 import asyncio
 import json
 import logging
+import logging.handlers
 import argparse
 import time
 import socket
@@ -34,12 +35,24 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 
 # -- Logging -------------------------------------------------------------------
+# Hard ceiling on SD card usage. A plain FileHandler appends forever and
+# survives reboots, so a busy node grows this file without bound — and
+# continuous small writes are exactly what wears out SD cards, the same
+# concern that put the detection ring on tmpfs. Total footprint is the
+# active file plus LOG_BACKUPS rotations.
+LOG_MAX_BYTES = int(os.environ.get("DRONEAWARE_LOG_MAX_BYTES", 40_000_000))
+LOG_BACKUPS   = 3
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
         logging.StreamHandler(),
-        logging.FileHandler("/var/log/droneaware_ble.log"),
+        logging.handlers.RotatingFileHandler(
+            "/var/log/droneaware_ble.log",
+            maxBytes=LOG_MAX_BYTES // (LOG_BACKUPS + 1),
+            backupCount=LOG_BACKUPS,
+        ),
     ],
 )
 log = logging.getLogger("droneaware.ble")

--- a/droneaware
+++ b/droneaware
@@ -1279,6 +1279,55 @@ if candidates:
     echo ""
 }
 
+# v1.5.0.7: resolve a feeder's SELF-REPORTED health from its state file in
+# /run/droneaware/. systemd only knows whether the process is alive — a
+# feeder whose adapter vanished keeps looping in FAULT and stays "active"
+# indefinitely, which is how a node ran ~6 days with no 2.4 GHz coverage
+# while this command showed green.
+#
+# Echoes exactly one of:
+#   ok              feeder reports healthy and the file is fresh
+#   fault:<reason>  feeder reports itself unhealthy, with its own reason
+#   stale:<n>s      not refreshed in >180s (3 missed 60s heartbeats)
+#   unknown         no state file — a pre-v1.5.0.7 feeder, or one that has
+#                   not reached its first heartbeat yet. Callers MUST treat
+#                   this as "report liveness only", never as a fault, so a
+#                   node mid-upgrade is not shown as broken.
+_feeder_health() {
+    local svc="${1%.service}"
+    local files
+    case "$svc" in
+        droneaware-ble)     files="/run/droneaware/ble_state.json" ;;
+        droneaware-wifi-2g) files="/run/droneaware/wifi_state_2g.json" ;;
+        droneaware-wifi-5g) files="/run/droneaware/wifi_state_5g.json" ;;
+        # Single-adapter mode: one process emits BOTH band rows, so check
+        # both files and report the worst of the two.
+        droneaware-wifi)    files="/run/droneaware/wifi_state_2g.json /run/droneaware/wifi_state_5g.json" ;;
+        *)                  echo "unknown"; return 0 ;;
+    esac
+
+    python3 - "$files" <<'PY' 2>/dev/null || echo "unknown"
+import json, sys, time
+worst, seen = None, False
+for p in sys.argv[1].split():
+    try:
+        with open(p) as f:
+            s = json.load(f)
+    except Exception:
+        continue                       # missing/unreadable — treat as absent
+    seen = True
+    ok    = s.get("wifi_ok") if "wifi_ok" in s else s.get("ble_ok")
+    fault = s.get("wifi_fault") or s.get("ble_fault")
+    if not ok:                         # fault outranks stale
+        print("fault:%s" % (fault or "feeder reports not ok"))
+        sys.exit(0)
+    age = time.time() - (s.get("updated_at") or 0)
+    if age > 180:
+        worst = "stale:%ds" % int(age)
+print("unknown" if not seen else (worst or "ok"))
+PY
+}
+
 cmd_status() {
     require_root "status"
     echo ""
@@ -1316,7 +1365,27 @@ cmd_status() {
         local enabled
         enabled=$(systemctl is-enabled "$svc" 2>/dev/null)
         if [[ "$state" == "active" ]]; then
-            echo -e "  ${GREEN}●${NC}  ${svc}  (running)"
+            # v1.5.0.7: "active" is liveness, not health. A feeder whose
+            # adapter is gone enters its FAULT loop and keeps running, so
+            # systemd reports active forever — one node sat that way for
+            # ~6 days showing green here while the server correctly showed
+            # the band down. Read the feeder's own state file instead.
+            local health
+            health=$(_feeder_health "$svc")
+            case "$health" in
+                fault:*)
+                    echo -e "  ${RED}●${NC}  ${svc}  (running — FAULT: ${health#fault:})"
+                    ;;
+                stale:*)
+                    echo -e "  ${YELLOW}●${NC}  ${svc}  (running — state stale ${health#stale:}, feeder may be wedged)"
+                    ;;
+                *)
+                    # "ok", or "unknown" for a feeder that predates state
+                    # files. Unknown reports liveness only, as before —
+                    # that is honest rather than alarming mid-upgrade.
+                    echo -e "  ${GREEN}●${NC}  ${svc}  (running)"
+                    ;;
+            esac
         elif [[ "$enabled" == "not-found" ]]; then
             echo -e "  ${RED}●${NC}  ${svc}  (unit file missing — run 'sudo droneaware refresh')"
         else

--- a/web_static/index.html
+++ b/web_static/index.html
@@ -39,6 +39,12 @@
       --status-warn:   #FB923C;
       --status-error:  #F87171;
       --status-idle:   #64748B;
+      /* Distance rings. Canvas-rendered, so JS reads these tokens rather
+         than CSS styling the stroke directly — but they live here so both
+         themes are defined in one place. */
+      --ring:          #00E5FF;
+      --ring-opacity:  0.45;
+      --ring-label:    rgba(0, 229, 255, 0.85);
     }
     [data-theme="day"] {
       --bg-primary:    #F7FAFD;
@@ -50,6 +56,11 @@
       --text-dim:      #475569;
       --text-muted:    #94A3B8;
       --accent:        #0BA5D9;
+      /* Cyan is near-invisible on a white basemap — the day ring is a
+         darker, more saturated teal so it reads against light tiles. */
+      --ring:          #0E7490;
+      --ring-opacity:  0.60;
+      --ring-label:    #0E7490;
     }
 
     * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -438,13 +449,17 @@
     /* Distance-ring labels — small mile markers on each ring */
     .ring-label {
       font-family: ui-monospace, "SF Mono", "Cascadia Mono", monospace;
-      font-size: 9px;
-      color: rgba(0, 229, 255, 0.55);
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--ring-label);
       background: transparent;
       border: none;
       padding: 0 4px;
       pointer-events: none;
-      text-shadow: 0 0 2px var(--bg-primary);
+      white-space: nowrap;
+      /* Doubled halo — labels cross both water and built-up areas, so a
+         single 2px shadow washes out over darker map features. */
+      text-shadow: 0 0 3px var(--bg-primary), 0 0 2px var(--bg-primary);
     }
 
     /* ========== Status bar (28px bottom) ========== */
@@ -954,6 +969,11 @@
 
       state.tileLayer = L.tileLayer(url, opts).addTo(state.map);
 
+      // Rings are Canvas-painted, so a theme swap does not restyle them the
+      // way it does the CSS-driven chrome. Redraw so the stroke colour
+      // follows the new basemap instead of staying tuned to the old one.
+      if (state.home) drawHomeView(state.home);
+
       // Listen for tile load failures on the CartoDB layer — first
       // failure swaps us to the local bundle. Covers the case where
       // navigator.onLine reports true but the browser can't actually
@@ -1030,6 +1050,20 @@
     const KM_METERS = 1000;
     const RING_COUNT = 10;
 
+    // Distance-ring stroke for the active theme. The map uses
+    // preferCanvas:true, so ring strokes are painted to a <canvas> and CSS
+    // cannot restyle them — JS has to read the tokens and pass them to
+    // Leaflet. Falls back to the dark-theme values if a token is missing.
+    function ringStyle() {
+      const cs = getComputedStyle(document.documentElement);
+      const color = (cs.getPropertyValue("--ring") || "").trim();
+      const op    = parseFloat(cs.getPropertyValue("--ring-opacity"));
+      return {
+        color:   color || "#00E5FF",
+        opacity: Number.isFinite(op) ? op : 0.45,
+      };
+    }
+
     function drawHomeView(home) {
       if (!home || home.lat == null || home.lon == null) {
         // No home location available — leave map at continental-US default
@@ -1051,16 +1085,18 @@
 
       const stepMeters = state.units === "metric" ? KM_METERS : MILE_METERS;
       const unitLabel  = state.units === "metric" ? "km" : "mi";
+      const ring       = ringStyle();
 
-      // Concentric distance rings, dashed cyan.
+      // Concentric distance rings, dashed. Colour comes from the active
+      // theme's tokens — see ringStyle().
       for (let i = 1; i <= RING_COUNT; i++) {
         L.circle(center, {
           radius: i * stepMeters,
-          color: "#00E5FF",
-          weight: 1,
-          opacity: 0.22,
+          color: ring.color,
+          weight: 1.2,
+          opacity: ring.opacity,
           fillOpacity: 0,
-          dashArray: "4 4",
+          dashArray: "6 5",
           interactive: false,
         }).addTo(state.homeLayer);
 

--- a/web_ui.py
+++ b/web_ui.py
@@ -704,23 +704,49 @@ def _read_feeder_states() -> dict:
         except (OSError, ValueError, json.JSONDecodeError):
             pass
 
-    # BLE — placeholder until BLE feeder gets its own state file. Check
-    # systemd for a rough "is it running" signal.
+    # BLE — read feeder-authored state, exactly like the WiFi bands above.
+    # v1.5.0.7: ble_feeder now writes /run/droneaware/ble_state.json. This
+    # used to shell out to `systemctl is-active` unconditionally, which is
+    # liveness rather than health: a feeder looping in FAULT with a dead
+    # adapter is still "active", so the UI showed BLE green while the CLI
+    # and the server both correctly reported it down.
     try:
-        r = subprocess.run(
-            ["systemctl", "is-active", "droneaware-ble.service"],
-            capture_output=True, text=True, timeout=2,
-        )
-        active = r.stdout.strip() == "active"
-    except Exception:
-        active = False
-    out["ble"] = {
-        "feeder": "ble",
-        "iface": "hci0",   # conventional — actual adapter may vary
-        "scan_mode": "lock",  # BLE is always "listening on all channels" — closest to lock
-        "wifi_ok": active,  # borrowing the field name for uniform frontend rendering
-        "stale": False,
-    }
+        with open("/run/droneaware/ble_state.json") as f:
+            s = json.load(f)
+        age = time.time() - (s.get("updated_at") or 0)
+        s["age_sec"] = int(age)
+        s["stale"] = age > 180
+        # The frontend renders all three rows from one field name.
+        s["wifi_ok"] = bool(s.get("ble_ok"))
+        s["iface"] = s.get("adapter") or "hci0"
+        s["health_source"] = "feeder"
+        out["ble"] = s
+    except (OSError, ValueError, json.JSONDecodeError):
+        # No state file — either a pre-v1.5.0.7 ble_feeder, or one that has
+        # not reached its first heartbeat yet. Fall back to systemd, but do
+        # not present the result as health.
+        try:
+            r = subprocess.run(
+                ["systemctl", "is-active", "droneaware-ble.service"],
+                capture_output=True, text=True, timeout=2,
+            )
+            active = r.stdout.strip() == "active"
+            asked  = True
+        except Exception:
+            # Failing to ask is NOT a negative answer. The previous code
+            # swallowed any exception into active=False, so a systemctl
+            # that timed out or was refused under User=droneaware rendered
+            # as "BLE down" — reported by two operators.
+            active = False
+            asked  = False
+        out["ble"] = {
+            "feeder": "ble",
+            "iface": "hci0",      # conventional — actual adapter may vary
+            "scan_mode": "lock",  # BLE listens on all advertising channels
+            "wifi_ok": active,
+            "health_source": "systemd" if asked else "unknown",
+            "stale": not asked,   # unknown renders as stale, never as green
+        }
     return out
 
 

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -26,6 +26,7 @@ import struct
 import json
 import hashlib
 import logging
+import logging.handlers
 import argparse
 import socket
 import glob
@@ -37,12 +38,24 @@ import serial
 import requests
 
 # -- Logging -------------------------------------------------------------------
+# Hard ceiling on SD card usage. A plain FileHandler appends forever and
+# survives reboots, so a busy node grows this file without bound — and
+# continuous small writes are exactly what wears out SD cards, the same
+# concern that put the detection ring on tmpfs. Total footprint is the
+# active file plus LOG_BACKUPS rotations.
+LOG_MAX_BYTES = int(os.environ.get("DRONEAWARE_LOG_MAX_BYTES", 40_000_000))
+LOG_BACKUPS   = 3
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
     handlers=[
         logging.StreamHandler(),
-        logging.FileHandler("/var/log/droneaware_wifi.log"),
+        logging.handlers.RotatingFileHandler(
+            "/var/log/droneaware_wifi.log",
+            maxBytes=LOG_MAX_BYTES // (LOG_BACKUPS + 1),
+            backupCount=LOG_BACKUPS,
+        ),
     ],
 )
 log = logging.getLogger("droneaware.wifi")


### PR DESCRIPTION
Every surface on the node now reads health from the feeder that owns it,
rather than inferring health from whether a process happens to be alive.

### The offline UI could report BLE as down on a healthy node

`web_ui` decided BLE health by running `systemctl is-active` and treating
any exception as "BLE down". It runs unprivileged, so anything that made
that subprocess fail became a red BLE row on a node scanning normally.

systemd also only knows whether a process is alive — a feeder whose adapter
failed keeps running its FAULT loop, so `is-active` reports "active"
indefinitely and the UI rendered green while the radio was dead.

`ble_feeder` now publishes `/run/droneaware/ble_state.json` on the pattern
`wifi_feeder` already uses: atomic replace, tmpfs, `updated_at` for
staleness, non-fatal on error. Written from the FAULT loop as well as the
healthy heartbeat, and before the token check in both — a faulted feeder
that writes nothing is indistinguishable from a healthy one.

`web_ui` falls back to systemd only when the file is absent, recording that
the answer was inferred; if the fallback itself fails the row is marked
unknown and stale rather than shown as a confident colour.

### Faulted feeders showed green in `droneaware status`

`cmd_status` called `_feeder_health`, which was never written. Bash resolved
that to "command not found", the variable came back empty, and the `case`
fell through to its default arm — printing green. The partial change was
worse than none: it looked fixed, leaked stderr, and still misreported.

`_feeder_health` now maps a unit to its feeder's state file and returns
`ok` / `fault:<reason>` / `stale:<n>s` / `unknown`. Fault outranks stale.
Single-adapter mode checks both band files, since one process emits both
rows. Unknown reports liveness only, so a node mid-upgrade is not shown as
broken.

### Distance rings were invisible on the light theme

Rings were drawn in fixed cyan at low opacity for both themes — about
1.5:1 contrast against the light basemap. Colour and opacity now come from
the active theme (~5.4:1 on light), with a heavier stroke, longer dash, and
larger semibold labels with a halo.

The map renders vector layers to a canvas, so ring colours cannot be
restyled by CSS; theme changes now redraw them explicitly rather than
leaving them in the previous theme's colour.

### Feeder logs grew without bound

Both feeders appended indefinitely to `/var/log/droneaware_*.log` with
nothing rotating them — about 206 KB/day on a long-running node, dominated
by heartbeat lines rather than detections, so growth continued regardless
of traffic.

Both now rotate with a 40 MB ceiling per feeder (`DRONEAWARE_LOG_MAX_BYTES`),
roughly six months of history. Implemented as a handler rather than a
logrotate config, which would be a new release asset. The detection
store-and-forward buffer is separate, in memory, and unaffected.