### PR TITLE
v1.5.0.9: accept both iw frequency formats when detecting adapter bands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,48 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.0.9] — Unreleased
+
+A single fix. Nodes running the currently supported OS could report having
+no WiFi adapter at all while one was connected and working.
+
+### A working adapter was reported as absent, and scanning quietly degraded
+
+The feeder and the CLI both determine which bands an adapter supports by
+reading the frequency list from `iw`. That output is formatted slightly
+differently depending on the version of `iw` installed:
+
+    older releases   * 2412 MHz [1] (30.0 dBm)
+    newer releases   * 2412.0 MHz [1] (20.0 dBm)
+
+Both parsers required the decimal, so on the older format they found no
+frequencies and concluded the adapter supported no bands at all.
+
+The visible symptom was both bands showing "Absent — no capable adapter"
+in the local interface, on `droneaware status`, and on the node's page,
+even though the adapter was present, in monitor mode, and reported by the
+same command that said it was absent.
+
+The more serious effect was not visible at all. With no band information,
+no adapter roles are assigned, and the feeder falls back to its legacy
+channel plan — an even sweep of channels 1 through 11 at a fifth of a
+second each. That is shorter than the interval between Remote ID
+broadcasts, so most visits to a channel end before anything is
+transmitted, and the great majority of the time is spent on channels that
+carry almost no Remote ID traffic. Affected nodes were still running, but
+detecting a small fraction of what they should, and reporting nothing in a
+way that resembles quiet airspace rather than a fault.
+
+Both parsers now accept either format. A node whose adapter is correctly
+detected will report its bands correctly on all three surfaces after the
+update, which re-runs hardware detection automatically.
+
+Separately, if the frequency list is ever unreadable in future, the feeder
+now says so plainly. Previously an empty result was silent, and surfaced
+only as two contradictory warnings about the same adapter — that it was
+2.4 GHz-only and 5 GHz-only at the same time — which is what made this
+difficult to recognize from a log.
+
 ## [1.5.0.8] — Unreleased
 
 Local reporting correctness, and radios that recover on their own.

--- a/droneaware
+++ b/droneaware
@@ -586,9 +586,17 @@ def _link(p):
     except OSError: return None
 
 def _bands(info):
+    # iw frequency format varies by version and the old pattern required a
+    # decimal that Bookworm's iw 5.19 does not print:
+    #   iw 6.9  (trixie)   * 2412.0 MHz [1]
+    #   iw 5.19 (bookworm) * 2412 MHz [1]
+    # Requiring the decimal returned no bands at all on the supported
+    # platform, so no adapter roles were assigned. Bullet and decimal are
+    # both optional now. Keep in sync with _wclassifier_parse_bands in
+    # wifi_feeder.py — the CLI and the feeder must agree about the hardware.
     b = set()
     for line in info.splitlines():
-        m = re.search(r"\*\s+(\d{4})\.\d+\s+MHz\s+\[\d+\]", line)
+        m = re.search(r"(\d{4})(?:\.\d+)?\s+MHz\s+\[\d+\]", line)
         if m:
             f = int(m.group(1))
             if 2400 <= f <= 2500: b.add("2.4")

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -648,11 +648,31 @@ def _wclassifier_readlink_base(path: str) -> str | None:
 
 
 def _wclassifier_parse_bands(iw_info: str) -> list:
-    """Parse `iw phy info` output for supported bands (2.4 / 5) via
-    frequency list. Frequencies appear as '* 2412.0 MHz [1] (...)' lines."""
+    r"""Parse `iw phy info` output for supported bands (2.4 / 5) via
+    frequency list.
+
+    The frequency format varies by iw version and the previous pattern
+    required a decimal that older releases do not print:
+
+        iw 6.9  (trixie)    * 2412.0 MHz [1] (20.0 dBm)
+        iw 5.19 (bookworm)  * 2412 MHz [1] (30.0 dBm)
+
+    Requiring "\d{4}\.\d+" matched only the newer form, so on Bookworm —
+    the supported platform — this returned an empty list for every adapter.
+    That is not a cosmetic failure: with no bands, no roles are assigned,
+    both bands report "absent" as though no radio were present, and the
+    feeder falls back to the legacy flat 1-11 hopper at 0.2s dwell, which
+    is below the 1 Hz beacon interval. Nodes looked like quiet airspace
+    rather than misconfigured ones.
+
+    Both the leading bullet and the decimal are now optional; "NNNN MHz [N]"
+    is distinctive enough on its own. Disabled channels still count toward
+    band capability, which is unchanged behaviour — the question here is
+    what the radio can physically do, not what regulatory currently allows.
+    """
     bands = set()
     for line in iw_info.splitlines():
