### PR TITLE
v1.5.0.8: local reporting correctness, and radios that recover on their own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,63 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.0.8] — Unreleased
+
+Local reporting correctness, and radios that recover on their own.
+
+### A feeder stayed dark after its adapter came back
+
+Both feeders entered a degraded loop when their adapter was missing and
+never left it. Plugging a radio into a running node did nothing: one node
+sat in FAULT for six minutes with a working, driver-bound adapter attached,
+and only recovered because an unrelated update happened to restart the
+process. Without that restart it would have stayed dark indefinitely.
+
+Both feeders now re-check for their adapter once a minute while degraded and
+resume scanning when it returns, without a restart. The Bluetooth feeder
+also retries its standard recovery sequence each cycle, which auto-heals the
+onboard UART losing sync — a path that previously ran only once at startup.
+
+Where the adapter cannot be adopted automatically — a replacement card whose
+address is not yet in the node's configuration — the feeder now names the
+attached adapters and says to run `sudo droneaware refresh`, instead of
+repeating "adapter not present" indefinitely. It deliberately does not adopt
+an unconfigured adapter on its own: configuration has a single writer, and a
+feeder choosing its own radio would race the orchestrator and the other
+band's feeder.
+
+### Old Bluetooth detections reappeared as live after a restart
+
+The local web interface replays its detection history at startup. Wi-Fi
+detections kept their original capture time, but Bluetooth detections were
+re-stamped with the moment of replay — so after any restart the entire
+Bluetooth history rendered as current, never ageing out and never pruning,
+while Wi-Fi in the same view aged correctly.
+
+The two feeders were publishing the same timestamp field in different
+formats, and every consumer type-checked it. Both feeders now publish the
+same format, and the consumers accept either — necessary rather than
+belt-and-braces, since the history buffer survives the upgrade and keeps
+replaying older records afterwards.
+
+### A drone's displayed identity flipped between its two IDs
+
+An aircraft may broadcast more than one identifier at once — commonly a
+serial number alongside a registration. The interface merged them into a
+single field, so the displayed identity alternated depending on which
+arrived last. Measured against a live capture of one aircraft broadcasting
+both, the identity changed 749 times.
+
+Identity is now classified by the broadcast ID type, and the two are kept as
+separate values that never compete. Classification is by the declared type
+only, never by matching the shape of the string: registration formats vary
+by jurisdiction and cannot be enumerated.
+
+The interface also now says when a single hardware address is carrying more
+than one aircraft serial. Some manufacturers ship airframes on a shared
+address, and since detections are grouped by address, those aircraft appear
+as one track. Saying so is more honest than showing whichever arrived last.
+
 ## [1.5.0.7] — Unreleased
 
 Local reporting accuracy and bounded resources. Every surface on the node

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -981,16 +981,30 @@ class BLEFeeder:
                 pub_event["decoded"] = msg
                 self.publisher.publish(pub_event)
 
-    async def _fault_loop(self, reason: str):
+    async def _fault_loop(self, reason: str) -> bool:
         """
         Degraded loop entered when the BLE adapter is unhealthy or absent.
         Emits heartbeats with ble_ok=False so the server marks the radio as FAULT.
         Performs no BLE scanning. WiFi status (if measurable) is still reported.
+
+        v1.5.0.8: returns True once the adapter is healthy again, so the
+        caller can retry setup. Before this the loop never exited, so
+        swapping a Bluetooth dongle on a running node left BLE dark until
+        someone restarted the service — the same gap the WiFi feeder had.
         """
         log.warning(f"[FAULT] ble feeder running in degraded mode: {reason}")
         while True:
             try:
                 await asyncio.sleep(60)
+                # Re-check, and retry the standard recovery sequence: the
+                # common case is the onboard UART losing sync, which
+                # hciconfig down/up fixes without operator intervention.
+                healthy, _ = get_ble_health(self.adapter)
+                if not healthy:
+                    healthy = await _attempt_ble_recovery(self.adapter)
+                if healthy:
+                    log.warning("[RECOVERY] BLE adapter healthy again — leaving FAULT mode")
+                    return True
                 cpu_temp = get_cpu_temp()
                 cpu_pct  = get_cpu_percent()
                 load_1m, load_5m, load_15m = get_cpu_load()
@@ -1037,6 +1051,16 @@ class BLEFeeder:
                 log.warning(f"FAULT loop error: {e}")
 
     async def run(self):
