### PR TITLE
v1.5.2.1: fix "ok: command not found" after a successful swap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ sweep-test-setup-and-hypothesis.md
 analyze-sweep-test.py
 scan-test-*.jsonl
 scan-trace-*.jsonl
+
+# CLI test harness — drives cmd_swap success paths without two dual-band
+# adapters. Not product; keep out of the packaged repo.
+cli-swap-test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.2.1] — Unreleased
+
+### `droneaware swap` printed an error after succeeding
+
+Swapping adapter roles on a two-adapter node ended with:
+
+```
+/usr/local/bin/droneaware: line 1285: ok: command not found
+```
+
+The swap itself worked — the roles were exchanged, saved and applied. The
+failing line was the confirmation message afterwards, which called a helper
+that does not exist. So the command did its job and then reported an error for
+having done it, which is alarming to read and gives no clue that nothing is
+wrong.
+
+Both the swap confirmation and the `--auto` release message were affected.
+
+The reason it shipped is worth recording: neither message can be reached
+unless the swap actually goes ahead, and every node available before release
+stopped earlier than that — one with a single adapter, one with none, and one
+whose second radio is 2.4 GHz-only and is correctly refused. Those refusals
+were treated as evidence the command worked, when they are precisely the paths
+that return before the message. It now has a test that drives the paths which
+only run when nothing is wrong.
+
 ## [1.5.2] — Unreleased
 
 Diagnostics: making the node able to tell you what it is actually doing.

--- a/droneaware
+++ b/droneaware
@@ -1218,7 +1218,7 @@ cmd_swap() {
         printf "    2.4 GHz : %s\n" "$(_swap_describe "$(_cfg_get "$cfg" WIFI_ADAPTER_2G_MAC)")"
         printf "    5 GHz   : %s\n" "$(_swap_describe "$(_cfg_get "$cfg" WIFI_ADAPTER_5G_MAC)")"
         echo ""
-        ok "Roles released — the node chooses them from now on."
+        info "Roles released — the node chooses them from now on."
         echo ""
         exit 0
     fi
@@ -1282,7 +1282,7 @@ cmd_swap() {
     _set_cfg_key "$cfg" WIFI_ADAPTER_ROLES_PINNED "true"
 
     systemctl restart droneaware-wifi-2g droneaware-wifi-5g 2>/dev/null || true
-    ok "Roles swapped and pinned — refresh and update will leave them alone."
+    info "Roles swapped and pinned — refresh and update will leave them alone."
     echo ""
     echo "  'sudo droneaware swap' again puts them back."
     echo "  'sudo droneaware swap --auto' hands the choice back to the node."


### PR DESCRIPTION
Field-reported on the v1.5.2 pre-release.

```
/usr/local/bin/droneaware: line 1285: ok: command not found
```

`swap` and `swap --auto` called `ok()`, which does not exist — the helpers are
`info`/`warn`/`fatal`. **The commands worked**: roles were exchanged, written and
applied. The failure was the confirmation message afterwards, so the command did
its job and then printed an error for having done it.

## Why it shipped

`bash -n` and shellcheck both pass on this — neither resolves command names.

More to the point, both messages are unreachable unless the swap actually
proceeds, and every node available before release returned earlier: one with a
single adapter, one with none, and one whose second radio is 2.4 GHz-only and is
correctly refused by the capability guard. Those refusals were reported as
evidence the command worked. They are precisely the paths that return before the
message.

## Test

Adds `cli-swap-test.sh` (untracked, like the other test tooling). It stubs the
classifier to present two dual-band adapters and points `INSTALL_DIR` at a temp
config, so it can drive the paths that only run when nothing is wrong:

```
  PASS  swap prints the success line
  PASS  swap does not hit an undefined command
  PASS  config pinned
  PASS  roles exchanged
  PASS  --auto prints the release line
  PASS  config released
  PASS  --auto is idempotent
  PASS  refuses a 2.4-only radio on the 5 GHz role
  PASS  refuses with one adapter
```

Also audited every command name at statement start in the file against defined
functions, shell builtins and `$PATH`. `ok` was the only invention.