### PR TITLE
v1.5.2: diagnostics — the node can explain itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,43 @@ the sweep working. An adapter that is plugged in but has not been assigned a
 job is named as unused, with a pointer to the command that adopts it — that
 case previously wasted hardware silently.
 
+### A warning that fired on every healthy node
+
+Every US node logged this at every start:
+
+```
+PHY does not advertise channels [13] — hopper will retune but the radio
+may not actually be there.
+```
+
+Nothing was wrong. The check ran before the channel plan was built, so it
+tested the raw candidate list rather than the plan — and channel 13, which is
+not permitted in the US, was correctly dropped from the plan one line later.
+The node then reported that it would tune somewhere it had already decided not
+to go.
+
+The check is removed rather than reordered, because the plan-building step
+already performs it after filtering and logs the accurate version, and the
+startup line lists the channels actually in use.
+
+A warning that fires on every healthy node teaches operators to ignore
+warnings, which is expensive on the day one of them is real.
+
+### Three smaller corrections
+
+**The GPS device was picked non-deterministically.** When more than one USB
+serial device is attached, the feeder chose from an unsorted list, so it could
+read a different device after a reboot — and report no GPS while the receiver
+sat there working. Now sorted, so the choice is repeatable.
+
+**The adapter-resolution line named the wrong setting.** It always reported
+`WIFI_ADAPTER_MAC`, even on a two-adapter node where the value had come from
+`WIFI_ADAPTER_2G_MAC` or `WIFI_ADAPTER_5G_MAC`. Anyone tracing an adapter
+mix-up was reading a line pointing at a setting they had never touched.
+
+**A node with no primary channel logged a stray separator** — `started:  +
+all 25 explore` — when the 2.4 or 5 GHz primary had been switched off.
+
 ### A Pi that is not getting enough power now says so
 
 The installer has checked for under-voltage since v1.5.0.6, but only once, at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,31 @@ the sweep working. An adapter that is plugged in but has not been assigned a
 job is named as unused, with a pointer to the command that adopts it — that
 case previously wasted hardware silently.
 