+        """v1.5.0.8: retry wrapper, mirroring wifi_feeder.run().
+
+        `_run_once` returns False when the adapter recovered and setup should
+        be retried, True when finished. A loop rather than recursion: a
+        flapping adapter would otherwise add a stack frame per recovery.
+        """
+        while not await self._run_once():
+            log.info("[RECOVERY] restarting BLE scan setup with the recovered adapter")
+
+    async def _run_once(self) -> bool:
         log.info(f"DroneAware BLE Feeder - Node: {self.node_id}  Adapter: {self.adapter}")
         _check_cli_freshness()
 
@@ -1057,8 +1081,8 @@ class BLEFeeder:
             )
             log.error("WiFi detection (if available) is unaffected and continues independently.")
             log.error("To restore BLE: connect a working Bluetooth adapter and restart this service.")
-            await self._fault_loop("adapter not present (recovery attempted)")
-            return
+            # False tells run() to retry setup; True means finished for good.
+            return not await self._fault_loop("adapter not present (recovery attempted)")
 
         log.info(f"Scanning for Remote ID broadcasts (UUID 0xFFFA)...")
 
@@ -1108,6 +1132,10 @@ class BLEFeeder:
                 await heartbeat_task
             except (asyncio.CancelledError, Exception):
                 pass
+        # Scanning ended by shutdown, not by a recoverable adapter fault.
+        # Returning None here would read as falsy and restart setup in a
+        # tight loop — the same trap as on the WiFi side.
+        return True
 
     def _write_ble_state(self, ble_ok: bool, adapter: str | None,
                          fault: str | None = None):

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -935,6 +935,17 @@ class BLEFeeder:
         event = {
             "node_id":              self.node_id,
             "observed_at":          datetime.now(timezone.utc).isoformat(),
+            # v1.5.0.8: epoch float alongside the ISO string. LocalPublisher
+            # publishes `"t": event.get("timestamp") or event.get("observed_at")`
+            # — wifi_feeder sets "timestamp" so its `t` is a float, while this
+            # feeder set only "observed_at", so its `t` was an ISO string.
+            # Consumers type-check `t` for a number, so every BLE event failed
+            # the check and was re-stamped with ingest time: after any web_ui
+            # restart the whole replayed BLE history rendered as LIVE, never
+            # ageing and never pruning, while WiFi aged correctly. Setting this
+            # makes both feeders emit the same type. "observed_at" is retained
+            # unchanged for existing external consumers.
+            "timestamp":            time.time(),
             "observed_monotonic":   time.monotonic(),
             "radio":                "ble",
             "source_mac":           device.address,

--- a/web_static/index.html
+++ b/web_static/index.html
@@ -916,7 +916,7 @@
     }
     function isTestEvent(evt) {
       // cmd_test broadcasts use a recognizable ID prefix — adjust as needed
-      const id = (evt.id || "").toString().toUpperCase();
+      const id = (evt.serial_number || evt.faa_registration || evt.id || "").toString().toUpperCase();
       return id.startsWith("TEST-") || id.startsWith("DA-TEST") || (evt.mac || "").startsWith("00:00:00");
     }
 
@@ -1297,7 +1297,7 @@
         card.addEventListener("dblclick", () => openModal(mac));
         entry.card = card;
       }
-      const id = evt.id || evt.uas_id || mac;
+      const id = displayId(evt, mac);
 
       // Stats row: altitude · speed · node-id. Skip components that don't
       // have data so we don't render dangling '·' separators.
@@ -1418,9 +1418,34 @@
       return out;
     }
 
