### PR TITLE
v1.5.2.3: report whether the Bluetooth radio is onboard or a USB dongle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Full release artifacts and discussion notes live at the
 
 ---
 
+## [1.5.2.3] — Unreleased
+
+### Nodes now report which Bluetooth radio they are using
+
+A USB adapter and the Pi's built-in Bluetooth both appear as `hci0`, so nothing
+recorded which one a node actually had — two nodes with different hardware
+looked identical in every record. It is now reported in the node's heartbeat
+and shown locally:
+
+```
+Bluetooth: hci0 (USB 0a12:0001) — hearing traffic ...
+Bluetooth: hci0 (onboard) — hearing traffic ...
+```
+
+Reported by faulted nodes as well as healthy ones, since a broken node is when
+it matters most. Only the chipset model — the same identifier any USB device
+gives the computer it is plugged into.
+
 ## [1.5.2.2] — Unreleased
 
 ### Bluetooth could stop working silently, and the node would not notice

--- a/ble_feeder.py
+++ b/ble_feeder.py
@@ -368,6 +368,56 @@ def get_ble_health(adapter: str = "hci0") -> tuple[bool, str]:
         return False, adapter
 
 
+def _adapter_hardware(adapter: str) -> dict:
+    """Identify what hci<N> physically is: onboard radio or USB dongle.
+
+    `hci0` alone is useless for telling a Sena UD100 from the Pi's built-in
+    Bluetooth -- both present as hci0, and the fleet could not be asked which
+    hardware was failing because nothing reported it.
+
+    Walks sysfs from the hci device toward the root looking for a USB parent.
+    Finding one means a dongle, and its idVendor:idProduct identifies the
+    chipset family. Finding none means the onboard radio, which hangs off a
+    serial/UART node instead.
+
+    NOTE for whoever reads the VID:PID: 0a12:0001 is Cambridge Silicon Radio's
+    generic identifier and the most widely cloned in Bluetooth. It establishes
+    "USB CSR dongle", never "genuine Sena" -- counterfeits report it too.
+
+    Hardware identity, not personal data: a chipset model, no address and
+    nothing about the devices around the node.
+    """
+    info = {"bus": "unknown", "usb_id": None, "usb_desc": None}
+    try:
+        dev = os.path.realpath(f"/sys/class/bluetooth/{adapter}/device")
+        while dev and dev != "/":
+            vid_path = os.path.join(dev, "idVendor")
+            if os.path.isfile(vid_path):
+                with open(vid_path) as f:
+                    vid = f.read().strip()
+                with open(os.path.join(dev, "idProduct")) as f:
+                    pid = f.read().strip()
+                info["bus"] = "usb"
+                info["usb_id"] = f"{vid}:{pid}"
+                parts = []
+                for name in ("manufacturer", "product"):
+                    try:
+                        with open(os.path.join(dev, name)) as f:
+                            v = f.read().strip()
+                        if v:
+                            parts.append(v)
+                    except OSError:
+                        pass
+                info["usb_desc"] = " ".join(parts) or None
+                return info
+            dev = os.path.dirname(dev)
+        # No USB parent anywhere up the chain -- the built-in radio.
+        info["bus"] = "onboard"
+    except Exception:
+        pass
+    return info
+
+
 def _scanning_alive(feeder) -> bool:
     """True when the radio has actually heard something recently.
 
@@ -1161,6 +1211,13 @@ class BLEFeeder:
                         "ble_ok":       False,
                         "ble_adapter":  self.adapter,
                         "ble_fault":    reason,
+                        # Carried in FAULT too. A broken node is exactly when
+                        # knowing whether it is a USB dongle or the onboard
+                        # radio matters most, and the healthy path reporting it
+                        # while the faulted path stays silent would leave the
+                        # failures -- the rows worth querying -- blank.
+                        "ble_bus":      _adapter_hardware(self.adapter or "hci0")["bus"],
+                        "ble_usb_id":   _adapter_hardware(self.adapter or "hci0")["usb_id"],
                         # v1.4.8: restart count meaningful even in FAULT
                         # (a crash-looping FAULT feeder should be visible).
                         "restarts_since_boot": self.restart_count,
@@ -1325,6 +1382,8 @@ class BLEFeeder:
                                if getattr(self, "last_adv_mono", None) is not None
                                else None),
                 "scanning":   _scanning_alive(self),
+                **{f"adapter_{k}": v
+                   for k, v in _adapter_hardware(adapter or "hci0").items()},
                 "sent_total": getattr(getattr(self, "forwarder", None),
                                       "sent_total", 0),
                 "updated_at": time.time(),
@@ -1408,6 +1467,13 @@ class BLEFeeder:
                                 # signal for the node's location, and nothing
                                 # needs it.
                                 "ble_scanning":               _scanning_alive(self),
+                                # Which radio this actually is. hci0 alone
+                                # cannot distinguish a USB dongle from the
+                                # Pi's built-in Bluetooth, so no fleet-wide
+                                # question about adapter hardware could be
+                                # answered. Chipset identity only.
+                                "ble_bus":                    _adapter_hardware(ble_adp or "hci0")["bus"],
+                                "ble_usb_id":                 _adapter_hardware(ble_adp or "hci0")["usb_id"],
                                 # v1.4.8 telemetry additions:
                                 "buffered":                   self.forwarder.held_events,
                                 "buffered_bytes":             self.forwarder.held_bytes,

--- a/droneaware
+++ b/droneaware
@@ -1788,6 +1788,14 @@ except Exception:
     sys.exit()
 adv, age, scanning = s.get("adv_total"), s.get("adv_age_s"), s.get("scanning")
 adapter = s.get("adapter") or "?"
+# hci0 alone cannot tell a USB dongle from the Pi's built-in radio -- both
+# present the same name. Say which one this is, since "my Bluetooth is not
+# working" has very different answers for each.
+bus, usb_id = s.get("adapter_bus"), s.get("adapter_usb_id")
+if bus == "usb":
+    adapter = f"{adapter} (USB {usb_id})" if usb_id else f"{adapter} (USB)"
+elif bus == "onboard":
+    adapter = f"{adapter} (onboard)"
 if adv is None:
     sys.exit()                      # pre-v1.5.2.2 feeder, nothing to show
 if scanning:


### PR DESCRIPTION
A USB adapter and the Pi's built-in Bluetooth both present as `hci0`, so no
record distinguished them. Two nodes with different Bluetooth hardware looked
identical in every field — which is why "is this a Sena problem?" could not be
answered across the fleet.

## What it sends

`ble_bus` and `ble_usb_id`, from **both** the healthy and the FAULT heartbeat.
A faulted node is when the answer matters most, and reporting only from the
healthy path would leave exactly the interesting rows blank.

Determined by walking sysfs from the hci device toward the root looking for a
USB parent — found means dongle, and `idVendor:idProduct` identifies the
chipset; not found means the onboard radio, which hangs off a serial node.
Verified against both a UART onboard radio and a USB dongle.

Also shown locally:

```
Bluetooth: hci0 (USB 0a12:0001) — hearing traffic ...
Bluetooth: hci0 (onboard) — hearing traffic ...
```

## Caveat for whoever queries this

**`0a12:0001` is Cambridge Silicon Radio's generic identifier and the most
widely cloned in Bluetooth.** It establishes "USB CSR dongle" — never "genuine
Sena", since counterfeits report the same. It answers the onboard-vs-dongle
question fully, and the counterfeit question only partly. Noted in the source
so the distinction survives.

## Privacy

Chipset model only — the same identifier any USB device gives the computer it
is plugged into. No address, nothing about nearby devices.