+### `droneaware test` refused to run on a node with a working GPS
+
+On a mobile node, `sudo droneaware test` failed with "No location configured.
+Set NODE_LAT/NODE_LON in config.env first" — on a node whose GPS had a fix
+from 19 satellites, which `sudo droneaware status` printed correctly seconds
+earlier, and whose position was already showing on the website.
+
+`NODE_LAT`/`NODE_LON` are deliberately empty on a mobile node, because the
+position comes from the receiver. There was a GPS fallback for exactly this
+case, but it read the serial port itself rather than the position the feeder
+already publishes, and it failed four separate ways:
+
+- it required `GPS_DEVICE` to be set in the config file, but the feeder finds
+  the receiver automatically, so that setting is normally empty — which
+  skipped the entire fallback
+- it assumed 4800 baud
+- it looked only for `$GPRMC` sentences, never the `$GNRMC` that
+  multi-constellation receivers send
+- it competed for the serial port with the feeder, which holds it open
+
+The fallback now reads the position the feeder publishes, which is the same
+source `status` uses — so the two commands can no longer disagree about
+whether the node knows where it is. A fix older than ten minutes is ignored,
+since on a mobile node that is no longer where it is.
+
 ### A GPS with no fix was reported as a stopped feeder
 
 `droneaware status` showed `GPS : state stale (135375s old — wifi_feeder may

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,35 @@ the sweep working. An adapter that is plugged in but has not been assigned a
 job is named as unused, with a pointer to the command that adopts it — that
 case previously wasted hardware silently.
 
+### Choosing which adapter sweeps 5 GHz
+
+On a two-adapter node the software decides which radio works 2.4 GHz and which
+sweeps 5 GHz. That decision is consistent — adapters are ordered by MAC
+address — but arbitrary from an operator's point of view, because a MAC says
+nothing about which radio is the better sweeper. It matters more than it
+sounds: the sweeping adapter changes channel around twenty-one times a cycle,
+and the time that takes varies by a factor of forty-five across adapters
+people actually own.
+
+Operators who edited the setting by hand found it reverted. Re-detecting
+hardware rewrites both role assignments every time it runs, and updates
+re-detect, so a deliberate change survived only until the next upgrade.
+
+```
+sudo droneaware swap            # exchange the two roles
+sudo droneaware swap --auto     # hand the choice back to the node
+```
+
+A swap is remembered across reboots, updates and re-installs. It refuses to
+move a 2.4 GHz-only adapter onto the 5 GHz role, since that node would run
+normally while never seeing a drone above 2.4 GHz.
+
+It is deliberately not permanent. If either adapter is unplugged or replaced,
+the next hardware re-detection notices the pinned radio is gone, says so, and
+returns to choosing automatically — so a new adapter is adopted normally
+rather than being ignored because of a preference set months earlier. The same
+release happens if the node drops to a single adapter.
+
 ### `droneaware test` refused to run on a node with a working GPS
 
 On a mobile node, `sudo droneaware test` failed with "No location configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,58 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.2] — Unreleased
+
+Diagnostics: making the node able to tell you what it is actually doing.
+
+### There was no way to see which adapter was on which channel
+
+`droneaware status` listed the services and the firmware version but said
+nothing about the radios themselves. Answering "which adapter is doing what,
+and where is it listening?" meant knowing about `iw` — which is not on the
+command path for an ordinary shell, so the obvious attempt returns nothing at
+all rather than an error.
+
+Status now lists each radio with its driver, mode, current channel, and the
+job it has been assigned:
+
+```
+  Radios:
+    wlan0   brcmfmac      managed  ch40    network uplink
+    wlan1   rt2800usb     monitor  ch6     2.4 GHz feeder
+    wlan2   mt76x2u       monitor  ch124   5 GHz feeder
+```
+
+Running it twice a few seconds apart shows the 5 GHz radio moving, which is
+the sweep working. An adapter that is plugged in but has not been assigned a
+job is named as unused, with a pointer to the command that adopts it — that
+case previously wasted hardware silently.
+
+### A GPS with no fix was reported as a stopped feeder
+
+`droneaware status` showed `GPS : state stale (135375s old — wifi_feeder may
+have stopped)` on a node whose feeders were both running, and which the same
+output listed as running two lines earlier.
+
+The GPS state file is written once when the serial port opens, and after that
+only when a valid position fix arrives. A receiver that is powered, connected
+and streaming NMEA — but has never achieved a fix, which is the normal state
+indoors or with a poor sky view — therefore never updated the file again. The
+status command treats anything older than two minutes as evidence the feeder
+died.
+
+So the one situation where an operator most needs a useful diagnostic produced
+a message that was wrong about the cause and pointed at the wrong component.
+
+The reader now refreshes that file every 20 seconds while the port is open,
+carrying the satellite count and fix quality it already parses. Status has
+always been able to report "NMEA, 6 satellites, no fix yet" — that line was
+simply unreachable, because the staleness check ran first.
+
+This is the same defect that was fixed for the `not_configured` state back in
+v1.3.0.2. `reading` had the identical write-once property and did not get the
+same treatment.
+
 ## [1.5.1] — Unreleased
 
 How the node chooses what to listen to. Until now it scanned two channels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,37 @@ the sweep working. An adapter that is plugged in but has not been assigned a
 job is named as unused, with a pointer to the command that adopts it — that
 case previously wasted hardware silently.
 
+### A Pi that is not getting enough power now says so
+
+The installer has checked for under-voltage since v1.5.0.6, but only once, at
+install time. A node that was healthy then and developed a power problem later
+said nothing at all — and an under-volted Pi degrades in ways that look like
+almost anything except a power fault.
+
+That gap matters more now that a second WiFi adapter is recommended, since
+adding one is exactly the change that pushes a marginal supply over the edge.
+Recommending the hardware without surfacing the consequence would have been a
+poor trade.
+
+`sudo droneaware status` now reports it:
+
+```
+  Power    : OK
+```
+
+or, when the supply is struggling, what is happening and what usually fixes it
+— the official supply, a short and thick USB cable, and a powered hub when
+several adapters are attached. Throttling with no under-voltage is reported
+separately, since that is usually heat rather than power.
+
+It is reported even when healthy. Saying nothing cannot distinguish "checked
+and fine" from "never checked", which is the same ambiguity that made the
+stale-GPS message misleading.
+
+One caveat worth knowing: these flags are latched since boot, so a clean
+reading on a Pi that has just started and has not yet drawn much current is
+weaker evidence than it appears.
+
 ### Choosing which adapter sweeps 5 GHz
 
 On a two-adapter node the software decides which radio works 2.4 GHz and which

--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ knows how your node is put together, so the same command works whether you
 have one WiFi adapter or two.
 
 ```bash
-# How is my node doing? Services, adapters, firmware version
+# How is my node doing? Services, firmware, and which radio is on
+# which channel right now
 sudo droneaware status
 
 # Watch detections as they arrive (add "ble" for the Bluetooth feeder)