+    // ASTM permits one airframe to broadcast several ID types at once. A
+    // CTA-2063-A serial and a CAA registration commonly arrive interleaved
+    // from the same MAC — they are different facts about the same aircraft,
+    // not competing answers. Sharing one `id` field made the displayed
+    // identity flip to whichever Basic ID arrived last.
+    //
+    // Classify by id_type ONLY. Never infer from the string's shape: the
+    // server side has had two identity-flip incidents caused by regex
+    // classification, because registration formats vary by jurisdiction and
+    // cannot be enumerated. Types None / UTM Assigned / Session ID are
+    // dropped, matching server semantics.
+    const ID_TYPE_SERIAL = "Serial Number (ANSI/CTA-2063-A)";
+    const ID_TYPE_CAA    = "CAA Assigned";
+    function classifyIds(evt) {
+      if (!evt.id || !evt.id_type) return evt;
+      if (evt.id_type === ID_TYPE_SERIAL)        evt.serial_number = evt.id;
+      else if (evt.id_type === ID_TYPE_CAA)      evt.faa_registration = evt.id;
+      else { delete evt.id; delete evt.id_type; }
+      return evt;
+    }
+    function displayId(evt, mac) {
+      return evt.serial_number || evt.faa_registration || evt.id || evt.uas_id || mac;
+    }
+
     function handleEvent(evt) {
       const mac = evt.mac || evt.source_mac;
       if (!mac) return;
+      classifyIds(evt);
       // Use the broadcast timestamp (evt.t — when the feeder captured
       // the packet) for first_seen/last_seen, NOT Date.now(). Same
       // reason as the backend fix: replayed-at-startup events arrive
@@ -1448,6 +1473,14 @@
         // already know about — protects against out-of-order arrivals.
         if (eventTs > entry.last_seen) entry.last_seen = eventTs;
         if (eventTs < entry.first_seen) entry.first_seen = eventTs;
+      }
+      // Some manufacturers ship airframes on a fixed MAC, so one MAC can
+      // carry many distinct serials. Server-side keys on MAC alone, which
+      // collapses them into a single track — 34 airframes on one MAC has
+      // been observed in the fleet. Record what we see so the UI can say
+      // so rather than silently showing whichever arrived last.
+      if (evt.serial_number) {
+        (entry.serials || (entry.serials = new Set())).add(evt.serial_number);
       }
       updateMarker(mac);
       renderCard(mac);
@@ -1674,12 +1707,24 @@
       const entry = state.macs.get(mac);
       if (!entry) return "<div class='da-popup-inner'>—</div>";
       const evt = entry.event;
-      const id = evt.id || evt.uas_id || mac;
+      const id = displayId(evt, mac);
       const ageSec = (Date.now() / 1000) - entry.last_seen;
 
       // Make/model only shown when server-side enrichment has populated
       // these fields (item #9 in v1.4.0 punch list — not yet implemented).
       // Until then, the row is hidden so we don't show "Unknown · —".
