### PR TITLE
v1.5.2.2: notice when the Bluetooth radio has gone deaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,53 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.2.2] — Unreleased
+
+### Bluetooth could stop working silently, and the node would not notice
+
+Several nodes stopped detecting anything over Bluetooth while reporting
+themselves perfectly healthy. Wi-Fi carried on normally on the same nodes —
+one logged over 231,000 Wi-Fi detections and exactly zero Bluetooth in the
+same month. One operator went roughly a month before noticing, and only
+because he lives beside a delivery hub and knew what he ought to be seeing.
+
+The node had no way to tell the difference between a broken radio and a quiet
+sky, and neither did we. Its health check asked whether the adapter was
+present and switched on — which it always was. That answers a different
+question from whether scanning still works.
+
+The trigger appears to be the Bluetooth service restarting underneath the
+feeder, which happens during ordinary system updates. The connection the
+feeder scans through is dropped, no error is raised, and it listens to a dead
+channel indefinitely. That matches what was seen: failures on different dates
+per node with no common software version, since it depends on when each
+operator last updated their system.
+
+Nodes now notice. If the radio hears nothing at all for fifteen minutes it
+rebuilds the scan and recovers without anyone being involved. `sudo droneaware
+status` gained a Bluetooth line reporting whether traffic is arriving, and the
+node tells the server whether its radio is alive rather than merely present.
+
+If your Bluetooth has been quiet, `sudo systemctl restart droneaware-ble`
+fixes it immediately on any version.
+
+### How this works, and what it does not collect
+
+To find Remote ID broadcasts, a Bluetooth radio has to listen to every
+advertisement near it — that is how Bluetooth scanning works, and it is what a
+phone does constantly. The node has always worked this way; there is no way to
+ask the adapter for only drone traffic.
+
+What is new is that it now **counts** them. Nothing else. Anything that is not
+Remote ID is discarded the moment it arrives: no address, no device name and
+no content is read, stored, written to a log, or sent anywhere. The count
+exists purely so the node can tell "working, nothing flying" apart from
+"stopped working".
+
+That count stays on your node. `sudo droneaware status` shows it to you; the
+server is told only whether the radio is alive, because a count would hint at
+how many devices are near your home and nothing needs that.
+
 ## [1.5.2.1] — Unreleased
 
 ### `droneaware swap` printed an error after succeeding

--- a/README.md
+++ b/README.md
@@ -145,7 +145,17 @@ automatically. Nothing is written to the SD card.
 
 **What data is collected?**
 Only data broadcast publicly by the drones themselves via FAA-mandated Remote ID