@@ -254,6 +255,20 @@ sudo droneaware test
 # Read-only GPS health check
 sudo droneaware gps-diagnose
 ```
+
+`status` answers the question people ask most — which adapter is doing what,
+and where it is tuned at this moment:
+
+```
+  Radios:
+    wlan0   brcmfmac      managed  ch40    network uplink
+    wlan1   rt2800usb     monitor  ch6     2.4 GHz feeder
+    wlan2   mt76x2u       monitor  ch124   5 GHz feeder
+```
+
+Run it twice a few seconds apart and you will see the 5 GHz radio move — that
+is the sweep working. An adapter listed as `unused` is plugged in but not
+assigned to anything.
 
 `refresh` is the one people miss. The node works out which adapter serves
 which band at install time, so if you add or move hardware afterwards, run it

--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ sudo droneaware update
 # After changing hardware — added an adapter, swapped a USB port, new GPS
 sudo droneaware refresh
 
+# Two adapters? Exchange which one works 2.4 GHz and which sweeps 5 GHz
+sudo droneaware swap
+sudo droneaware swap --auto     # hand the choice back to the node
+
 # Transmit a sanctioned 60-second test flight and confirm your node sees it
 sudo droneaware test
 
@@ -269,6 +273,14 @@ and where it is tuned at this moment:
 Run it twice a few seconds apart and you will see the 5 GHz radio move — that
 is the sweep working. An adapter listed as `unused` is plugged in but not
 assigned to anything.
+
+`swap` exists because the node's own choice, while consistent, is arbitrary
+from your point of view — it orders adapters by MAC address, which says
+nothing about which radio is the better sweeper. The sweeping adapter changes
+channel around 21 times a cycle, so putting the faster one there is worth real
+detection performance. It refuses to move a 2.4 GHz-only adapter onto the
+5 GHz role, and the choice survives updates and reboots until you release it
+or the hardware changes.
 
 `refresh` is the one people miss. The node works out which adapter serves
 which band at install time, so if you add or move hardware afterwards, run it

--- a/droneaware
+++ b/droneaware
@@ -1559,6 +1559,46 @@ cmd_status() {
 
     echo ""
 
+    # Which radio is doing what, and where it is right now. "Which adapter is
+    # on which channel" is the question operators actually ask, and answering
+    # it previously meant knowing about `iw` — which is not even on a
+    # non-login shell's PATH, so the obvious attempt returns nothing.
+    #
+    # The role column is the useful half: it maps a physical adapter to the
+    # job it was assigned, and names an adapter that is plugged in but not
+    # configured, which is the case that silently wastes hardware.
+    local _iw
+    _iw=$(command -v iw 2>/dev/null || echo /usr/sbin/iw)
+    if [[ -x "$_iw" ]] && compgen -G "/sys/class/net/wl*" >/dev/null; then
+        local m2g m5g m1
+        m2g=$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC)
+        m5g=$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC)
+        m1=$(_cfg_get "$cfg" WIFI_ADAPTER_MAC)
+        echo "  Radios:"
+        local dev
+        for dev in /sys/class/net/wl*; do
+            [[ -e "$dev" ]] || continue
+            local ifn drv mac info mode chan role
+            ifn=${dev##*/}
+            drv=$(basename "$(readlink "$dev/device/driver" 2>/dev/null)" 2>/dev/null)
+            mac=$(cat "$dev/address" 2>/dev/null)
+            info=$("$_iw" dev "$ifn" info 2>/dev/null)
+            mode=$(grep -oE 'type [a-z]+' <<<"$info" | cut -d' ' -f2)
+            chan=$(grep -oE 'channel [0-9]+' <<<"$info" | cut -d' ' -f2)
+            if   [[ -n "$mac" && "$mac" == "$m2g" ]]; then role="2.4 GHz feeder"
+            elif [[ -n "$mac" && "$mac" == "$m5g" ]]; then role="5 GHz feeder"
+            elif [[ -n "$mac" && "$mac" == "$m1"  ]]; then role="detection"
+            elif [[ "$drv" == brcmfmac* ]];          then role="network uplink"
+            elif [[ "$mode" == "monitor" ]];         then role="unused — run 'sudo droneaware refresh'"
+            else                                          role="not used for detection"
+            fi
+            printf "    %-7s %-13s %-8s %-7s %s\n" \
+                "$ifn" "${drv:-?}" "${mode:-?}" \
+                "$( [[ -n "$chan" ]] && echo "ch${chan}" || echo "—" )" "$role"
+        done
+        echo ""
+    fi
+
     # Web UI URL — shown when service is active and bound, so operators
     # know how to reach it from another device on the LAN.
     if systemctl is-active --quiet droneaware-web 2>/dev/null; then

--- a/droneaware
+++ b/droneaware
@@ -1721,33 +1721,42 @@ cmd_test() {
         exit 1
     fi
 
-    # Fall back to GPS fix if available and static coords are missing
+    # Fall back to the live GPS fix when static coords are missing, which is
+    # the NORMAL state on a mobile node -- NODE_LAT/NODE_LON are deliberately
+    # empty there because position comes from the receiver.
+    #
+    # Read the state file the feeder maintains, NOT the serial port. The
+    # previous version re-read /dev/tty* itself and failed four separate ways:
+    # it required GPS_DEVICE to be set in config (the feeder auto-discovers,
+    # so it is normally empty and the whole branch was skipped), hardcoded
+    # 4800 baud, matched only $GPRMC and never the $GNRMC that multi-
+    # constellation receivers emit, and contended with the feeder, which holds
+    # the port open with exclusive locking. Net effect: `droneaware status`
+    # printed a valid fix while `droneaware test` insisted no location was
+    # configured -- same node, seconds apart.
     if [[ -z "$lat" || "$lat" == "0" || -z "$lon" || "$lon" == "0" ]]; then
-        local gps_dev
-        gps_dev=$(_cfg_get "$cfg" GPS_DEVICE)
-        if [[ -n "$gps_dev" && -e "$gps_dev" ]]; then
-            local nmea
-            nmea=$(stty -F "$gps_dev" 4800 2>/dev/null; timeout 8 cat "$gps_dev" 2>/dev/null \
-                | grep -m1 '^\$GPRMC.*,A,')
-            if [[ -n "$nmea" ]]; then
-                lat=$(echo "$nmea" | python3 -c "
-import sys, re
-parts = sys.stdin.read().strip().split(',')
-d=int(float(parts[3])/100); m=float(parts[3])-d*100
-lat=round(d+m/60,6)
-if parts[4]=='S': lat=-lat
-d=int(float(parts[5])/100); m=float(parts[5])-d*100
-lon=round(d+m/60,6)
-if parts[6].split('*')[0]=='W': lon=-lon
-print(lat, lon)" | awk '{print $1}')
-                lon=$(echo "$nmea" | python3 -c "
-import sys
-parts = sys.stdin.read().strip().split(',')
-d=int(float(parts[5])/100); m=float(parts[5])-d*100
-lon=round(d+m/60,6)
-if parts[6].split('*')[0]=='W': lon=-lon
-print(lon)")
-            fi
+        local gps_fix
+        gps_fix=$(python3 - <<'GPSPY' 2>/dev/null
+import json, time
+try:
+    with open("/run/droneaware/gps_state.json") as f:
+        s = json.load(f)
+except Exception:
+    raise SystemExit
+lat, lon = s.get("lat"), s.get("lon")
+if lat is None or lon is None:
+    raise SystemExit
+# A stale fix is not where the node is now, which matters most on exactly
+# the mobile nodes this fallback exists for.
+if time.time() - (s.get("updated_at") or 0) > 600:
+    raise SystemExit
+print(lat, lon)
+GPSPY
+)
+        if [[ -n "$gps_fix" ]]; then
+            lat=${gps_fix%% *}
+            lon=${gps_fix##* }
+            echo "  Using live GPS fix (lat=${lat}, lon=${lon})"
         fi
     fi
 

--- a/droneaware
+++ b/droneaware
@@ -802,6 +802,15 @@ elif len(monitor) >= 2:
 print(f"MONITOR_COUNT={len(monitor)}")
 print(f"ROLE_2G_MAC={role_24g['mac'] if role_24g else ''}")
 print(f"ROLE_5G_MAC={role_5g['mac'] if role_5g else ''}")
+# Per-adapter detail so `droneaware swap` can name what it is moving and
+# refuse to put a 2.4-only radio on the 5 GHz role. Ordering is by MAC and
+# therefore stable, which is what makes the roles reproducible across
+# reboots -- it is just unrelated to which adapter the operator wants where.
+for _i, _a in enumerate(monitor):
+    print(f"MON{_i}_MAC={_a['mac']}")
+    print(f"MON{_i}_IFACE={_a.get('iface','')}")
+    print(f"MON{_i}_DRIVER={_a.get('driver','')}")
+    print(f"MON{_i}_BANDS={','.join(_a['bands'])}")
 PY
 }
 
@@ -851,6 +860,27 @@ _orchestrate_wifi_mode() {
     info "v1.5.0 mode-detect: ${MONITOR_COUNT} monitor-capable USB adapter(s) present"
 
     if [[ "$MONITOR_COUNT" -ge 2 && -n "$ROLE_2G_MAC" && -n "$ROLE_5G_MAC" ]]; then
+        # An operator pin (from `droneaware swap`) beats the classifier -- but
+        # ONLY while both pinned adapters are still attached. A pin that
+        # outlives its hardware would leave the node permanently faulted, which
+        # is precisely the class of failure refresh exists to repair, so it
+        # self-clears rather than being honored forever.
+        local _pinned _p2g _p5g
+        _pinned=$(_cfg_get "$cfg" WIFI_ADAPTER_ROLES_PINNED)
+        if [[ "$(echo "$_pinned" | tr '[:upper:]' '[:lower:]')" == "true" ]]; then
+            _p2g=$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC)
+            _p5g=$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC)
+            if [[ -n "$_p2g" && -n "$_p5g" ]] \
+               && grep -qixF "$_p2g" /sys/class/net/*/address 2>/dev/null \
+               && grep -qixF "$_p5g" /sys/class/net/*/address 2>/dev/null; then
+                info "v1.5.0 mode-detect: keeping operator-pinned adapter roles (droneaware swap)"
+                ROLE_2G_MAC="$_p2g"
+                ROLE_5G_MAC="$_p5g"
+            else
+                warn "Pinned adapter roles name hardware that is no longer attached — reverting to automatic assignment"
+                _set_cfg_key "$cfg" WIFI_ADAPTER_ROLES_PINNED "false"
+            fi
+        fi
         _switch_to_dual_adapter_mode "$cfg" "$ROLE_2G_MAC" "$ROLE_5G_MAC"
     elif [[ "$MONITOR_COUNT" -ge 1 ]]; then
         local single_mac="${ROLE_2G_MAC:-$ROLE_5G_MAC}"
@@ -1031,6 +1061,10 @@ _switch_to_single_adapter_mode() {
         info "v1.5.0.6: clearing stale dual-adapter band keys (node resolved to single-adapter)"
         _set_cfg_key "$cfg" WIFI_ADAPTER_2G_MAC ""
         _set_cfg_key "$cfg" WIFI_ADAPTER_5G_MAC ""
+        # A role pin cannot outlive the pair it describes. Leaving it set would
+        # make config.env claim an operator choice over two MACs that were just
+        # blanked, which is the dishonest record this block exists to prevent.
+        _set_cfg_key "$cfg" WIFI_ADAPTER_ROLES_PINNED "false"
     fi
 
     # v1.5.0.6: enforce the enable-state for single mode, symmetric with
@@ -1123,6 +1157,136 @@ _start_wifi_services_for_current_mode() {
         systemctl stop droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
         systemctl start droneaware-wifi 2>/dev/null || true
     fi
+}
+
+# v1.5.2 — operator-chosen adapter roles.
+#
+# With two adapters the node decides which one works 2.4 GHz and which sweeps
+# 5 GHz. That choice is stable (adapters are ordered by MAC) but arbitrary from
+# the operator's point of view -- lowest MAC wins, which has nothing to do with
+# which radio is the better sweeper. It matters: the sweeping adapter retunes
+# ~21 times a cycle, so putting the faster radio there is worth real detection
+# performance, and the spread between adapters is 45x.
+#
+# Editing config.env by hand did not survive, because refresh recomputes and
+# rewrites both role keys on every run. An operator reported exactly that: the
+# swap held until the next update, then silently reverted. This command pins
+# the choice so refresh respects it.
+cmd_swap() {
+    require_root "swap"
+    local cfg="${INSTALL_DIR}/config.env"
+    local mode="${2:-}"
+    local MONITOR_COUNT="" ROLE_2G_MAC="" ROLE_5G_MAC=""
+    local MON0_MAC="" MON0_IFACE="" MON0_DRIVER="" MON0_BANDS=""
+    local MON1_MAC="" MON1_IFACE="" MON1_DRIVER="" MON1_BANDS=""
+    eval "$(_classify_wifi_adapters 2>/dev/null)"
+
+    _swap_describe() {
+        local mac="$1"
+        [[ -z "$mac" ]] && { echo "(none)"; return; }
+        if   [[ "$mac" == "$MON0_MAC" ]]; then echo "${MON0_IFACE} (${MON0_DRIVER})"
+        elif [[ "$mac" == "$MON1_MAC" ]]; then echo "${MON1_IFACE} (${MON1_DRIVER})"
+        else echo "$mac"; fi
+    }
+    _swap_bands() {
+        local mac="$1"
+        if   [[ "$mac" == "$MON0_MAC" ]]; then echo "$MON0_BANDS"
+        elif [[ "$mac" == "$MON1_MAC" ]]; then echo "$MON1_BANDS"
+        else echo ""; fi
+    }
+
+    # --auto hands the choice back. Symmetric with the verb that took it:
+    # an operator who set the roles with a command should not have to learn
+    # a config key name to undo it.
+    if [[ "$mode" == "--auto" ]]; then
+        echo ""
+        echo -e "${BOLD}DroneAware Adapter Roles — automatic${NC}"
+        echo ""
+        local was
+        was=$(_cfg_get "$cfg" WIFI_ADAPTER_ROLES_PINNED)
+        if [[ "$(echo "$was" | tr '[:upper:]' '[:lower:]')" != "true" ]]; then
+            echo "  Roles are already chosen automatically — nothing to release."
+            echo ""
+            exit 0
+        fi
+        _set_cfg_key "$cfg" WIFI_ADAPTER_ROLES_PINNED "false"
+        # Re-derive immediately rather than waiting for the next refresh, so
+        # the command visibly does something when it is run.
+        _orchestrate_wifi_mode "$cfg"
+        systemctl restart droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+        echo ""
+        printf "    2.4 GHz : %s\n" "$(_swap_describe "$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC)")"
+        printf "    5 GHz   : %s\n" "$(_swap_describe "$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC)")"
+        echo ""
+        ok "Roles released — the node chooses them from now on."
+        echo ""
+        exit 0
+    fi
+
+    echo ""
+    echo -e "${BOLD}DroneAware Adapter Swap${NC}"
+    echo ""
+
+    [[ -z "$MONITOR_COUNT" ]] && fatal "Could not read the WiFi adapters — try 'sudo droneaware status'."
+
+    if (( MONITOR_COUNT < 2 )); then
+        echo "  Found ${MONITOR_COUNT} monitor-capable USB adapter(s)."
+        echo "  Swapping needs two: one works 2.4 GHz, the other sweeps 5 GHz."
+        echo ""
+        exit 1
+    fi
+    if (( MONITOR_COUNT > 2 )); then
+        echo "  Found ${MONITOR_COUNT} monitor-capable USB adapters; swap only knows how to"
+        echo "  exchange a pair. Set the roles by hand instead:"
+        echo ""
+        echo "    WIFI_ADAPTER_2G_MAC / WIFI_ADAPTER_5G_MAC   in ${cfg}"
+        echo "    WIFI_ADAPTER_ROLES_PINNED=true              so refresh leaves them alone"
+        echo ""
+        exit 1
+    fi
+
+    # Fall back to what the classifier would pick, so swap works on a node
+    # whose roles have never been pinned.
+    local cur_2g cur_5g
+    cur_2g=$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC); cur_2g="${cur_2g:-$ROLE_2G_MAC}"
+    cur_5g=$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC); cur_5g="${cur_5g:-$ROLE_5G_MAC}"
+
+    local new_2g="$cur_5g" new_5g="$cur_2g"
+
+    # The 5 GHz role needs a radio that can reach 5 GHz. Refusing here is the
+    # main reason this is a command rather than a documented config edit: a
+    # 2.4-only adapter pinned to the 5 GHz role just FAULTs, leaving the
+    # operator to work out why from the feeder log.
+    if [[ ",$(_swap_bands "$new_5g")," != *",5,"* ]]; then
+        echo -e "  ${RED}Cannot swap.${NC}"
+        echo ""
+        echo "    $(_swap_describe "$new_5g") does not support 5 GHz, so it cannot take"
+        echo "    the 5 GHz role. The node would run but never see a drone above 2.4 GHz."
+        echo ""
+        echo "  Roles unchanged."
+        echo ""
+        exit 1
+    fi
+
+    echo "  Before:"
+    printf "    2.4 GHz : %s\n" "$(_swap_describe "$cur_2g")"
+    printf "    5 GHz   : %s\n" "$(_swap_describe "$cur_5g")"
+    echo ""
+    echo "  After:"
+    printf "    2.4 GHz : %s\n" "$(_swap_describe "$new_2g")"
+    printf "    5 GHz   : %s\n" "$(_swap_describe "$new_5g")"
+    echo ""
+
+    _set_cfg_key "$cfg" WIFI_ADAPTER_2G_MAC "$new_2g"
+    _set_cfg_key "$cfg" WIFI_ADAPTER_5G_MAC "$new_5g"
+    _set_cfg_key "$cfg" WIFI_ADAPTER_ROLES_PINNED "true"
+
+    systemctl restart droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
+    ok "Roles swapped and pinned — refresh and update will leave them alone."
+    echo ""
+    echo "  'sudo droneaware swap' again puts them back."
+    echo "  'sudo droneaware swap --auto' hands the choice back to the node."
+    echo ""
 }
 
 cmd_refresh() {
@@ -2361,6 +2525,7 @@ case "$1" in
     install-webui)  cmd_install_webui ;;
     gps-diagnose)   cmd_gps_diagnose ;;
     refresh)        cmd_refresh ;;
+    swap)           cmd_swap "$@" ;;
     __migrate)
         # Internal subcommand used by cmd_update for post-install config
         # migration. The double-underscore prefix is a convention signaling
@@ -2388,6 +2553,8 @@ case "$1" in
         echo "    install-webui   Install the optional local Web UI (LAN dashboard)"
         echo "    gps-diagnose    Read-only GPS health check (device, port, protocol, state)"
         echo "    refresh         Re-detect hardware (WiFi adapters, GPS) and sync services"
+        echo "    swap            Exchange which adapter works 2.4 GHz vs sweeps 5 GHz"
+        echo "    swap --auto     Hand the adapter role choice back to the node"
         echo ""
         ;;
 esac

--- a/droneaware
+++ b/droneaware
@@ -1775,6 +1775,43 @@ cmd_status() {
         echo ""
     fi
 
+    # Power. The installer has checked this since v1.5.0.6, but only once, at
+    # install time — a node that was healthy then and browns out later says
+    # nothing. That gap matters more now that we recommend a SECOND WiFi
+    # adapter, which is exactly the change that pushes a marginal supply over
+    # the edge, and an under-volted Pi degrades in ways that look like
+    # anything but a power problem.
+    #
+    # Reported even when healthy: silence cannot distinguish "checked and
+    # fine" from "never checked", which is the same ambiguity that made the
+    # stale-GPS message misleading.
+    #
+    # Flags are latched since boot, so 0x0 on a freshly booted Pi that has not
+    # yet drawn much current is weaker evidence than it looks.
+    if command -v vcgencmd >/dev/null 2>&1; then
+        local _thr _bits
+        _thr=$(vcgencmd get_throttled 2>/dev/null)
+        _bits="${_thr#throttled=}"
+        if [[ "$_bits" =~ ^0x[0-9a-fA-F]+$ ]]; then
+            if (( _bits == 0 )); then
+                echo "  Power    : OK"
+            elif (( (_bits & 0x1) != 0 )); then
+                echo -e "  Power    : ${RED}UNDER-VOLTAGE NOW${NC} — the Pi is not getting enough power"
+                echo "             Detection degrades in ways that do not look like a power fault."
+                echo "             Use the official PSU and a short, thick USB cable; a powered hub"
+                echo "             if you have several adapters attached."
+            elif (( (_bits & 0x10000) != 0 )); then
+                echo -e "  Power    : ${YELLOW}under-voltage has occurred${NC} since boot (${_bits})"
+                echo "             Not happening right now, but the supply is marginal under load."
+            elif (( (_bits & 0x4) != 0 || (_bits & 0x40000) != 0 )); then
+                echo "  Power    : throttled (${_bits}) with no under-voltage — most likely thermal"
+            else
+                echo "  Power    : ${_bits}"
+            fi
+            echo ""
+        fi
+    fi
+
     # GPS state — read tmpfs state file written by wifi_feeder. Soft-fails
     # if file missing (feeder not yet started, or pre-v1.3.0 binary).
     python3 - <<'PYEOF'

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -929,9 +929,16 @@ def resolve_monitor_iface(fallback_iface: str | None, band: str = "auto") -> str
                         # would pick peer band's adapter and cause contention.
                         return ""
                     break  # single-adapter mode — safe to fall through
+                # Name the key the value actually came from. This said
+                # WIFI_ADAPTER_MAC unconditionally, so on a two-adapter node it
+                # reported a key the operator had not set while the real one --
+                # WIFI_ADAPTER_2G_MAC or _5G_MAC -- went unmentioned. Anyone
+                # debugging an adapter mix-up was reading a line that pointed
+                # at the wrong setting.
                 log.info(
-                    f"[iface v1.5.0] resolved WIFI_ADAPTER_MAC={configured_mac} "
-                    f"→ {iface}"
+                    f"[iface v1.5.0] resolved "
+                    f"{band_key if band_specific_configured else 'WIFI_ADAPTER_MAC'}"
+                    f"={configured_mac} → {iface}"
                 )
                 return iface
         else:
@@ -1810,8 +1817,12 @@ class ScanPlanHopper(threading.Thread):
             legs_per_cycle = n_social + len(self._explore)
             explore_desc = f"all {len(self._explore)} explore @ {self.dwell_explore_s}s"
         true_cycle = cycle + legs_per_cycle * r
+        # Join only the parts that exist. A plan whose primary channel has
+        # been switched off has no social leg, which rendered as a stray
+        # leading " + ".
+        plan_desc = " + ".join(p for p in (social, explore_desc) if p)
         log.info(
-            f"Scan plan {self.plan.upper()} started: {social} + {explore_desc} "
+            f"Scan plan {self.plan.upper()} started: {plan_desc} "
             f"({true_cycle:.1f}s cycle incl. {1000*r:.0f}ms retune x{legs_per_cycle}); "
             f"camp after {self.camp_trigger_frames} frames/"
             f"{self.camp_trigger_window_s}s, release on {self.camp_silence_s}s silence "
@@ -2443,7 +2454,11 @@ def find_gps_device() -> str | None:
         return env_device
 
     # USB paths — probed for every node.
-    usb_candidates = glob.glob('/dev/ttyUSB*') + glob.glob('/dev/ttyACM*')
+    # Sorted, because glob returns filesystem order. On a node with more than
+    # one USB serial device the pick was nondeterministic across boots, so the
+    # feeder could read a different device than last time and report no GPS
+    # while the receiver sat there working.
+    usb_candidates = sorted(glob.glob('/dev/ttyUSB*')) + sorted(glob.glob('/dev/ttyACM*'))
     usb_candidates = [c for c in usb_candidates if os.path.exists(c)]
     if usb_candidates:
         return usb_candidates[0]
@@ -3010,18 +3025,17 @@ class WiFiFeeder:
     def _run_once(self) -> bool:
         log.info(f"DroneAware WiFi Feeder - Node: {self.node_id}")
         _check_cli_freshness()
-        target = self.hopper.target_channels
-        log.info(f"Interface: {self.iface or '<not configured>'}  |  Hopper channels: {target}")
-
-        if self.iface and os.path.exists(f"/sys/class/net/{self.iface}"):
-            supported = _supported_channels(self.iface)
-            if supported:
-                missing = [c for c in target if c not in supported]
-                if missing:
-                    log.warning(
-                        f"PHY does not advertise channels {missing} — "
-                        "hopper will retune but the radio may not actually be there."
-                    )
+        # Deliberately does NOT pre-check the channel list against the PHY.
+        # This ran before hopper.run() called _build_plan(), so it saw the raw
+        # candidates and warned that the radio "may not actually be there" for
+        # channels the plan then dropped one line later — on every US node, at
+        # every start, for ch13. _build_plan does the same check after
+        # filtering and logs the accurate version, and the "Scan plan started"
+        # line reports the channels actually in use.
+        #
+        # A warning that fires on every healthy node teaches operators to
+        # ignore warnings, which is expensive the day one is real.
+        log.info(f"Interface: {self.iface or '<not configured>'}")
 
         # FAULT mode — missing or invalid WiFi adapter
         if not self.iface or not os.path.exists(f"/sys/class/net/{self.iface}"):

--- a/wifi_feeder.py
+++ b/wifi_feeder.py
@@ -2331,7 +2331,10 @@ def _write_gps_state(*, device: str | None = None, baud: int | None = None,
                         DroneAware can't parse; protocol field carries which
       detecting_baud  — probing baud rates against the device
       no_nmea         — device opened but no valid NMEA sentences received
-      reading         — serial port open, NMEA flowing, awaiting first fix
+      reading         — serial port open, NMEA flowing, awaiting first fix.
+                        REFRESHED every 20 s by the reader loop. It must be,
+                        or a receiver that never fixes looks identical to a
+                        stopped feeder to the staleness check in the CLI.
       fix             — most recent $GPRMC was "A" (active/valid); lat/lon populated
 
     Extended fields (v1.4.12+):
@@ -2557,10 +2560,40 @@ def gps_reader_thread(device: str):
 
             with serial.Serial(device, baudrate=baud, timeout=2) as ser:
                 log.info(f"[GPS] Reading from {device} at {baud} baud")
+                last_nmea  = time.time()
+                last_write = last_nmea
                 _write_gps_state(device=device, baud=baud, status="reading",
-                                 last_nmea_at=time.time(), protocol="nmea")
+                                 last_nmea_at=last_nmea, protocol="nmea")
                 while True:
                     line = ser.readline().decode('ascii', errors='ignore').strip()
+                    if line:
+                        last_nmea = time.time()
+
+                    # Heartbeat the state file even with no fix. It used to be
+                    # written once above and then ONLY on a valid RMC fix, so a
+                    # receiver streaming NMEA that never achieves a fix left the
+                    # file untouched forever — and `droneaware status` reports
+                    # anything older than 120 s as "wifi_feeder may have
+                    # stopped", which is both wrong and blames a component the
+                    # same output shows as running two lines earlier.
+                    #
+                    # This is the defect already fixed once for the
+                    # not_configured state; "reading" has the identical
+                    # write-once property and never got the same treatment.
+                    # The status command's "reading" branch already prints the
+                    # satellite count — it was simply unreachable, because the
+                    # staleness check short-circuited before it.
+                    now = time.time()
+                    if now - last_write >= 20.0:
+                        with _gps_lock:
+                            cur_lat, cur_lon = _gps_lat, _gps_lon
+                        _write_gps_state(
+                            device=device, baud=baud,
+                            status="fix" if cur_lat is not None else "reading",
+                            last_nmea_at=last_nmea, protocol="nmea",
+                            lat=cur_lat, lon=cur_lon,
+                            fix_quality=fix_quality, sats_in_use=sats_in_use)
+                        last_write = now
 
                     # GGA — fix quality + sats-in-use. Field layout:
                     #   $GxGGA,time,lat,N,lon,W,fix_quality,sats,hdop,...
@@ -2590,6 +2623,7 @@ def gps_reader_thread(device: str):
                                          last_nmea_at=time.time(), lat=lat, lon=lon,
                                          protocol="nmea", fix_quality=fix_quality,
                                          sats_in_use=sats_in_use)
+                        last_write = time.time()
                     except (ValueError, IndexError):
                         continue
         except serial.SerialException as e:


### PR DESCRIPTION
Six changes, four of them from contributor reports in a single day.

## `droneaware status` now shows the radios

Answering "which adapter is doing what, and where is it listening?" required
knowing about `iw` — which isn't on a non-login shell's PATH, so the obvious
attempt returns nothing rather than an error.

```
  Radios:
    wlan0   brcmfmac      managed  ch40    network uplink
    wlan1   rt2800usb     monitor  ch6     2.4 GHz feeder
    wlan2   mt76x2u       monitor  ch124   5 GHz feeder