-        m = re.search(r"\*\s+(\d{4})\.\d+\s+MHz\s+\[\d+\]", line)
+        m = re.search(r"(\d{4})(?:\.\d+)?\s+MHz\s+\[\d+\]", line)
         if not m:
             continue
         freq = int(m.group(1))
@@ -660,6 +680,17 @@ def _wclassifier_parse_bands(iw_info: str) -> list:
             bands.add("2.4")
         elif 5000 <= freq <= 6000:
             bands.add("5")
+    if not bands and iw_info.strip():
+        # Non-empty iw output that yielded no frequencies means the format
+        # changed again. Say so: an empty band list is otherwise silent and
+        # surfaces only as two contradictory warnings ("2.4GHz-only" AND
+        # "5GHz-only" for the same adapter), which is how this went
+        # undiagnosed in the field.
+        log.warning(
+            "[classifier] could not parse any frequencies from iw output — "
+            "band detection unavailable, adapter roles may be wrong. "
+            "Check `iw phy <phy> info` formatting for this iw version."
+        )
     return sorted(bands)
 
 


### PR DESCRIPTION
### A working adapter reported as absent, and scanning quietly degraded

Band detection parsed `iw phy info` frequency lines with a pattern requiring
a decimal:

```
re.search(r"\*\s+(\d{4})\.\d+\s+MHz\s+\[\d+\]", line)
```

`iw 6.9` prints `* 2412.0 MHz [1]` and matches. **`iw 5.19` — the version on
the platform `install.sh` declares as required, and the one CI pins its
builds to — prints `* 2412 MHz [1]` and does not.** On those nodes every
adapter parsed as supporting no bands.

Confirmed in the field: an operator reported `iw version 5.19` emitting
`2412 MHz [1]` with no decimal, on a node whose adapter was otherwise
healthy and in monitor mode.

### Why it was hard to recognize

An empty band list fails every "is band X supported" test, so the classifier
logged both of these for the same interface, one line apart:

```
[WARNING] wlan1 is 2.4GHz-only — 5GHz channel 149 lock impossible
[WARNING] wlan1 is 5GHz-only — 2.4GHz hopping impossible
```

### Impact was worse than mislabeling

With no bands, no roles are assigned. `config.env` gets empty
`WIFI_ADAPTER_2G_MAC`/`_5G_MAC`, both bands emit `scan_mode=absent`, and the
feeder falls back to the legacy flat 1–11 hopper at **0.2s dwell** — below
the 1 Hz beacon interval, spending most of its time on channels carrying
almost no RID. Affected nodes were degraded, and reported zero detections in
a way that resembles quiet airspace rather than a fault.

### Fix

Two independent parsers were affected and both are fixed:

- CLI `_bands` — role assignment, writes `config.env`
- feeder `_wclassifier_parse_bands` — `scan_mode` in the heartbeat and state files

Bullet and decimal are both optional now; `NNNN MHz [N]` is distinctive on
its own. Verified against six format variants including disabled channels,
and against a live classifier run on `iw 6.9` to confirm no regression
(`MONITOR_COUNT=1`, correct 2.4 GHz role).

Because `cmd_update` re-execs the newly installed CLI's `refresh`, a single
`sudo droneaware update` repairs role assignment and reporting together —
all three surfaces read from the same corrected data.

Also added: an explicit warning when `iw` returns output but no frequencies
parse, so the next format change is legible rather than silent.

### Why this escaped testing

Both development nodes have drifted to Debian 13 / `iw 6.9`, while
`install.sh` requires Bookworm and CI pins Bookworm. The supported platform
had no test coverage, so this class of bug is currently invisible
pre-release.