-transmissions. Remote ID is an open broadcast equivalent to a drone's tail
+transmissions.
+
+The Bluetooth radio has to listen to every nearby advertisement in order to find
+the Remote ID ones — that is how Bluetooth scanning works, and it is what your
+phone does constantly. Anything that is not Remote ID is discarded immediately:
+no address, no device name, and no content is read, stored, logged or
+transmitted. The node keeps a running **count** of advertisements, and nothing
+else about them, purely so it can tell "my Bluetooth radio is working and the
+sky is quiet" apart from "my Bluetooth radio has stopped working". That count
+never leaves your node — `sudo droneaware status` shows it to you, and the
+server is told only whether the radio is alive. Remote ID is an open broadcast equivalent to a drone's tail
 number visible on a radar screen. No private communications, networks, or
 personal devices are accessed. Your node's GPS coordinates are stored on the
 DroneAware server to correctly place detections on the map.

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -260,6 +260,13 @@ UA_TYPE = {
 
 # -- Adapter Resolution --------------------------------------------------------
 
+# How long a radio may hear NOTHING AT ALL before we treat the scan as dead
+# and rebuild it. Generous on purpose: this counts every advertisement from
+# every device, so anywhere with people nearby ticks constantly, and only a
+# genuinely broken subscription goes quiet this long.
+BLE_SILENCE_RESTART_SEC = 15 * 60
+
+
 def find_adapter_by_mac(target_mac: str) -> str | None:
     """
     Resolve a Bluetooth adapter MAC address to its HCI device name (e.g. 'hci0').
@@ -359,6 +366,21 @@ def get_ble_health(adapter: str = "hci0") -> tuple[bool, str]:
         return "UP RUNNING" in result.stdout, adapter
     except Exception:
         return False, adapter
+
+
+def _scanning_alive(feeder) -> bool:
+    """True when the radio has actually heard something recently.
+
+    Distinct from ble_ok, which is `hciconfig` reporting UP RUNNING and
+    therefore answers "does the interface exist" rather than "does scanning
+    work". This is the boolean the server needs to tell a broken radio from a
+    quiet one -- and it is the ONLY thing derived from the advertisement count
+    that leaves the node. The count itself stays local.
+    """
+    last = getattr(feeder, "last_adv_mono", None)
+    if last is None:
+        return False
+    return (time.monotonic() - last) <= BLE_SILENCE_RESTART_SEC
 
 
 async def _attempt_ble_recovery(adapter: str) -> bool:
@@ -976,8 +998,39 @@ class BLEFeeder:
         self.restart_count           = _get_restart_count()
         self.max_lag_ms_this_interval = 0
 
+        # v1.5.2.2 — liveness. ble_ok is `hciconfig` reporting UP RUNNING,
+        # which says the interface exists, not that scanning works. A node
+        # whose BlueZ subscription is orphaned (bluetooth.service restarting
+        # under `apt upgrade`, say) keeps reporting UP RUNNING and hears
+        # nothing, forever, with no fault raised. Seven nodes sat like that.
+        #
+        # Counting only Remote ID cannot detect it: a healthy radio in a quiet
+        # area also sees zero. Counting EVERY advertisement can — anywhere with
+        # people in it is saturated with phones, earbuds and TVs.
+        #
+        # PRIVACY: this is a counter and nothing else. The callback already
+        # receives every advertisement in range (there is no UUID pre-filter —
+        # the CSR adapter cannot do one reliably), and already discards
+        # non-Remote-ID ones untouched. Incrementing an integer adds no new
+        # reception and retains nothing: no address, no name, no payload. The
+        # count stays on the node; only a boolean reaches the server.
+        self.adv_total      = 0          # every advertisement, local only
+        self.adv_ever_seen  = False      # gate for self-heal, see below
+        self.last_adv_mono  = None
+
     def on_advertisement(self, device: BLEDevice, adv: AdvertisementData):
-        """Callback for every BLE advertisement containing UUID 0xFFFA service data."""
+        """Callback for every BLE advertisement the adapter receives.
+
+        Docstring corrected: there is no UUID pre-filter on the scanner, so
+        this fires for every device in range, not only 0xFFFA ones.
+        """
+        # Liveness only. Counted before anything is examined, and nothing
+        # about the advertisement is read, kept or logged unless it turns out
+        # to be Remote ID below.
+        self.adv_total += 1
+        self.adv_ever_seen = True
+        self.last_adv_mono = time.monotonic()
+
         # Locate the FFFA service data entry
         svc_data  = None
         svc_uuid  = None
@@ -992,8 +1045,10 @@ class BLEFeeder:
 
         rid_payload_hex, strategy = extract_rid_payload(svc_data)
         if rid_payload_hex is None:
+            # Address deliberately omitted: the payload is what is
+            # diagnostically useful, and a MAC written to disk is not.
             log.warning(
-                f"Unrecognised service data from {device.address} "
+                f"Unrecognised 0xFFFA service data "
                 f"({len(svc_data)} bytes: {svc_data.hex()}) — skipped"
             )
             return
@@ -1187,6 +1242,28 @@ class BLEFeeder:
                         self.max_lag_ms_this_interval = lag_ms
                     last_tick_time = now
 
+                    # Liveness. If the radio has heard nothing whatsoever for
+                    # BLE_SILENCE_RESTART_SEC, the scan is dead even though
+                    # hciconfig still says UP RUNNING — rebuild it. Returning
+                    # False hands control back to run()'s retry wrapper, the
+                    # same path adapter recovery already uses.
+                    #
+                    # Gated on having seen at least one advertisement since
+                    # start. A node genuinely alone in a field would otherwise
+                    # rebuild its scanner every 15 minutes forever, achieving
+                    # nothing; it reports scanning=False instead, which is
+                    # visible and does not thrash. The failure this fixes —
+                    # working, then orphaned — always has traffic before the
+                    # silence.
+                    if (self.adv_ever_seen and self.last_adv_mono is not None
+                            and now - self.last_adv_mono > BLE_SILENCE_RESTART_SEC):
+                        log.warning(
+                            f"[Liveness] No BLE advertisements of any kind for "
+                            f"{int(now - self.last_adv_mono)}s while the adapter "
+                            f"reports UP RUNNING — the scan is dead. Rebuilding."
+                        )
+                        return False
+
                     # Flush via a worker thread — sync requests.post inside
                     # Forwarder._flush no longer blocks the async loop.
                     if self.forwarder.should_flush():
@@ -1240,6 +1317,14 @@ class BLEFeeder:
                 "ble_ok":     ble_ok,
                 "ble_fault":  fault,
                 "seen_total": getattr(self, "count", 0),
+                # Local only -- read by `droneaware status` so an operator can
+                # confirm their own radio is hearing traffic. Never sent to the
+                # server; the heartbeat carries a boolean derived from it.
+                "adv_total":  getattr(self, "adv_total", 0),
+                "adv_age_s":  (round(time.monotonic() - self.last_adv_mono, 1)
+                               if getattr(self, "last_adv_mono", None) is not None
+                               else None),
+                "scanning":   _scanning_alive(self),
                 "sent_total": getattr(getattr(self, "forwarder", None),
                                       "sent_total", 0),
                 "updated_at": time.time(),
@@ -1313,6 +1398,16 @@ class BLEFeeder:
                                 "load_15m":                   load_15m,
                                 "ble_ok":                     ble_ok,
                                 "ble_adapter":                ble_adp,
+                                # v1.5.2.2. ble_ok means the interface is UP
+                                # RUNNING; this means advertisements are
+                                # actually arriving. A node reporting
+                                # ble_ok=true with ble_scanning=false is the
+                                # silent failure that left seven nodes dark.
+                                # Deliberately a boolean and not the count:
+                                # the count would leak a rough device-density
+                                # signal for the node's location, and nothing
+                                # needs it.
+                                "ble_scanning":               _scanning_alive(self),
                                 # v1.4.8 telemetry additions:
                                 "buffered":                   self.forwarder.held_events,
                                 "buffered_bytes":             self.forwarder.held_bytes,

--- a/droneaware
+++ b/droneaware
@@ -1775,6 +1775,35 @@ cmd_status() {
         echo ""
     fi
 
+    # Bluetooth liveness. The count is read from the feeder's own state file
+    # and shown ONLY here, on the operator's own node -- it is never sent to
+    # the server, which receives a boolean. An operator checking their own
+    # antenna is a different decision from telemetry leaving the device.
+    if [[ -r /run/droneaware/ble_state.json ]]; then
+        python3 - <<'BLEPY'
+import json, sys
+try:
+    s = json.load(open("/run/droneaware/ble_state.json"))
+except Exception:
+    sys.exit()
+adv, age, scanning = s.get("adv_total"), s.get("adv_age_s"), s.get("scanning")
+adapter = s.get("adapter") or "?"
+if adv is None:
+    sys.exit()                      # pre-v1.5.2.2 feeder, nothing to show
+if scanning:
+    print(f"  Bluetooth: {adapter} — hearing traffic "
+          f"({adv:,} advertisements seen, last {age}s ago)")
+elif adv == 0:
+    print(f"  Bluetooth: {adapter} — NO advertisements heard at all.")
+    print(f"             The adapter reports up, but nothing is arriving. In any")
+    print(f"             populated area this means the scan is dead, not quiet.")
+else:
+    print(f"  Bluetooth: {adapter} — silent for {int(age)}s "
+          f"({adv:,} heard earlier). Rebuilding the scan.")
+print("")
+BLEPY
+    fi
+
     # Power. The installer has checked this since v1.5.0.6, but only once, at
     # install time — a node that was healthy then and browns out later says
     # nothing. That gap matters more now that we recommend a SECOND WiFi


### PR DESCRIPTION
Seven nodes stopped detecting over Bluetooth while reporting themselves
healthy. Wi-Fi continued normally on the same nodes — one logged 231,709 Wi-Fi
detections and exactly zero BLE in the same 30 days.

## Why nothing caught it

`ble_ok` is `hciconfig` reporting `UP RUNNING`. That answers *does the adapter
exist*, not *does scanning work* — and a radio that has stopped listening still
reports UP RUNNING.

Counting Remote ID alone cannot tell the difference, because a healthy radio in
a quiet area also sees zero. Attempting to reproduce it made that concrete —
heartbeats before and after deliberately breaking the subscription were
byte-identical:

```
seen=0  sent=0  ble=True     ← before
seen=0  sent=0  ble=True     ← after
```

## Mechanism

Scanning uses `bleak` over BlueZ D-Bus. When `bluetooth.service` restarts — as
it does during ordinary `apt upgrade` — the subscription is orphaned. No
exception is raised, the scan loop keeps ticking, and the node listens to a
dead channel indefinitely.

That fits every observation: failure dates scattered per node with no common
firmware version (it depends when each operator last updated), Wi-Fi
unaffected, `ble_ok=true` throughout. It also explains why recently-updated
nodes are the best performers — `droneaware update` restarts the feeder, so
they have fresh subscriptions.

**Testable server-side with existing data:** any affected node that updated
firmware after going dark should have started detecting again.

## The fix

Counts every advertisement rather than only Remote ID ones. The callback
already receives them all — there is no UUID pre-filter, because the CSR
adapter cannot do one reliably — and already discards non-RID ones untouched,
so this adds no new reception.

Fifteen minutes of total silence rebuilds the scanner through `run()`'s
existing retry wrapper, the same path adapter recovery already uses. Gated on
having heard something since start, so a node genuinely alone in a field
reports `scanning=false` rather than rebuilding every 15 minutes forever.

`sudo droneaware status` gains a Bluetooth line. Existing nodes can recover
immediately with `sudo systemctl restart droneaware-ble`.

## Privacy

**The count never leaves the node.** `droneaware status` shows it to the
operator; the heartbeat carries a boolean. A count would hint at device density
near someone's home, and nothing needs it.

Nothing about an advertisement is read, retained or logged unless it is Remote
ID — no address, no device name, no payload. The README now states this plainly
rather than leaving it defensible but unstated.

## For the server

`ble_scanning` is a **new** field; `ble_ok` is unchanged. Redefining a field's
meaning without coordination is the mistake `scan_mode` taught us — switch to
the new one when ready.