```

The role column is the useful half — it names an adapter that is plugged in but
unassigned, which previously wasted hardware silently.

## `droneaware swap`

The classifier orders adapters by MAC and gives 5 GHz to the first that
supports it. Stable, but arbitrary from the operator's view — and it matters,
because the sweeping radio retunes ~21 times a cycle across adapters whose
retune cost spans 45x. Editing config.env didn't survive: refresh rewrites both
role keys, and update re-execs refresh.

```
sudo droneaware swap          # exchange the roles, and pin them
sudo droneaware swap --auto   # hand the choice back
```

The pin survives reboot, refresh, update and re-install — but **self-clears**
when either pinned adapter goes missing, or when the node drops to a single
adapter. A pin that outlived its hardware would leave a node permanently
faulted. It also refuses to put a 2.4-only radio on the 5 GHz role, which is
the main argument for a verb over a documented config edit.

## GPS: three separate bugs, one root cause

The state file exists so callers don't have to touch the hardware. Three paths
reimplemented hardware access instead of reading it.

**A receiver with no fix looked like a dead feeder.** The file was written once
when the port opened and thereafter only on a valid fix, so a receiver
streaming NMEA that never fixes — normal indoors — left it untouched. Status
treats anything over 120s old as a stopped feeder, so it blamed a feeder it
listed as running two lines earlier. Now refreshed every 20s, carrying the
satellite count it already parses.

**`droneaware test` refused to run on a node with a working GPS.** `NODE_LAT`
is deliberately empty on a mobile node. The fallback re-read the serial port
and failed four ways at once: it required `GPS_DEVICE` to be set (the feeder
auto-discovers, so it's normally empty and the branch never ran), hardcoded
4800 baud, matched only `$GPRMC` and never `$GNRMC`, and contended with the
feeder for a port it holds exclusively. Now reads the same source `status`
uses, so the two commands can't disagree about whether the node knows where it
is.

**Device selection was nondeterministic.** `glob` returns filesystem order, so
a node with more than one USB serial device could bind a different one after a
reboot. Sorted.

## Under-voltage in `status`

The installer has checked this since v1.5.0.6 — once, at install. A node that
browned out later said nothing, and an under-volted Pi degrades in ways that
look like anything except a power fault. That gap matters more now that the
README recommends a second adapter, which is exactly the change that pushes a
marginal supply over the edge.

Reported even when healthy, because silence can't distinguish "checked and
fine" from "never checked".

## A warning that fired on every healthy node

```
PHY does not advertise channels [13] — hopper will retune but the radio
may not actually be there.
```

Every US node, every start, and nothing wrong: the check ran before the plan
was built, so it tested raw candidates while the plan dropped ch13 correctly
one line later. Removed rather than reordered — `_build_plan` already does the
check after filtering and logs the accurate version.

Also: the adapter-resolution line now names the key the value came from rather
than always saying `WIFI_ADAPTER_MAC`, and a plan with its primary channel
switched off no longer renders as `started:  + all 25 explore`.