+      // A MAC carrying more than one CTA-2063-A serial is a fixed-MAC fleet:
+      // several distinct airframes sharing one hardware address. The server
+      // keys on MAC alone, so they collapse into a single track. Say so
+      // rather than presenting the collapsed track as one confident aircraft.
+      const serialCount = entry.serials ? entry.serials.size : 0;
+      const multiSerialHTML = serialCount > 1 ? `
+        <div class="da-popup-row">
+          <span class="k">Note</span>
+          <span class="v">${serialCount} distinct serials on this MAC —
+            multiple aircraft may be shown as one</span>
+        </div>` : "";
+
       const hasMakeModel = evt.make || evt.model;
       const makeModelHTML = hasMakeModel ? `
         <div class="da-popup-makemodel">
@@ -1733,6 +1778,7 @@
             <div class="da-popup-specs-body">
               <span class="k">Radio</span><span class="v">${escapeHtml(radioTxt)}</span>
               <span class="k">Channel</span><span class="v">${evt.channel ?? "—"}</span>
+${multiSerialHTML}
               <span class="k">Msg type</span><span class="v">${escapeHtml(evt.type || "—")}</span>
               <span class="k">Heading</span><span class="v">${escapeHtml(headingTxt)}</span>
               <span class="k">Lat</span><span class="v">${(typeof evt.lat === "number") ? evt.lat.toFixed(6) : "—"}</span>

--- a/web_static/index.html
+++ b/web_static/index.html
@@ -1427,7 +1427,17 @@
       // via SSE near-instantly but their real broadcast time may be
       // much older. Using Date.now() here would make 10-hour-old
       // events look LIVE.
-      const eventTs = (typeof evt.t === "number") ? evt.t : (Date.now() / 1000);
+      // v1.5.0.8: accept both shapes. Pre-v1.5.0.8 ble_feeder sent `t` as an
+      // ISO-8601 string, which failed the number check and fell through to
+      // Date.now() — so replayed BLE events rendered as LIVE regardless of
+      // age, exactly what the note above says not to do. The ring survives
+      // upgrades, so string timestamps keep arriving after the feeder is fixed.
+      let eventTs = evt.t;
+      if (typeof eventTs === "string") {
+        const parsed = Date.parse(eventTs);
+        eventTs = Number.isNaN(parsed) ? null : parsed / 1000;
+      }
+      if (typeof eventTs !== "number") eventTs = Date.now() / 1000;
       let entry = state.macs.get(mac);
       if (!entry) {
         entry = { event: evt, first_seen: eventTs, last_seen: eventTs, marker: null, card: null };

--- a/web_ui.py
+++ b/web_ui.py
@@ -54,6 +54,7 @@ the feeders, the forwarder, or the wire format in any way.
 """
 import argparse
 import collections
+import datetime
 import json
 import logging
 import os
@@ -202,6 +203,18 @@ class DetectionStore:
         # current wall clock for events that somehow lack it (shouldn't
         # happen with LocalPublisher output, but defensive).
         ts = event.get("t")
+        if isinstance(ts, str):
+            # v1.5.0.8: pre-v1.5.0.8 ble_feeder emitted an ISO-8601 string
+            # here. This branch used to fall straight through to time.time(),
+            # so every replayed BLE event was stamped with ingest time — the
+            # exact "restarting web_ui made every old detection look LIVE"
+            # failure this method's docstring warns about, except it only ever
+            # hit BLE. Parse rather than discard: the tmpfs ring survives the
+            # upgrade, so ISO records keep replaying after the feeder is fixed.
+            try:
+                ts = datetime.datetime.fromisoformat(ts).timestamp()
+            except ValueError:
+                ts = None
         if not isinstance(ts, (int, float)):
             ts = time.time()
         with self._lock:

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -2450,6 +2450,23 @@ class WiFiFeeder:
             self.hopper.notify_detection(channel)
 
     def run(self):
+        """v1.5.0.8: retry wrapper around the capture setup.
+
+        Previously the feeder entered `_fault_loop` and stayed there for the
+        life of the process. Plugging an adapter into a running node did
+        nothing — one node sat in FAULT for six minutes with a working,
+        driver-bound radio attached, and only recovered because an unrelated
+        `update` happened to restart the process. Without that restart it
+        would have stayed dark indefinitely, which is the same silent-failure
+        class as reporting liveness instead of health.
+
+        `_run_once` returns False when the adapter came back and setup should
+        be retried; True when it is finished for good.
+        """
+        while not self._run_once():
+            log.info("[RECOVERY] re-running capture setup with the recovered adapter")
+
+    def _run_once(self) -> bool:
         log.info(f"DroneAware WiFi Feeder - Node: {self.node_id}")
         _check_cli_freshness()
         target = self.hopper.target_channels
@@ -2472,16 +2489,16 @@ class WiFiFeeder:
             )
             log.error("BLE detection (if available) is unaffected and continues independently.")
             log.error("To restore WiFi: connect a USB monitor-mode adapter and re-run the installer.")
-            self._fault_loop("adapter not present")
-            return
+            # Returns True once the adapter reappears, so setup is retried
+            # rather than the process sitting dark until someone restarts it.
+            return not self._fault_loop("adapter not present")
 
         try:
             set_monitor_mode(self.iface)
         except Exception as e:
             log.error(f"Could not put {self.iface} into monitor mode: {e}")
             log.error("Entering FAULT mode — adapter likely does not support monitor mode.")
-            self._fault_loop("monitor mode unsupported")
-            return
+            return not self._fault_loop("monitor mode unsupported")
 
         self.hopper.start()
 
@@ -2512,6 +2529,10 @@ class WiFiFeeder:
                 f"[Summary] Beacon RID={self.count}  NAN frames={self.nan_count}  "
                 f"sent={self.forwarder.sent_total}  failed={self.forwarder.failed_total}"
             )
+        # Capture ended by KeyboardInterrupt/shutdown, not by a recoverable
+        # adapter fault. Tell run() we are finished — returning None here
+        # would read as falsy and restart setup in a tight loop.
+        return True
 
     # ------------------------------------------------------------------
     # v1.5.0 heartbeat schema — feeder split (wifi_2g / wifi_5g / scan_mode)
@@ -2707,16 +2728,64 @@ class WiFiFeeder:
         except requests.RequestException as e:
             log.warning(f"Heartbeat failed (feeder={payload.get('feeder', 'wifi[legacy]')}): {e}")
 
-    def _fault_loop(self, reason: str):
+    def _try_recover_adapter(self) -> bool:
+        """v1.5.0.8: re-resolve the configured adapter from inside FAULT.
+
+        Returns True once it is present again, so the caller can retry setup.
+
+        Also reports the case this cannot fix on its own: our configured MAC
+        is absent while some OTHER monitor-capable USB adapter is attached.
+        That is what an operator swapping a dead card for a new one produces
+        — the new MAC is not in config.env, so only `droneaware refresh` can
+        adopt it. Saying so turns an indefinite silent FAULT into an
+        instruction. The feeder deliberately does NOT adopt it itself:
+        config.env has one writer, and a feeder that picks its own adapter
+        would race the orchestrator and the peer band's feeder.
+        """
+        try:
+            iface = resolve_monitor_iface(self.iface, band=self.band)
+        except Exception:
+            iface = None
+        if iface and os.path.exists(f"/sys/class/net/{iface}"):
+            if iface != self.iface:
+                log.warning(
+                    f"[RECOVERY] adapter now resolves to {iface} "
+                    f"(was {self.iface or 'none'})"
+                )
+            self.iface = iface
+            log.warning("[RECOVERY] configured adapter present again — leaving FAULT mode")
+            return True
+
+        try:
+            others = [a for a in wclassifier_enumerate()
+                      if a.get("classification") == "usb-monitor"]
+        except Exception:
+            others = []
+        if others:
+            macs = ", ".join(a.get("mac", "?") for a in others[:3])
+            log.error(
+                "[FAULT] configured adapter is absent, but monitor-capable "
+                f"adapter(s) are attached ({macs}). They are not in config.env — "
+                "run 'sudo droneaware refresh' to adopt them."
+            )
+        return False
+
+    def _fault_loop(self, reason: str) -> bool:
         """
         Degraded loop entered when no usable WiFi adapter is present.
         Emits heartbeats with wifi_ok=False so the server marks the radio as FAULT.
         Performs no monitor-mode setup, no packet capture, no event forwarding.
+
+        v1.5.0.8: returns True when the adapter reappears. Before this the
+        loop never exited, so plugging a radio into a running node did
+        nothing until someone restarted the process.
         """
         log.warning(f"[FAULT] wifi feeder running in degraded mode: {reason}")
         while True:
             try:
                 time.sleep(60)
+                if self._try_recover_adapter():
+                    return True
                 log.info(
                     f"[Heartbeat] FAULT — wifi_ok=False  reason={reason}  "
                     f"uptime={int(time.time() - self.start_time)}s"


### PR DESCRIPTION
### A feeder stayed dark after its adapter came back

Both feeders entered `_fault_loop` and never left it. Plugging a radio into
a running node did nothing — a node sat in FAULT for six minutes with a
working, driver-bound adapter attached, and recovered only because an
unrelated `update` restarted the process. Without that it would have stayed
dark indefinitely.

`run()` is now a retry wrapper around `_run_once()`, which returns False when
the adapter came back and setup should be retried. `_fault_loop` re-resolves
once per cycle and returns True on recovery. The BLE side additionally
retries `_attempt_ble_recovery` each cycle, auto-healing the onboard UART
sync issue — a path that previously ran only at startup.

Both normal paths return True explicitly. Falling off the end returns None,
which reads as falsy and restarts setup in a tight loop; that would be worse
than the bug being fixed. A loop is used rather than recursion, which would
add a stack frame per recovery on a flapping adapter.

Where the adapter cannot be adopted automatically — a replacement card whose
MAC is not in `config.env` — the feeder names the attached adapters and says
to run `refresh`, rather than repeating "adapter not present" forever. It
does not adopt an unconfigured adapter itself: `config.env` has one writer,
and a feeder choosing its own radio would race the orchestrator and the peer
band's feeder.

### Old BLE detections reappeared as live after a web_ui restart

`LocalPublisher` publishes `"t": event.get("timestamp") or event.get("observed_at")`.
`wifi_feeder` sets `timestamp` (a float); `ble_feeder` set only `observed_at`
(an ISO string), so the `or` fell through. Both consumers type-check `t` and
fall back to the current clock, so every replayed BLE event was stamped with
ingest time — the whole BLE history rendered LIVE after any restart, never
ageing and never pruning, while WiFi aged correctly.

`ble_feeder` now sets `timestamp` alongside the unchanged `observed_at`, and
both consumers parse either form — required, not defensive, since the tmpfs
ring survives the upgrade and keeps replaying string-stamped records.

Verified A/B against a live ring of 2,080 real ISO-stamped records: BLE age
17.9 min → 490.2 min, matching true capture time. WiFi unchanged.

### Displayed identity flipped between an aircraft's two IDs

ASTM permits several ID types at once; a CTA-2063-A serial interleaved with
a CAA registration is common. The UI merged both into one `id`, so identity
alternated. Measured against a live capture: 749 changes → 0.

Identity is now classified by `id_type` into `serial_number` and
`faa_registration`, which never compete. Classification is by `id_type`
only, never by regex on the string — registration formats vary by
jurisdiction and cannot be enumerated.

Also surfaces fixed-MAC fleets: where one MAC carries multiple serials, the
UI says the track may represent more than one aircraft instead of silently
showing whichever arrived last.